### PR TITLE
ci: harden main release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [develop]
+    branches: [develop, main]
   pull_request:
     branches: [develop, main]
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,18 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
-  release:
+  check_release:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      tag_exists: ${{ steps.tag_check.outputs.exists }}
     permissions:
-      contents: write
-      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -30,44 +36,46 @@ jobs:
         if: steps.tag_check.outputs.exists == 'true'
         run: echo "v${{ steps.version.outputs.version }} already released, skipping."
 
+  release:
+    needs: check_release
+    if: needs.check_release.outputs.tag_exists == 'false'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
       - uses: oven-sh/setup-bun@v2
-        if: steps.tag_check.outputs.exists == 'false'
         with:
           bun-version: latest
 
       - name: Install dependencies
-        if: steps.tag_check.outputs.exists == 'false'
         run: bun install
 
       - name: Typecheck
-        if: steps.tag_check.outputs.exists == 'false'
         run: bun run typecheck
 
       - name: Test
-        if: steps.tag_check.outputs.exists == 'false'
         run: bun test
 
       - name: Build
-        if: steps.tag_check.outputs.exists == 'false'
         run: bun run build
 
       - name: Create GitHub Release
-        if: steps.tag_check.outputs.exists == 'false'
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: v${{ steps.version.outputs.version }}
-          name: v${{ steps.version.outputs.version }}
+          tag_name: v${{ needs.check_release.outputs.version }}
+          name: v${{ needs.check_release.outputs.version }}
           generate_release_notes: true
           target_commitish: main
 
       - uses: actions/setup-node@v4
-        if: steps.tag_check.outputs.exists == 'false'
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
 
       - name: Publish to npm
-        if: steps.tag_check.outputs.exists == 'false'
         run: npm publish --access public --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/docs/review/review-list.json
+++ b/docs/review/review-list.json
@@ -122,6 +122,57 @@
       ]
     },
     {
+      "id": "ci-main-push-coverage",
+      "severity": "medium",
+      "title": "CI should run on main pushes when main PRs are supported",
+      "appliesTo": {
+        "paths": [".github/workflows/ci.yml"],
+        "diffIncludesAny": ["pull_request", "main", "push"]
+      },
+      "checks": [
+        {
+          "type": "anyContentRegex",
+          "paths": [".github/workflows/ci.yml"],
+          "pattern": "push:\\s*\\n\\s*branches:\\s*\\[[^\\]\\n]*main",
+          "message": "Include `main` in CI push branches when PRs can target main."
+        }
+      ]
+    },
+    {
+      "id": "release-main-publish-concurrency",
+      "severity": "high",
+      "title": "Main-branch publish workflows must serialize release attempts",
+      "appliesTo": {
+        "paths": [".github/workflows/release.yml"],
+        "diffIncludesAny": ["npm publish", "branches: [main]", "tag_check"]
+      },
+      "checks": [
+        {
+          "type": "anyContentRegex",
+          "paths": [".github/workflows/release.yml"],
+          "pattern": "^concurrency:",
+          "message": "Add workflow-level concurrency so concurrent main pushes cannot double-publish the same version."
+        }
+      ]
+    },
+    {
+      "id": "release-tag-gate-single-path",
+      "severity": "medium",
+      "title": "Release tag checks should gate the publish path once",
+      "appliesTo": {
+        "paths": [".github/workflows/release.yml"],
+        "diffIncludesAny": ["tag_check.outputs.exists", "npm publish"]
+      },
+      "checks": [
+        {
+          "type": "noneContentRegex",
+          "paths": [".github/workflows/release.yml"],
+          "pattern": "if:\\s*steps\\.tag_check\\.outputs\\.exists\\s*==\\s*'false'[\\s\\S]*if:\\s*steps\\.tag_check\\.outputs\\.exists\\s*==\\s*'false'",
+          "message": "Use a job-level publish gate instead of repeating the same tag-check condition on many steps."
+        }
+      ]
+    },
+    {
       "id": "plan-path-resolution-doc-contract",
       "severity": "medium",
       "title": "Plan docs must not describe unsafe config.vault string concatenation",

--- a/src/__tests__/cli-codex.test.ts
+++ b/src/__tests__/cli-codex.test.ts
@@ -42,8 +42,8 @@ function fixture(name: string): string {
 function makeFakeCodexPath(home: string): string {
   const binDir = join(home, "bin");
   mkdirSync(binDir, { recursive: true });
-  for (const name of ["codex", "agentlog"]) {
-    const bin = join(binDir, name);
+  for (const binName of ["codex", "agentlog"]) {
+    const bin = join(binDir, binName);
     writeFileSync(bin, "#!/bin/sh\nexit 0\n", "utf-8");
     chmodSync(bin, 0o755);
   }


### PR DESCRIPTION
## Summary
- Run CI on main pushes as well as develop pushes
- Serialize main release workflows and gate publish steps at the job level
- Promote workflow review findings into self-review rules
- Rename the fake binary loop variable in Codex CLI tests

## Verification
- ruby YAML load for ci/release workflows
- bun run self-review -- --mode working --no-history
- bun run self-review -- --mode staged --no-history
- bun run typecheck
- bun test
- bun run build
- historical self-review replay fails the old workflow issues