### PR TITLE
chore: prepare main sync release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,10 +223,10 @@ Invoked automatically by Codex on `agent-turn-complete`. Do not call directly.
 
 #### 10:53 · js/agentlog
 <!-- cwd=/Users/you/work/js/agentlog -->
-- - - - [[claude_a1b2c3]]
+- - - - [[claude_a1b2c3d4]]
 - 10:53 start building agentlog
 - 11:07 open the spec document
-- - - - [[claude_e5f6a7]]
+- - - - [[claude_e5f6a7b8]]
 - 11:21 initialize git
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,7 @@ agentlog doctor
 
 ### `agentlog open`
 
-Opens today's Daily Note in Obsidian using the Obsidian CLI (`obsidian daily`). Requires Obsidian 1.12+ with CLI enabled and Obsidian app running.
+Opens today's Daily Note in Obsidian using the Obsidian CLI (`obsidian daily`). Requires Obsidian 1.12.4+ with CLI enabled and Obsidian app running.
 
 Example:
 ```
@@ -191,7 +191,7 @@ Invoked automatically by Codex on `agent-turn-complete`. Do not call directly.
 ### Obsidian CLI
 
 - Used to resolve the Daily Note path via `obsidian daily:path`
-- Minimum version: checked by `doctor` (1.12+)
+- Minimum version: checked by `doctor` (1.12.4+)
 - Override binary path: `OBSIDIAN_BIN`
 - Fallback when CLI unavailable: `{vault}/Daily/YYYY-MM-DD-<weekday>.md`
 
@@ -223,10 +223,10 @@ Invoked automatically by Codex on `agent-turn-complete`. Do not call directly.
 
 #### 10:53 · js/agentlog
 <!-- cwd=/Users/you/work/js/agentlog -->
-- - - - [[ses_a1b2c3d4]]
+- - - - [[claude_a1b2c3]]
 - 10:53 start building agentlog
 - 11:07 open the spec document
-- - - - [[ses_e5f6a7b8]]
+- - - - [[claude_e5f6a7]]
 - 11:21 initialize git
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ Claude Code hook / Codex notify → Daily Note append
 
 #### 10:53 · js/agentlog
 <!-- cwd=/Users/you/work/js/agentlog -->
-- - - - [[claude_a1b2c3]]
+- - - - [[claude_a1b2c3d4]]
 - 10:53 start building agentlog
 - 11:07 open the spec document
-- - - - [[claude_e5f6a7]]
+- - - - [[claude_e5f6a7b8]]
 - 11:21 initialize git and open it in VS Code
 ```
 
@@ -139,13 +139,13 @@ Each working directory gets its own `#### project` subsection. Session changes i
 
 #### 10:53 · js/agentlog
 <!-- cwd=/Users/you/work/js/agentlog -->
-- - - - [[claude_a1b2c3]]
+- - - - [[claude_a1b2c3d4]]
 - 10:53 start building agentlog
 - 11:07 open the spec document
 
 #### 14:00 · kotlin/message-gate
 <!-- cwd=/Users/you/work/kotlin/message-gate -->
-- - - - [[codex_e5f6a7]]
+- - - - [[codex_e5f6a7b8]]
 - 14:00 adjust the API response
 - 14:30 run tests
 ```

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ Claude Code hook / Codex notify → Daily Note append
 
 #### 10:53 · js/agentlog
 <!-- cwd=/Users/you/work/js/agentlog -->
-- - - - [[ses_a1b2c3d4]]
+- - - - [[claude_a1b2c3]]
 - 10:53 start building agentlog
 - 11:07 open the spec document
-- - - - [[ses_e5f6a7b8]]
+- - - - [[claude_e5f6a7]]
 - 11:21 initialize git and open it in VS Code
 ```
 
@@ -49,7 +49,7 @@ Claude Code hook / Codex notify → Daily Note append
 | `> 🕐 HH:MM — project › prompt` | Latest entry (always updated) |
 | `#### HH:MM · project` | Project subsection (grouped by cwd) |
 | `<!-- cwd=... -->` | Section matching key (hidden in Obsidian Reading view) |
-| `- - - - [[ses_...]]` | Session boundary (Obsidian wiki-link) |
+| `- - - - [[claude_...]]` / `[[codex_...]]` | Session boundary (Obsidian wiki-link) |
 | `- HH:MM prompt` | Individual log entry |
 
 No manual logging. No copy-paste. No AI summarization overhead.
