### PR TITLE
fix: extract only last line from obsidian daily:path stdout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.env
 node_modules/
 dist/
 .omc/state

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "agentlog",
-  "version": "0.1.0",
+  "name": "@albireo3754/agentlog",
+  "version": "0.1.1",
   "description": "Claude Code prompts → Obsidian Daily Note auto-logger",
   "type": "module",
   "bin": {
@@ -22,6 +22,7 @@
   "files": [
     "src",
     "!src/__tests__",
+    "scripts",
     "README.md",
     "LICENSE",
     "docs"

--- a/src/obsidian-cli.ts
+++ b/src/obsidian-cli.ts
@@ -68,8 +68,10 @@ export function cliDailyPath(): string | null {
   if (!bin) return null;
   const result = spawnSync(bin, ["daily:path"], { encoding: "utf-8", timeout: 3000 });
   if (result.status !== 0) return null;
-  // stdout may contain warning lines on stderr; stdout has the path
-  const path = result.stdout.trim();
+  // stdout may contain Electron noise lines (e.g. "Loading updated app package",
+  // version warnings). The actual path is always the last non-empty line.
+  const lines = result.stdout.trim().split("\n").filter(Boolean);
+  const path = (lines.at(-1) ?? "").trim();
   return path || null;
 }
 


### PR DESCRIPTION
## Summary
- Fix `cliDailyPath()` to use only the last non-empty line from `obsidian daily:path` stdout, ignoring Electron noise lines ("Loading updated app package", version warnings)
- Add `.env` to `.gitignore` for npm token management
- Add `scripts/` to package.json `files` for postinstall to work
- Bump version to 0.1.1

Fixes #7

## Test plan
- [x] 118 tests pass
- [x] TypeScript typecheck passes
- [ ] Verify no rogue directories created after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)