### PR TITLE
fix: isolate config path via AGENTLOG_CONFIG_DIR env var

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,54 +1,41 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
 import { join } from "path";
-import { homedir } from "os";
 import { tmpdir } from "os";
+import { homedir } from "os";
 
-// We test config functions by overriding the module's path resolution via temp dirs.
-// Since CONFIG_PATH is hardcoded to ~/.agentlog/config.json, we import and test
-// the exported functions directly (loadConfig/saveConfig operate on that fixed path).
-// For isolation, we back up and restore any real config.
+// Tests use AGENTLOG_CONFIG_DIR to isolate from real ~/.agentlog/config.json.
+// No backup/restore dance needed — each test gets a fresh temp directory.
 
 import { loadConfig, saveConfig, expandHome, configPath } from "../config.js";
 
-const REAL_CONFIG = join(homedir(), ".agentlog", "config.json");
-const BACKUP_PATH = join(tmpdir(), `agentlog-config-backup-${Date.now()}.json`);
+let tempDir: string;
 
-function backupConfig() {
-  if (existsSync(REAL_CONFIG)) {
-    const content = Bun.file(REAL_CONFIG).toString();
-    writeFileSync(BACKUP_PATH, content, "utf-8");
-    return true;
-  }
-  return false;
-}
-
-function restoreConfig(hadBackup: boolean) {
-  if (hadBackup && existsSync(BACKUP_PATH)) {
-    const content = Bun.file(BACKUP_PATH).toString();
-    writeFileSync(REAL_CONFIG, content, "utf-8");
-    rmSync(BACKUP_PATH, { force: true });
-  } else {
-    // Remove any test-written config
-    rmSync(REAL_CONFIG, { force: true });
-  }
+function makeTempDir(): string {
+  const dir = join(tmpdir(), `agentlog-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
 }
 
 describe("config", () => {
-  let hadBackup = false;
-
   beforeEach(() => {
-    hadBackup = backupConfig();
-    // Remove config so each test starts clean
-    rmSync(REAL_CONFIG, { force: true });
+    tempDir = makeTempDir();
+    process.env.AGENTLOG_CONFIG_DIR = tempDir;
   });
 
   afterEach(() => {
-    restoreConfig(hadBackup);
+    delete process.env.AGENTLOG_CONFIG_DIR;
+    rmSync(tempDir, { recursive: true, force: true });
   });
 
-  // C10: configPath returns expected location
-  it("configPath returns ~/.agentlog/config.json", () => {
+  // C10: configPath respects AGENTLOG_CONFIG_DIR
+  it("configPath returns path under AGENTLOG_CONFIG_DIR when set", () => {
+    expect(configPath()).toBe(join(tempDir, "config.json"));
+  });
+
+  // C10b: configPath defaults to ~/.agentlog when env is unset
+  it("configPath defaults to ~/.agentlog/config.json", () => {
+    delete process.env.AGENTLOG_CONFIG_DIR;
     expect(configPath()).toBe(join(homedir(), ".agentlog", "config.json"));
   });
 
@@ -60,8 +47,7 @@ describe("config", () => {
   // C1: loadConfig when file exists
   it("loadConfig returns parsed config when file exists", () => {
     const cfg = { vault: "/Users/testuser/Obsidian" };
-    mkdirSync(join(homedir(), ".agentlog"), { recursive: true });
-    writeFileSync(REAL_CONFIG, JSON.stringify(cfg), "utf-8");
+    writeFileSync(join(tempDir, "config.json"), JSON.stringify(cfg), "utf-8");
 
     const result = loadConfig();
     expect(result).not.toBeNull();
@@ -70,21 +56,20 @@ describe("config", () => {
 
   // C3: loadConfig with malformed JSON
   it("loadConfig returns null when config file has malformed JSON", () => {
-    mkdirSync(join(homedir(), ".agentlog"), { recursive: true });
-    writeFileSync(REAL_CONFIG, "{broken", "utf-8");
+    writeFileSync(join(tempDir, "config.json"), "{broken", "utf-8");
 
     expect(loadConfig()).toBeNull();
   });
 
   // C4: saveConfig creates dir if missing
-  it("saveConfig creates the .agentlog directory if it does not exist", () => {
-    const agentlogDir = join(homedir(), ".agentlog");
-    rmSync(agentlogDir, { recursive: true, force: true });
+  it("saveConfig creates the config directory if it does not exist", () => {
+    const nested = join(tempDir, "nested");
+    process.env.AGENTLOG_CONFIG_DIR = nested;
 
     saveConfig({ vault: "/some/vault" });
 
-    expect(existsSync(agentlogDir)).toBe(true);
-    expect(existsSync(REAL_CONFIG)).toBe(true);
+    expect(existsSync(nested)).toBe(true);
+    expect(existsSync(join(nested, "config.json"))).toBe(true);
   });
 
   // C5: saveConfig expands ~ in vault path

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,7 +12,7 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync, rmSync } from "fs";
 import { join, resolve } from "path";
 import { homedir } from "os";
 import { spawnSync } from "child_process";
-import { saveConfig, loadConfig, expandHome } from "./config.js";
+import { saveConfig, loadConfig, expandHome, configPath, configDir } from "./config.js";
 import { detectVaults, detectCli } from "./detect.js";
 import { isVersionAtLeast, MIN_CLI_VERSION, resolveCliBin } from "./obsidian-cli.js";
 import * as readline from "readline";
@@ -83,7 +83,7 @@ Or to write to a plain folder:
 
   // Save config
   saveConfig({ vault, ...(plain ? { plain: true } : {}) });
-  console.log(`Config saved: ${join(homedir(), ".agentlog", "config.json")}`);
+  console.log(`Config saved: ${configPath()}`);
   console.log(`  vault: ${vault}${plain ? " (plain mode)" : ""}`);
 
   // Probe CLI availability (informational)
@@ -254,7 +254,7 @@ function unregisterHook(): boolean {
 
 async function cmdUninstall(args: string[]): Promise<void> {
   const skipConfirm = args.includes("-y");
-  const configDir = join(homedir(), ".agentlog");
+  const cfgDir = configDir();
 
   if (!skipConfirm && process.stdin.isTTY) {
     const answer = await ask("Remove AgentLog hook and config? [y/N]: ");
@@ -272,10 +272,10 @@ async function cmdUninstall(args: string[]): Promise<void> {
     console.log(`Hook not found (already removed or never registered)`);
   }
 
-  // Remove ~/.agentlog/
-  if (existsSync(configDir)) {
-    rmSync(configDir, { recursive: true, force: true });
-    console.log(`Config removed: ${configDir}`);
+  // Remove config directory
+  if (existsSync(cfgDir)) {
+    rmSync(cfgDir, { recursive: true, force: true });
+    console.log(`Config removed: ${cfgDir}`);
   } else {
     console.log(`Config not found (already removed)`);
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,17 +3,19 @@ import { homedir } from "os";
 import { join } from "path";
 import type { AgentLogConfig } from "./types.js";
 
-const CONFIG_DIR = join(homedir(), ".agentlog");
-const CONFIG_PATH = join(CONFIG_DIR, "config.json");
+export function configDir(): string {
+  return process.env.AGENTLOG_CONFIG_DIR ?? join(homedir(), ".agentlog");
+}
 
 export function configPath(): string {
-  return CONFIG_PATH;
+  return join(configDir(), "config.json");
 }
 
 export function loadConfig(): AgentLogConfig | null {
-  if (!existsSync(CONFIG_PATH)) return null;
+  const cfgPath = configPath();
+  if (!existsSync(cfgPath)) return null;
   try {
-    const raw = readFileSync(CONFIG_PATH, "utf-8");
+    const raw = readFileSync(cfgPath, "utf-8");
     return JSON.parse(raw) as AgentLogConfig;
   } catch {
     return null;
@@ -21,13 +23,14 @@ export function loadConfig(): AgentLogConfig | null {
 }
 
 export function saveConfig(config: AgentLogConfig): void {
-  mkdirSync(CONFIG_DIR, { recursive: true });
+  const cfgDir = configDir();
+  mkdirSync(cfgDir, { recursive: true });
   // Expand ~ in vault path before saving
   const normalized: AgentLogConfig = {
     ...config,
     vault: expandHome(config.vault),
   };
-  writeFileSync(CONFIG_PATH, JSON.stringify(normalized, null, 2), "utf-8");
+  writeFileSync(configPath(), JSON.stringify(normalized, null, 2), "utf-8");
 }
 
 export function expandHome(p: string): string {


### PR DESCRIPTION
## Summary

- `config.ts`: config 경로를 `AGENTLOG_CONFIG_DIR` 환경변수로 오버라이드 가능하게 변경 (기본값: `~/.agentlog`)
- `config.test.ts`: 실제 config 파일 backup/restore 대신 temp 디렉토리 격리 방식으로 전면 재작성
- `cli.ts`: 하드코딩된 `~/.agentlog` 경로를 `configDir()`/`configPath()`로 교체

## 문제

`bun link`가 global 설치를 덮어씌우는 과정에서 `~/.agentlog/config.json`이 사라지는 현상. 테스트가 실제 config를 직접 삭제/복구하는 방식이라 중단 시 config 유실.

## Test plan

- [x] `bun test` — 128 tests 전부 통과
- [x] config 테스트가 `~/.agentlog/config.json`을 건드리지 않는 것 확인

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)