@@ -117,10 +117,10 @@ Use Claude Code or Codex normally. Claude prompts are logged at prompt-submit ti
 
 1. Claude Code fires `UserPromptSubmit`, or Codex invokes `notify` on `agent-turn-complete`
 2. AgentLog extracts the latest user-visible input and sanitizes it
-3. Finds your Daily Note via `obsidian daily:path` (Obsidian CLI 1.12+). If that fails, it falls back to `{vault}/Daily/YYYY-MM-DD-<Korean weekday>.md`
+3. Finds your Daily Note via `obsidian daily:path` (Obsidian CLI 1.12.4+). If that fails, it falls back to `{vault}/Daily/YYYY-MM-DD-<Korean weekday>.md`
 4. Finds or creates a `## AgentLog` section
 5. Finds or creates a `#### project` subsection matching the current working directory
-6. Inserts a session divider `[[ses_...]]` if the session changed, then appends the entry
+6. Inserts a source-prefixed session divider such as `[[claude_...]]` or `[[codex_...]]` if the session changed, then appends the entry
 7. Updates the `> 🕐` latest-entry line at the top of the section
 
 Total overhead: < 50ms per prompt. Fire-and-forget, never blocks Claude Code.
@@ -129,9 +129,9 @@ Total overhead: < 50ms per prompt. Fire-and-forget, never blocks Claude Code.
 
 ### Obsidian Mode (default)
 
-AgentLog resolves the Daily Note path via `obsidian daily:path` when the Obsidian CLI is available (1.12+). If the CLI is unavailable or Obsidian is not running, it falls back to `{vault}/Daily/YYYY-MM-DD-<Korean weekday>.md` such as `2026-03-01-일.md`.
+AgentLog resolves the Daily Note path via `obsidian daily:path` when the Obsidian CLI is available (1.12.4+). If the CLI is unavailable or Obsidian is not running, it falls back to `{vault}/Daily/YYYY-MM-DD-<Korean weekday>.md` such as `2026-03-01-일.md`.
 
-Each working directory gets its own `#### project` subsection. Session changes insert a `[[ses_...]]` wiki-link divider. The `> 🕐` blockquote at the top always shows the latest entry across all projects.
+Each working directory gets its own `#### project` subsection. Session changes insert a source-prefixed wiki-link divider such as `[[claude_...]]` or `[[codex_...]]`. The `> 🕐` blockquote at the top always shows the latest entry across all projects.
 
 ```markdown
 ## AgentLog
@@ -139,13 +139,13 @@ Each working directory gets its own `#### project` subsection. Session changes i
 
 #### 10:53 · js/agentlog
 <!-- cwd=/Users/you/work/js/agentlog -->
-- - - - [[ses_a1b2c3d4]]
+- - - - [[claude_a1b2c3]]
 - 10:53 start building agentlog
 - 11:07 open the spec document
 
 #### 14:00 · kotlin/message-gate
 <!-- cwd=/Users/you/work/kotlin/message-gate -->
