### PR TITLE
docs: record review loop memory

### DIFF
--- a/docs/review/SELF_REVIEW.md
+++ b/docs/review/SELF_REVIEW.md
@@ -83,6 +83,25 @@ Check:
 - Old statements like "always uses Obsidian CLI" are removed or qualified.
 - README/CLAUDE/docs are updated only when they are in scope.
 
+### Plan and Design Contract Drift
+
+Implementation plans and design docs must not drift from the current code contract.
+
+Check:
+
+- Plans do not require unavailable external skills, prompts, or tools.
+- Path-resolution docs match the current implementation order and fallback behavior.
+- Version requirements match exported constants and tests, such as `MIN_CLI_VERSION`.
+- Acceptance criteria have explicit test tasks, especially for preservation behavior.
+- Manual commit or staging examples include every file required by the task, or instruct the agent to inspect `git status`.
+
+Good evidence:
+
+- plan prerequisites exist locally or are replaced with repo-native instructions
+- line-level agreement between plan, design, implementation, and tests
+- test tasks that prove each user-visible acceptance criterion
+- no stale manual `git add` list after docs or tests are added
+
 ### Date Format Token Validation
 
 Supported date format tokens must be explicit and tested.

--- a/docs/review/review-list.json
+++ b/docs/review/review-list.json
@@ -105,6 +105,40 @@
       ]
     },
     {
+      "id": "plan-path-resolution-doc-contract",
+      "severity": "medium",
+      "title": "Plan docs must not describe unsafe config.vault string concatenation",
+      "appliesTo": {
+        "paths": ["docs/plans/**/*.md"],
+        "diffIncludesAny": ["config.vault", "relativePath"]
+      },
+      "checks": [
+        {
+          "type": "noneContentRegex",
+          "paths": ["docs/plans/**/*.md"],
+          "pattern": "config\\.vault\\s*\\+\\s*relativePath",
+          "message": "Use path joining or confinement wording instead of `config.vault + relativePath` in plans."
+        }
+      ]
+    },
+    {
+      "id": "plan-cli-min-version-doc-contract",
+      "severity": "medium",
+      "title": "Plan docs must use the enforced Obsidian CLI minimum version",
+      "appliesTo": {
+        "paths": ["docs/plans/**/*.md"],
+        "diffIncludesAny": ["Obsidian CLI", "MIN_CLI_VERSION", "1.12+"]
+      },
+      "checks": [
+        {
+          "type": "noneContentRegex",
+          "paths": ["docs/plans/**/*.md"],
+          "pattern": "Obsidian CLI[^\\n`]*1\\.12\\+",
+          "message": "Use `Obsidian CLI 1.12.4+` or reference `MIN_CLI_VERSION` in plans."
+        }
+      ]
+    },
+    {
       "id": "format-token-validation",
       "severity": "medium",
       "title": "Date format token support must be explicit and tested",


### PR DESCRIPTION
## Summary
- add PR #27 review-loop lessons to the LLM self-review memory
- keep raw loop logs out of git while preserving repeatable review criteria in Markdown

## Verification
- bun run self-review -- --mode staged