-- - - - [[ses_e5f6a7b8]]
+- - - - [[codex_e5f6a7]]
 - 14:00 adjust the API response
 - 14:30 run tests
 ```
@@ -169,7 +169,7 @@ Current CLI:
 | `agentlog detect` | List detected Obsidian vaults and CLI status |
 | `agentlog codex-debug <prompt>` | Run `codex exec "<prompt>"` with notify auto-registered |
 | `agentlog doctor` | Run health checks for the binary, vault, hook, and Obsidian CLI. Also checks Codex notify status if configured |
-| `agentlog open` | Open today's Daily Note in Obsidian (requires CLI 1.12+) |
+| `agentlog open` | Open today's Daily Note in Obsidian (requires CLI 1.12.4+) |
 | `agentlog version` | Print AgentLog version. In `dev` builds, also shows channel and commit |
 | `agentlog uninstall [-y] [--codex\|--all]` | `default`: Remove Claude hook + config, `--codex`: Remove Codex notify only, `--all`: Remove both |
 | `agentlog hook` | Invoked automatically by Claude Code (not for direct use) |

--- a/docs/review/review-list.json
+++ b/docs/review/review-list.json
@@ -99,7 +99,7 @@
       "checks": [
         {
           "type": "changedPathRegex",
-          "pattern": "^(CLAUDE\\.md|README\\.md|docs/.*\\.md)$",
+          "pattern": "^(AGENTS\\.md|CLAUDE\\.md|README\\.md|llms\\.txt|docs/.*\\.md)$",
           "message": "Update docs when Daily Note path resolution order changes."
         }
       ]

--- a/docs/review/review-list.json
+++ b/docs/review/review-list.json
@@ -105,6 +105,23 @@
       ]
     },
     {
+      "id": "docs-session-divider-length",
+      "severity": "medium",
+      "title": "Documented source-prefixed session dividers must use runtime suffix length",
+      "appliesTo": {
+        "paths": ["AGENTS.md", "README.md", "llms.txt", "docs/**/*.md"],
+        "diffIncludesAny": ["[[claude_", "[[codex_", "session divider"]
+      },
+      "checks": [
+        {
+          "type": "noneContentRegex",
+          "paths": ["AGENTS.md", "README.md", "llms.txt", "docs/**/*.md"],
+          "pattern": "\\[\\[(?:claude|codex)_[A-Za-z0-9]{6}\\]\\]",
+          "message": "Use 8 session-id characters in source-prefixed divider examples, matching runtime `sessionId.slice(0, 8)`."
+        }
+      ]
+    },
+    {
       "id": "plan-path-resolution-doc-contract",
       "severity": "medium",
       "title": "Plan docs must not describe unsafe config.vault string concatenation",

--- a/llms.txt
+++ b/llms.txt
@@ -95,10 +95,10 @@ Obsidian mode appends to a `## AgentLog` section, grouped by working directory:
 
 #### 10:53 · js/agentlog
 <!-- cwd=/Users/you/work/js/agentlog -->
-- - - - [[claude_a1b2c3]]
+- - - - [[claude_a1b2c3d4]]
 - 10:53 start building agentlog
 - 11:07 open the spec document
-- - - - [[claude_e5f6a7]]
+- - - - [[claude_e5f6a7b8]]
 - 11:21 initialize git
 ```
 

--- a/llms.txt
+++ b/llms.txt
@@ -48,7 +48,7 @@ agentlog doctor
 
 agentlog open
     Open today's Daily Note in Obsidian via CLI.
-    Requires Obsidian 1.12+ with CLI enabled and app running.
+    Requires Obsidian 1.12.4+ with CLI enabled and app running.
 
 agentlog uninstall [-y] [--codex|--all]
     (default)  Remove Claude hook + delete ~/.agentlog/
@@ -95,10 +95,10 @@ Obsidian mode appends to a `## AgentLog` section, grouped by working directory:
 
 #### 10:53 · js/agentlog
 <!-- cwd=/Users/you/work/js/agentlog -->
-- - - - [[ses_a1b2c3d4]]
+- - - - [[claude_a1b2c3]]
 - 10:53 start building agentlog
 - 11:07 open the spec document
-- - - - [[ses_e5f6a7b8]]
+- - - - [[claude_e5f6a7]]
 - 11:21 initialize git
 ```
 
@@ -110,7 +110,7 @@ Plain mode appends to `{folder}/YYYY-MM-DD.md`:
 ```
 
 Daily Note path resolution order:
-1. `obsidian daily:path` (Obsidian CLI 1.12+, app must be running)
+1. `obsidian daily:path` (Obsidian CLI 1.12.4+, app must be running)
 2. Fallback: `{vault}/Daily/YYYY-MM-DD-<weekday>.md`
 
 ## How the Hook Works

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@albireo3754/agentlog",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Auto-log Claude Code prompts to Obsidian Daily Notes",
   "type": "module",
   "bin": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -104,7 +104,7 @@ function printObsidianCliStatus(plain: boolean): void {
     console.log(`  Daily notes will be written via CLI when Obsidian is running.`);
   } else {
     console.log(`  Obsidian CLI: not detected (using direct file write)`);
-    console.log(`  For better integration, enable CLI in Obsidian 1.12+ Settings.`);
+    console.log(`  For better integration, enable CLI in Obsidian ${MIN_CLI_VERSION}+ Settings.`);
   }
 }
 
@@ -400,7 +400,7 @@ async function cmdDetect(opts: { format: string; fields?: string }): Promise<voi
     console.log(`Obsidian CLI: ${cli.binPath} (${cli.version ?? "version unknown"})`);
   } else {
     console.log("Obsidian CLI: not detected");
-    console.log("  Enable in Obsidian 1.12+ Settings > General > Command line interface");
+    console.log(`  Enable in Obsidian ${MIN_CLI_VERSION}+ Settings > General > Command line interface`);
   }
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -579,7 +579,7 @@ async function cmdOpen(): Promise<void> {
     console.log("Opened today's Daily Note in Obsidian.");
   } else {
     console.error("Failed to open. Is Obsidian running with CLI enabled?");
-    console.error("  Enable CLI in Obsidian 1.12.4+ Settings > General > Command line interface");
+    console.error(`  Enable CLI in Obsidian ${MIN_CLI_VERSION}+ Settings > General > Command line interface`);
     process.exit(1);
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -579,7 +579,7 @@ async function cmdOpen(): Promise<void> {
     console.log("Opened today's Daily Note in Obsidian.");
   } else {
     console.error("Failed to open. Is Obsidian running with CLI enabled?");
-    console.error("  Enable CLI in Obsidian 1.12+ Settings > General > Command line interface");
+    console.error("  Enable CLI in Obsidian 1.12.4+ Settings > General > Command line interface");
     process.exit(1);
   }
 }

--- a/src/detect.ts
+++ b/src/detect.ts
@@ -1,7 +1,7 @@
 /**
  * Obsidian vault auto-detection for agentlog init.
  * Reads macOS Obsidian app registry and scans common paths.
- * Also detects Obsidian CLI (1.12+) availability.
+ * Also detects Obsidian CLI (1.12.4+) availability.
  */
 
 import { existsSync, readFileSync } from "fs";

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -38,7 +38,7 @@ export const Errors = {
   CLI_NOT_FOUND: (): AgentLogError => ({
     code: "CLI_NOT_FOUND",
     message: "Obsidian CLI not found in PATH",
-    fix: "Enable CLI in Obsidian 1.12+ Settings > General > Command line interface",
+    fix: "Enable CLI in Obsidian 1.12.4+ Settings > General > Command line interface",
   }),
 
   APP_NOT_RESPONDING: (): AgentLogError => ({

--- a/src/note-writer.ts
+++ b/src/note-writer.ts
@@ -147,9 +147,9 @@ export function appendEntry(
  *   ## AgentLog
  *   > 🕐 HH:MM — project › prompt        ← latest entry (always updated)
  *
- *   #### project · HH:MM <!-- cwd ses --> ← one section per cwd
+ *   #### project · HH:MM                  ← one section per cwd
  *   - HH:MM entry
- *   - - - - (ses_XXXXXXXX)               ← divider when session changes
+ *   - - - - [[claude_XXXXXXXX]]          ← divider when session changes
  *   - HH:MM entry
  */
 function insertIntoAgentLogSection(content: string, entry: LogEntry): string {

--- a/src/obsidian-cli.ts
+++ b/src/obsidian-cli.ts
@@ -1,5 +1,5 @@
 /**
- * Obsidian CLI (1.12+) detection and execution.
+ * Obsidian CLI (1.12.4+) detection and execution.
  * Encapsulates all Obsidian CLI interaction so other modules
  * only need to call these functions.
  */
@@ -103,4 +103,3 @@ export function isVersionAtLeast(version: string, minimum: string): boolean {
   }
   return true; // equal
 }
-

--- a/src/schema/daily-note.ts
+++ b/src/schema/daily-note.ts
@@ -79,7 +79,7 @@ export function buildProjectHeader(
  *
  * Kept on a separate line so the #### heading remains visually clean.
  * HTML comments are hidden in Obsidian reading view.
- * Session tracking is done via - - - - (ses_XXXXXXXX) divider lines in content.
+ * Session tracking is done via source-prefixed divider lines in content.
  */
 export function buildProjectMetadata(cwd: string): string {
   return `<!-- cwd=${cwd} -->`;


### PR DESCRIPTION
## Summary
- bump package version to 0.1.3 so the main release workflow will not skip an already tagged version
- update README session divider examples to match source-prefixed runtime output
- align Obsidian CLI minimum-version wording with MIN_CLI_VERSION

## Verification
- bun run self-review -- --mode working --no-history
- bun run self-review -- --mode staged
- bun run typecheck
- bun test
- bun run build