### PR TITLE
feat: add EnglishAsk Codex evaluator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,7 +203,11 @@ Invoked automatically by Codex on `agent-turn-complete`. Do not call directly.
 {
   "vault": "/Users/you/Obsidian",
   "plain": false,
-  "codexNotifyRestore": null
+  "codexNotifyRestore": null,
+  "englishAsk": {
+    "enabled": false,
+    "mode": "log-only"
+  }
 }
 ```
 
@@ -212,6 +216,9 @@ Invoked automatically by Codex on `agent-turn-complete`. Do not call directly.
 | `vault` | yes | Absolute path to the Obsidian vault or plain output folder |
 | `plain` | no | If true, writes simple `YYYY-MM-DD.md` files without Obsidian section structure |
 | `codexNotifyRestore` | no | Previous Codex `notify` value, restored on `uninstall --codex` |
+| `englishAsk` | no | Optional Codex prompt evaluator config. Disabled unless `englishAsk.enabled` is true |
+
+EnglishAsk evaluates English Codex user prompts with `codex exec` after the normal Daily Note append. Results are written under `## EnglishAsk`; evaluator failures and timeouts are fail-soft. `AGENTLOG_ENGLISHASK_EVAL=1` prevents recursive evaluator logging.
 
 ## Daily Note Output Format
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,7 +218,7 @@ Invoked automatically by Codex on `agent-turn-complete`. Do not call directly.
 | `codexNotifyRestore` | no | Previous Codex `notify` value, restored on `uninstall --codex` |
 | `englishAsk` | no | Optional Codex prompt evaluator config. Disabled unless `englishAsk.enabled` is true |
 
-EnglishAsk evaluates English Codex user prompts with `codex exec` after the normal Daily Note append. Results are written under `## EnglishAsk`; evaluator failures and timeouts are fail-soft. `AGENTLOG_ENGLISHASK_EVAL=1` prevents recursive evaluator logging.
+EnglishAsk evaluates English Codex user prompts with `codex exec` after the normal Daily Note append. Results are written under `## EnglishAsk`; evaluator failures and timeouts are fail-soft. `AGENTLOG_ENGLISHASK_EVAL=1` skips evaluator child notify turns.
 
 ## Daily Note Output Format
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Example EnglishAsk config:
 }
 ```
 
-When enabled, AgentLog evaluates English Codex user prompts with `codex exec` after writing the normal AgentLog entry. Results are appended to the same Daily Note under `## EnglishAsk`. Evaluator failures and timeouts are ignored. Child evaluator runs set `AGENTLOG_ENGLISHASK_EVAL=1` so AgentLog does not recursively evaluate evaluator prompts.
+When enabled, AgentLog evaluates English Codex user prompts with `codex exec` after writing the normal AgentLog entry. Results are appended to the same Daily Note under `## EnglishAsk`. Evaluator failures and timeouts are ignored. Child evaluator runs set `AGENTLOG_ENGLISHASK_EVAL=1` so AgentLog skips evaluator child notify turns.
 
 Environment variables:
 

--- a/README.md
+++ b/README.md
@@ -184,12 +184,29 @@ Current CLI:
 | `vault` | (required) | Path to the Obsidian vault or plain output folder |
 | `plain` | `false` | Plain mode that writes simple markdown files without Obsidian integration |
 | `codexNotifyRestore` | unset | Previous Codex `notify` command. Used to forward/restore on Codex uninstall |
+| `englishAsk` | unset | Optional Codex prompt evaluator config. Disabled unless `englishAsk.enabled` is `true` |
+
+Example EnglishAsk config:
+
+```json
+{
+  "englishAsk": {
+    "enabled": true,
+    "mode": "log-only",
+    "threshold": 3,
+    "timeoutMs": 8000
+  }
+}
+```
+
+When enabled, AgentLog evaluates English Codex user prompts with `codex exec` after writing the normal AgentLog entry. Results are appended to the same Daily Note under `## EnglishAsk`. Evaluator failures and timeouts are ignored. Child evaluator runs set `AGENTLOG_ENGLISHASK_EVAL=1` so AgentLog does not recursively evaluate evaluator prompts.
 
 Environment variables:
 
 | Variable | Description |
 |----------|-------------|
 | `AGENTLOG_CONFIG_DIR` | Override the config directory (default: `~/.agentlog`) |
+| `AGENTLOG_ENGLISHASK_EVAL` | Internal recursion guard for EnglishAsk evaluator runs |
 | `AGENTLOG_PHASE` | Force the runtime channel (`dev` or `prod`), overriding auto-detection |
 | `OBSIDIAN_BIN` | Override the Obsidian CLI binary path |
 

--- a/docs/review/SELF_REVIEW.md
+++ b/docs/review/SELF_REVIEW.md
@@ -96,7 +96,7 @@ Check:
 - Prompts and evaluator output are redacted and bounded before storage.
 - Stored prompt metadata is flattened before being written as a Markdown list item.
 - Stored evaluator feedback cannot break out of its Markdown code fence.
-- New feedback is inserted inside the existing `## EnglishAsk` section, before the next top-level heading.
+- New feedback is inserted inside the existing `## EnglishAsk` section, before the next top-level heading, including when the next heading immediately follows the section header.
 
 Good evidence:
 

--- a/docs/review/SELF_REVIEW.md
+++ b/docs/review/SELF_REVIEW.md
@@ -83,6 +83,23 @@ Check:
 - Old statements like "always uses Obsidian CLI" are removed or qualified.
 - README/CLAUDE/docs are updated only when they are in scope.
 
+### Evaluator Hooks
+
+Any evaluator launched from a hook or notify path must be fail-soft and non-recursive.
+
+Check:
+
+- Child evaluator runs set an env guard before invoking Codex or other agent tooling.
+- The notify/hook path checks that guard and skips evaluator recursion.
+- Evaluator failure, non-zero exit, and timeout cannot prevent the normal AgentLog write.
+- Prompts and evaluator output are redacted and bounded before storage.
+
+Good evidence:
+
+- env guard such as `AGENTLOG_ENGLISHASK_EVAL`
+- tests for guard skip, evaluator failure, and timeout
+- config defaults that keep evaluator features off unless explicitly enabled
+
 ### Plan and Design Contract Drift
 
 Implementation plans and design docs must not drift from the current code contract.

--- a/docs/review/SELF_REVIEW.md
+++ b/docs/review/SELF_REVIEW.md
@@ -90,7 +90,7 @@ Any evaluator launched from a hook or notify path must be fail-soft and non-recu
 Check:
 
 - Child evaluator runs set an env guard before invoking Codex or other agent tooling.
-- The notify/hook path checks that guard before normal writes/forwarding and skips evaluator child turns entirely.
+- The notify/hook path checks that guard before reading stdin, normal writes, and forwarding, then skips evaluator child turns entirely.
 - Notify payload `cwd` can be stale or unavailable on CI/another machine; evaluator cwd must fall back safely.
 - Evaluator failure, non-zero exit, timeout, and feedback append failures cannot prevent the normal AgentLog write or surface as generic notify errors.
 - Prompts and evaluator output are redacted and bounded before storage.

--- a/docs/review/SELF_REVIEW.md
+++ b/docs/review/SELF_REVIEW.md
@@ -90,17 +90,18 @@ Any evaluator launched from a hook or notify path must be fail-soft and non-recu
 Check:
 
 - Child evaluator runs set an env guard before invoking Codex or other agent tooling.
-- The notify/hook path checks that guard and skips evaluator recursion.
+- The notify/hook path checks that guard before normal writes/forwarding and skips evaluator child turns entirely.
 - Notify payload `cwd` can be stale or unavailable on CI/another machine; evaluator cwd must fall back safely.
 - Evaluator failure, non-zero exit, timeout, and feedback append failures cannot prevent the normal AgentLog write or surface as generic notify errors.
 - Prompts and evaluator output are redacted and bounded before storage.
 - Stored prompt metadata is flattened before being written as a Markdown list item.
+- Stored evaluator feedback cannot break out of its Markdown code fence.
 - New feedback is inserted inside the existing `## EnglishAsk` section, before the next top-level heading.
 
 Good evidence:
 
 - env guard such as `AGENTLOG_ENGLISHASK_EVAL`
-- tests for guard skip, missing cwd fallback, evaluator failure, timeout, append failure, prompt flattening, and existing-section insertion
+- tests for guarded notify no-write/no-forward, missing cwd fallback, evaluator failure, timeout, append failure, prompt flattening, feedback fence safety, and existing-section insertion
 - config defaults that keep evaluator features off unless explicitly enabled
 
 ### Plan and Design Contract Drift

--- a/docs/review/SELF_REVIEW.md
+++ b/docs/review/SELF_REVIEW.md
@@ -92,13 +92,15 @@ Check:
 - Child evaluator runs set an env guard before invoking Codex or other agent tooling.
 - The notify/hook path checks that guard and skips evaluator recursion.
 - Notify payload `cwd` can be stale or unavailable on CI/another machine; evaluator cwd must fall back safely.
-- Evaluator failure, non-zero exit, and timeout cannot prevent the normal AgentLog write.
+- Evaluator failure, non-zero exit, timeout, and feedback append failures cannot prevent the normal AgentLog write or surface as generic notify errors.
 - Prompts and evaluator output are redacted and bounded before storage.
+- Stored prompt metadata is flattened before being written as a Markdown list item.
+- New feedback is inserted inside the existing `## EnglishAsk` section, before the next top-level heading.
 
 Good evidence:
 
 - env guard such as `AGENTLOG_ENGLISHASK_EVAL`
-- tests for guard skip, missing cwd fallback, evaluator failure, and timeout
+- tests for guard skip, missing cwd fallback, evaluator failure, timeout, append failure, prompt flattening, and existing-section insertion
 - config defaults that keep evaluator features off unless explicitly enabled
 
 ### Plan and Design Contract Drift

--- a/docs/review/SELF_REVIEW.md
+++ b/docs/review/SELF_REVIEW.md
@@ -91,13 +91,14 @@ Check:
 
 - Child evaluator runs set an env guard before invoking Codex or other agent tooling.
 - The notify/hook path checks that guard and skips evaluator recursion.
+- Notify payload `cwd` can be stale or unavailable on CI/another machine; evaluator cwd must fall back safely.
 - Evaluator failure, non-zero exit, and timeout cannot prevent the normal AgentLog write.
 - Prompts and evaluator output are redacted and bounded before storage.
 
 Good evidence:
 
 - env guard such as `AGENTLOG_ENGLISHASK_EVAL`
-- tests for guard skip, evaluator failure, and timeout
+- tests for guard skip, missing cwd fallback, evaluator failure, and timeout
 - config defaults that keep evaluator features off unless explicitly enabled
 
 ### Plan and Design Contract Drift

--- a/docs/review/SELF_REVIEW.md
+++ b/docs/review/SELF_REVIEW.md
@@ -93,6 +93,7 @@ Check:
 - The notify/hook path checks that guard before reading stdin, normal writes, and forwarding, then skips evaluator child turns entirely.
 - Notify payload `cwd` can be stale or unavailable on CI/another machine; evaluator cwd must fall back safely.
 - Evaluator failure, non-zero exit, timeout, and feedback append failures cannot prevent the normal AgentLog write or surface as generic notify errors.
+- Evaluators receive the raw user prompt for semantic review; display-only formatting such as `prettyPrompt(...)` is used only for Daily Note entries.
 - Prompts and evaluator output are redacted and bounded before storage.
 - Stored prompt metadata is flattened before being written as a Markdown list item.
 - Stored evaluator feedback cannot break out of its Markdown code fence.
@@ -101,7 +102,7 @@ Check:
 Good evidence:
 
 - env guard such as `AGENTLOG_ENGLISHASK_EVAL`
-- tests for guarded notify no-write/no-forward, missing cwd fallback, evaluator failure, timeout, append failure, prompt flattening, feedback fence safety, and existing-section insertion
+- tests for guarded notify no-write/no-forward, raw evaluator input vs display prompt, missing cwd fallback, evaluator failure, timeout, append failure, prompt flattening, feedback fence safety, and existing-section insertion
 - config defaults that keep evaluator features off unless explicitly enabled
 
 ### Plan and Design Contract Drift

--- a/docs/review/review-list.json
+++ b/docs/review/review-list.json
@@ -184,14 +184,14 @@
         {
           "type": "anyContentRegex",
           "paths": ["src/codex-notify.ts"],
-          "pattern": "ENGLISHASK_GUARD_ENV|AGENTLOG_ENGLISHASK_EVAL",
-          "message": "Check `AGENTLOG_ENGLISHASK_EVAL` in the notify entry point before normal writes/forwarding."
+          "pattern": "runCodexNotify[\\s\\S]*ENGLISHASK_GUARD_ENV[\\s\\S]*readStdin",
+          "message": "Check `AGENTLOG_ENGLISHASK_EVAL` at the start of the notify entry point before reading stdin or forwarding."
         },
         {
           "type": "anyContentRegex",
           "paths": ["src/__tests__/**/*.ts"],
-          "pattern": "guarded evaluator child turns|AGENTLOG_ENGLISHASK_EVAL",
-          "message": "Test that guarded evaluator child notify turns create no note and no forwarded notify."
+          "pattern": "guarded evaluator child turns|without a notify argument|AGENTLOG_ENGLISHASK_EVAL",
+          "message": "Test that guarded evaluator child notify turns create no note, no forwarded notify, and no stdin wait."
         }
       ]
     },

--- a/docs/review/review-list.json
+++ b/docs/review/review-list.json
@@ -196,6 +196,29 @@
       ]
     },
     {
+      "id": "englishask-raw-evaluator-input",
+      "severity": "medium",
+      "title": "EnglishAsk evaluator must receive the raw prompt, not display formatting",
+      "appliesTo": {
+        "paths": ["src/**/*.ts"],
+        "diffIncludesAny": ["EnglishAsk", "englishAsk", "evaluator", "prettyPrompt"]
+      },
+      "checks": [
+        {
+          "type": "noneContentRegex",
+          "paths": ["src/codex-notify.ts"],
+          "pattern": "const\\s+prompt\\s*=\\s*prettyPrompt\\([^)]*\\)[\\s\\S]*evaluateEnglishAsk\\(config,\\s*prompt\\s*,",
+          "message": "Pass the raw parsed prompt to EnglishAsk; reserve `prettyPrompt(...)` for Daily Note display."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/__tests__/**/*.ts"],
+          "pattern": "raw prompt to EnglishAsk|logging the display prompt|User prompt:\\\\n\\$\\{prompt\\}",
+          "message": "Add a regression test proving the evaluator receives raw multi-line prompt text while the note logs the display prompt."
+        }
+      ]
+    },
+    {
       "id": "englishask-cwd-fallback",
       "severity": "medium",
       "title": "EnglishAsk evaluator must tolerate unavailable notify cwd",

--- a/docs/review/review-list.json
+++ b/docs/review/review-list.json
@@ -196,6 +196,29 @@
       ]
     },
     {
+      "id": "englishask-cwd-fallback",
+      "severity": "medium",
+      "title": "EnglishAsk evaluator must tolerate unavailable notify cwd",
+      "appliesTo": {
+        "paths": ["src/**/*.ts"],
+        "diffIncludesAny": ["EnglishAsk", "englishAsk", "evaluator", "cwd"]
+      },
+      "checks": [
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/**/*.ts"],
+          "pattern": "statSync\\(|runnableCwd\\(|process\\.cwd\\(",
+          "message": "Do not run the evaluator blindly in notify `cwd`; fall back when that path is unavailable."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/__tests__/**/*.ts"],
+          "pattern": "notify cwd is unavailable|missing cwd|missing-cwd",
+          "message": "Add a regression test for unavailable notify cwd, matching CI/other-machine payloads."
+        }
+      ]
+    },
+    {
       "id": "englishask-fail-soft",
       "severity": "high",
       "title": "EnglishAsk evaluator failures must not break AgentLog writes",

--- a/docs/review/review-list.json
+++ b/docs/review/review-list.json
@@ -183,15 +183,15 @@
       "checks": [
         {
           "type": "anyContentRegex",
-          "paths": ["src/**/*.ts"],
-          "pattern": "AGENTLOG_ENGLISHASK_EVAL",
-          "message": "Set and check `AGENTLOG_ENGLISHASK_EVAL` around evaluator runs."
+          "paths": ["src/codex-notify.ts"],
+          "pattern": "ENGLISHASK_GUARD_ENV|AGENTLOG_ENGLISHASK_EVAL",
+          "message": "Check `AGENTLOG_ENGLISHASK_EVAL` in the notify entry point before normal writes/forwarding."
         },
         {
           "type": "anyContentRegex",
           "paths": ["src/__tests__/**/*.ts"],
-          "pattern": "AGENTLOG_ENGLISHASK_EVAL",
-          "message": "Test EnglishAsk recursion guard behavior."
+          "pattern": "guarded evaluator child turns|AGENTLOG_ENGLISHASK_EVAL",
+          "message": "Test that guarded evaluator child notify turns create no note and no forwarded notify."
         }
       ]
     },
@@ -261,6 +261,29 @@
           "paths": ["src/__tests__/**/*.ts"],
           "pattern": "existing EnglishAsk section|## Other",
           "message": "Add a regression test proving new feedback lands inside an existing `## EnglishAsk` section."
+        }
+      ]
+    },
+    {
+      "id": "englishask-feedback-fence-safety",
+      "severity": "medium",
+      "title": "EnglishAsk feedback must not escape its Markdown code fence",
+      "appliesTo": {
+        "paths": ["src/**/*.ts"],
+        "diffIncludesAny": ["EnglishAsk", "englishAsk", "feedback", "```"]
+      },
+      "checks": [
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/**/*.ts"],
+          "pattern": "codeFenceFor\\(|longestBacktickRun",
+          "message": "Use a dynamic fence longer than any backtick run in evaluator feedback."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/__tests__/**/*.ts"],
+          "pattern": "longer Markdown fence|## Injected",
+          "message": "Add a regression test with evaluator feedback containing ``` and a heading-like line."
         }
       ]
     },

--- a/docs/review/review-list.json
+++ b/docs/review/review-list.json
@@ -259,8 +259,8 @@
         {
           "type": "anyContentRegex",
           "paths": ["src/__tests__/**/*.ts"],
-          "pattern": "existing EnglishAsk section|## Other",
-          "message": "Add a regression test proving new feedback lands inside an existing `## EnglishAsk` section."
+          "pattern": "existing EnglishAsk section|immediately following top-level section|## Other",
+          "message": "Add regression tests proving new feedback lands inside `## EnglishAsk`, including when the next `##` heading follows immediately."
         }
       ]
     },

--- a/docs/review/review-list.json
+++ b/docs/review/review-list.json
@@ -219,6 +219,52 @@
       ]
     },
     {
+      "id": "englishask-prompt-list-line",
+      "severity": "medium",
+      "title": "EnglishAsk prompt metadata must stay on one Markdown list line",
+      "appliesTo": {
+        "paths": ["src/**/*.ts"],
+        "diffIncludesAny": ["EnglishAsk", "englishAsk", "feedback.prompt", "[truncated]"]
+      },
+      "checks": [
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/**/*.ts"],
+          "pattern": "listItemValue\\(|replace\\(/\\\\s\\+/",
+          "message": "Flatten stored prompt metadata before writing it as a Markdown list item."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/__tests__/**/*.ts"],
+          "pattern": "one Markdown list line|\\[truncated\\]",
+          "message": "Add a regression test for truncated multi-line prompt metadata in `- prompt:`."
+        }
+      ]
+    },
+    {
+      "id": "englishask-section-insertion",
+      "severity": "medium",
+      "title": "EnglishAsk feedback must be inserted inside the existing section",
+      "appliesTo": {
+        "paths": ["src/**/*.ts"],
+        "diffIncludesAny": ["## EnglishAsk", "appendEnglishAskFeedback", "EnglishAsk"]
+      },
+      "checks": [
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/**/*.ts"],
+          "pattern": "insertFeedbackBlock\\(|nextHeading",
+          "message": "Insert new feedback before the next top-level heading after `## EnglishAsk`, not blindly at EOF."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/__tests__/**/*.ts"],
+          "pattern": "existing EnglishAsk section|## Other",
+          "message": "Add a regression test proving new feedback lands inside an existing `## EnglishAsk` section."
+        }
+      ]
+    },
+    {
       "id": "englishask-fail-soft",
       "severity": "high",
       "title": "EnglishAsk evaluator failures must not break AgentLog writes",
@@ -238,6 +284,12 @@
           "paths": ["src/__tests__/**/*.ts"],
           "pattern": "times out",
           "message": "Add a regression test for evaluator timeout handling."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/__tests__/**/*.ts"],
+          "pattern": "append failures silent",
+          "message": "Add a regression test proving EnglishAsk feedback append failures stay fail-soft."
         }
       ]
     },

--- a/docs/review/review-list.json
+++ b/docs/review/review-list.json
@@ -173,6 +173,52 @@
       ]
     },
     {
+      "id": "englishask-recursion-guard",
+      "severity": "high",
+      "title": "EnglishAsk evaluator must not recursively evaluate itself",
+      "appliesTo": {
+        "paths": ["src/**/*.ts"],
+        "diffIncludesAny": ["EnglishAsk", "englishAsk", "evaluator"]
+      },
+      "checks": [
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/**/*.ts"],
+          "pattern": "AGENTLOG_ENGLISHASK_EVAL",
+          "message": "Set and check `AGENTLOG_ENGLISHASK_EVAL` around evaluator runs."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/__tests__/**/*.ts"],
+          "pattern": "AGENTLOG_ENGLISHASK_EVAL",
+          "message": "Test EnglishAsk recursion guard behavior."
+        }
+      ]
+    },
+    {
+      "id": "englishask-fail-soft",
+      "severity": "high",
+      "title": "EnglishAsk evaluator failures must not break AgentLog writes",
+      "appliesTo": {
+        "paths": ["src/**/*.ts"],
+        "diffIncludesAny": ["EnglishAsk", "englishAsk", "evaluator"]
+      },
+      "checks": [
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/__tests__/**/*.ts"],
+          "pattern": "EnglishAsk evaluator fails",
+          "message": "Add a regression test proving AgentLog still writes when EnglishAsk fails."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/__tests__/**/*.ts"],
+          "pattern": "times out",
+          "message": "Add a regression test for evaluator timeout handling."
+        }
+      ]
+    },
+    {
       "id": "plan-path-resolution-doc-contract",
       "severity": "medium",
       "title": "Plan docs must not describe unsafe config.vault string concatenation",

--- a/llms.txt
+++ b/llms.txt
@@ -79,9 +79,11 @@ Fields:
 - `vault` (required): absolute path to Obsidian vault or plain folder
 - `plain` (optional): if true, writes simple YYYY-MM-DD.md files
 - `codexNotifyRestore` (optional): saved previous Codex notify value, restored on uninstall
+- `englishAsk` (optional): Codex prompt evaluator config. Disabled unless `englishAsk.enabled` is true. Results append under `## EnglishAsk`.
 
 Environment variables:
 - `AGENTLOG_CONFIG_DIR`: override config directory (default: `~/.agentlog`)
+- `AGENTLOG_ENGLISHASK_EVAL`: internal recursion guard for EnglishAsk evaluator runs
 - `AGENTLOG_PHASE`: force channel `dev` or `prod`
 - `OBSIDIAN_BIN`: override Obsidian CLI binary path
 

--- a/llms.txt
+++ b/llms.txt
@@ -83,7 +83,7 @@ Fields:
 
 Environment variables:
 - `AGENTLOG_CONFIG_DIR`: override config directory (default: `~/.agentlog`)
-- `AGENTLOG_ENGLISHASK_EVAL`: internal recursion guard for EnglishAsk evaluator runs
+- `AGENTLOG_ENGLISHASK_EVAL`: internal guard that skips EnglishAsk evaluator child notify turns
 - `AGENTLOG_PHASE`: force channel `dev` or `prod`
 - `OBSIDIAN_BIN`: override Obsidian CLI binary path
 

--- a/src/__tests__/cli-codex.test.ts
+++ b/src/__tests__/cli-codex.test.ts
@@ -348,6 +348,50 @@ describe("cli codex commands", () => {
     expect(readFileSync(evaluator.inputPath, "utf-8")).toContain("User prompt:\nReply with exactly: OK");
   });
 
+  it("codex-notify sends the raw prompt to EnglishAsk while logging the display prompt", async () => {
+    const vault = join(tmpHome, "notes");
+    const cfgDir = join(tmpHome, ".agentlog");
+    const evaluator = makeFakeEnglishAskEvaluator(tmpHome);
+    mkdirSync(vault, { recursive: true });
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(
+      join(cfgDir, "config.json"),
+      JSON.stringify({
+        vault,
+        plain: true,
+        englishAsk: {
+          enabled: true,
+          mode: "log-only",
+          evaluatorCommand: evaluator.command,
+        },
+      }),
+      "utf-8"
+    );
+
+    const prompt = [
+      "Please preserve this prompt exactly:",
+      "line one",
+      "line two",
+      "What changed?",
+    ].join("\n");
+    const raw = JSON.stringify({
+      type: "agent-turn-complete",
+      "thread-id": "thread-englishask-raw",
+      cwd: "/Users/pray/work/js/agentlog",
+      "input-messages": [prompt],
+    });
+    const { exitCode, stderr } = await runCli(["codex-notify", raw], {
+      HOME: tmpHome,
+      AGENTLOG_CONFIG_DIR: cfgDir,
+    });
+
+    const content = readFileSync(findPlainNotePath(vault), "utf-8");
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(content).toContain("Please preserve this prompt exactly: (+2 lines) What changed?");
+    expect(readFileSync(evaluator.inputPath, "utf-8")).toContain(`User prompt:\n${prompt}`);
+  });
+
   it("codex-notify skips guarded evaluator child turns without forwarding", async () => {
     const vault = join(tmpHome, "notes");
     const cfgDir = join(tmpHome, ".agentlog");

--- a/src/__tests__/cli-codex.test.ts
+++ b/src/__tests__/cli-codex.test.ts
@@ -66,6 +66,23 @@ printf 'Score: 3/5\\nNatural version: Reply with exactly OK.\\nMissing context: 
   return { command: [script, inputPath], inputPath };
 }
 
+function makeReadonlyNoteEnglishAskEvaluator(home: string, vault: string): { command: string[]; inputPath: string } {
+  const script = join(home, "englishask-readonly-note.sh");
+  const inputPath = join(home, "englishask-readonly-input.txt");
+  writeFileSync(
+    script,
+    `#!/bin/sh
+test "$AGENTLOG_ENGLISHASK_EVAL" = "1" || exit 7
+cat > "$1"
+chmod 444 "$2"/*.md || exit 8
+printf '%s\\n' 'Score: 3/5' 'Natural version: Reply with exactly OK.' 'Missing context: none' 'Rewrite with: exact expected output'
+`,
+    "utf-8"
+  );
+  chmodSync(script, 0o755);
+  return { command: [script, inputPath, vault], inputPath };
+}
+
 function findPlainNotePath(vault: string): string {
   const file = readdirSync(vault).find((name) => /^\d{4}-\d{2}-\d{2}\.md$/.test(name));
   if (!file) {
@@ -357,6 +374,38 @@ describe("cli codex commands", () => {
 
     const content = readFileSync(findPlainNotePath(vault), "utf-8");
     expect(exitCode).toBe(0);
+    expect(content).toContain("Reply with exactly: OK");
+    expect(content).not.toContain("## EnglishAsk");
+  });
+
+  it("codex-notify keeps EnglishAsk append failures silent", async () => {
+    const vault = join(tmpHome, "notes");
+    const cfgDir = join(tmpHome, ".agentlog");
+    const evaluator = makeReadonlyNoteEnglishAskEvaluator(tmpHome, vault);
+    mkdirSync(vault, { recursive: true });
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(
+      join(cfgDir, "config.json"),
+      JSON.stringify({
+        vault,
+        plain: true,
+        englishAsk: {
+          enabled: true,
+          evaluatorCommand: evaluator.command,
+        },
+      }),
+      "utf-8"
+    );
+
+    const raw = fixture("codex-notify-single.json");
+    const { exitCode, stderr } = await runCli(["codex-notify", raw], {
+      HOME: tmpHome,
+      AGENTLOG_CONFIG_DIR: cfgDir,
+    });
+
+    const content = readFileSync(findPlainNotePath(vault), "utf-8");
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
     expect(content).toContain("Reply with exactly: OK");
     expect(content).not.toContain("## EnglishAsk");
   });

--- a/src/__tests__/cli-codex.test.ts
+++ b/src/__tests__/cli-codex.test.ts
@@ -50,6 +50,22 @@ function makeFakeCodexPath(home: string): string {
   return `${binDir}:${process.env.PATH ?? "/usr/bin:/bin"}`;
 }
 
+function makeFakeEnglishAskEvaluator(home: string): { command: string[]; inputPath: string } {
+  const script = join(home, "englishask-eval.sh");
+  const inputPath = join(home, "englishask-input.txt");
+  writeFileSync(
+    script,
+    `#!/bin/sh
+test "$AGENTLOG_ENGLISHASK_EVAL" = "1" || exit 7
+cat > "$1"
+printf 'Score: 3/5\\nNatural version: Reply with exactly OK.\\nMissing context: none\\nRewrite with: exact expected output\\n'
+`,
+    "utf-8"
+  );
+  chmodSync(script, 0o755);
+  return { command: [script, inputPath], inputPath };
+}
+
 function findPlainNotePath(vault: string): string {
   const file = readdirSync(vault).find((name) => /^\d{4}-\d{2}-\d{2}\.md$/.test(name));
   if (!file) {
@@ -278,6 +294,71 @@ describe("cli codex commands", () => {
     expect(exitCode).toBe(0);
     expect(readdirSync(vault).some((name) => /^\d{4}-\d{2}-\d{2}\.md$/.test(name))).toBe(false);
     expect(existsSync(marker)).toBe(true);
+  });
+
+  it("codex-notify appends EnglishAsk feedback when enabled", async () => {
+    const vault = join(tmpHome, "notes");
+    const cfgDir = join(tmpHome, ".agentlog");
+    const evaluator = makeFakeEnglishAskEvaluator(tmpHome);
+    mkdirSync(vault, { recursive: true });
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(
+      join(cfgDir, "config.json"),
+      JSON.stringify({
+        vault,
+        plain: true,
+        englishAsk: {
+          enabled: true,
+          mode: "log-only",
+          evaluatorCommand: evaluator.command,
+        },
+      }),
+      "utf-8"
+    );
+
+    const raw = fixture("codex-notify-single.json");
+    const { exitCode, stderr } = await runCli(["codex-notify", raw], {
+      HOME: tmpHome,
+      AGENTLOG_CONFIG_DIR: cfgDir,
+    });
+
+    const content = readFileSync(findPlainNotePath(vault), "utf-8");
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(content).toContain("Reply with exactly: OK");
+    expect(content).toContain("## EnglishAsk");
+    expect(content).toContain("- score: 3/5");
+    expect(readFileSync(evaluator.inputPath, "utf-8")).toContain("User prompt:\nReply with exactly: OK");
+  });
+
+  it("codex-notify still writes the note when EnglishAsk evaluator fails", async () => {
+    const vault = join(tmpHome, "notes");
+    const cfgDir = join(tmpHome, ".agentlog");
+    mkdirSync(vault, { recursive: true });
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(
+      join(cfgDir, "config.json"),
+      JSON.stringify({
+        vault,
+        plain: true,
+        englishAsk: {
+          enabled: true,
+          evaluatorCommand: ["sh", "-lc", "exit 42"],
+        },
+      }),
+      "utf-8"
+    );
+
+    const raw = fixture("codex-notify-single.json");
+    const { exitCode } = await runCli(["codex-notify", raw], {
+      HOME: tmpHome,
+      AGENTLOG_CONFIG_DIR: cfgDir,
+    });
+
+    const content = readFileSync(findPlainNotePath(vault), "utf-8");
+    expect(exitCode).toBe(0);
+    expect(content).toContain("Reply with exactly: OK");
+    expect(content).not.toContain("## EnglishAsk");
   });
 
   it("legacy codex-uninstall command is rejected", async () => {

--- a/src/__tests__/cli-codex.test.ts
+++ b/src/__tests__/cli-codex.test.ts
@@ -9,7 +9,7 @@ const CLI_PATH = fileURLToPath(new URL("../cli.ts", import.meta.url));
 
 async function runCli(
   args: string[],
-  opts: { HOME?: string; AGENTLOG_CONFIG_DIR?: string; PATH?: string } = {}
+  opts: { HOME?: string; AGENTLOG_CONFIG_DIR?: string; PATH?: string; AGENTLOG_ENGLISHASK_EVAL?: string } = {}
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   const env = { ...process.env, ...opts };
   const proc = Bun.spawn(
@@ -346,6 +346,38 @@ describe("cli codex commands", () => {
     expect(content).toContain("## EnglishAsk");
     expect(content).toContain("- score: 3/5");
     expect(readFileSync(evaluator.inputPath, "utf-8")).toContain("User prompt:\nReply with exactly: OK");
+  });
+
+  it("codex-notify skips guarded evaluator child turns without forwarding", async () => {
+    const vault = join(tmpHome, "notes");
+    const cfgDir = join(tmpHome, ".agentlog");
+    const marker = join(tmpHome, "forwarded-guarded.txt");
+    mkdirSync(vault, { recursive: true });
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(
+      join(cfgDir, "config.json"),
+      JSON.stringify({
+        vault,
+        plain: true,
+        codexNotifyRestore: ["sh", "-lc", `printf forwarded > '${marker}'`],
+        englishAsk: {
+          enabled: true,
+        },
+      }),
+      "utf-8"
+    );
+
+    const raw = fixture("codex-notify-single.json");
+    const { exitCode, stderr } = await runCli(["codex-notify", raw], {
+      HOME: tmpHome,
+      AGENTLOG_CONFIG_DIR: cfgDir,
+      AGENTLOG_ENGLISHASK_EVAL: "1",
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(readdirSync(vault).some((name) => /^\d{4}-\d{2}-\d{2}\.md$/.test(name))).toBe(false);
+    expect(existsSync(marker)).toBe(false);
   });
 
   it("codex-notify still writes the note when EnglishAsk evaluator fails", async () => {

--- a/src/__tests__/cli-codex.test.ts
+++ b/src/__tests__/cli-codex.test.ts
@@ -348,6 +348,45 @@ describe("cli codex commands", () => {
     expect(readFileSync(evaluator.inputPath, "utf-8")).toContain("User prompt:\nReply with exactly: OK");
   });
 
+  it("codex-notify evaluates the raw prompt while logging a pretty prompt", async () => {
+    const vault = join(tmpHome, "notes");
+    const cfgDir = join(tmpHome, ".agentlog");
+    const evaluator = makeFakeEnglishAskEvaluator(tmpHome);
+    mkdirSync(vault, { recursive: true });
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(
+      join(cfgDir, "config.json"),
+      JSON.stringify({
+        vault,
+        plain: true,
+        englishAsk: {
+          enabled: true,
+          mode: "log-only",
+          evaluatorCommand: evaluator.command,
+        },
+      }),
+      "utf-8"
+    );
+
+    const raw = JSON.stringify({
+      type: "agent-turn-complete",
+      "thread-id": "thread-raw-prompt",
+      cwd: "/Users/pray/Obsidian",
+      "input-messages": ["Line one\nLine two\nLine three"],
+    });
+    const { exitCode, stderr } = await runCli(["codex-notify", raw], {
+      HOME: tmpHome,
+      AGENTLOG_CONFIG_DIR: cfgDir,
+    });
+
+    const content = readFileSync(findPlainNotePath(vault), "utf-8");
+    const evaluatorInput = readFileSync(evaluator.inputPath, "utf-8");
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(content).toContain("Line one (+1 lines) Line three");
+    expect(evaluatorInput).toContain("User prompt:\nLine one\nLine two\nLine three");
+  });
+
   it("codex-notify skips guarded evaluator child turns without forwarding", async () => {
     const vault = join(tmpHome, "notes");
     const cfgDir = join(tmpHome, ".agentlog");

--- a/src/__tests__/cli-codex.test.ts
+++ b/src/__tests__/cli-codex.test.ts
@@ -380,6 +380,34 @@ describe("cli codex commands", () => {
     expect(existsSync(marker)).toBe(false);
   });
 
+  it("codex-notify exits immediately for guarded child turns without a notify argument", async () => {
+    const vault = join(tmpHome, "notes");
+    const cfgDir = join(tmpHome, ".agentlog");
+    mkdirSync(vault, { recursive: true });
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(
+      join(cfgDir, "config.json"),
+      JSON.stringify({
+        vault,
+        plain: true,
+        englishAsk: {
+          enabled: true,
+        },
+      }),
+      "utf-8"
+    );
+
+    const { exitCode, stderr } = await runCli(["codex-notify"], {
+      HOME: tmpHome,
+      AGENTLOG_CONFIG_DIR: cfgDir,
+      AGENTLOG_ENGLISHASK_EVAL: "1",
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(readdirSync(vault).some((name) => /^\d{4}-\d{2}-\d{2}\.md$/.test(name))).toBe(false);
+  });
+
   it("codex-notify still writes the note when EnglishAsk evaluator fails", async () => {
     const vault = join(tmpHome, "notes");
     const cfgDir = join(tmpHome, ".agentlog");

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -84,13 +84,24 @@ describe("config", () => {
 
   // C6: save then load round-trip
   it("saveConfig and loadConfig round-trip preserves all fields", () => {
-    const cfg = { vault: "/abs/vault", plain: true };
+    const cfg = {
+      vault: "/abs/vault",
+      plain: true,
+      englishAsk: {
+        enabled: true,
+        mode: "log-only" as const,
+        threshold: 3,
+        timeoutMs: 8000,
+      },
+    };
     saveConfig(cfg);
 
     const loaded = loadConfig();
     expect(loaded).not.toBeNull();
     expect(loaded!.vault).toBe("/abs/vault");
     expect(loaded!.plain).toBe(true);
+    expect(loaded!.englishAsk?.enabled).toBe(true);
+    expect(loaded!.englishAsk?.threshold).toBe(3);
   });
 
   // C7: expandHome with ~/

--- a/src/__tests__/english-ask.test.ts
+++ b/src/__tests__/english-ask.test.ts
@@ -95,6 +95,21 @@ describe("EnglishAsk", () => {
     expect(result).toBeNull();
   });
 
+  it("falls back to the current process cwd when the notify cwd is unavailable", () => {
+    const { command, inputPath } = fakeEvaluator(
+      "Score: 4/5\nNatural version: ok\nMissing context: none\nRewrite with: none"
+    );
+
+    const result = evaluateEnglishAsk(
+      { vault: tmp, englishAsk: { enabled: true, evaluatorCommand: command } },
+      "What should I do next?",
+      join(tmp, "missing-cwd")
+    );
+
+    expect(result?.score).toBe(4);
+    expect(readFileSync(inputPath, "utf-8")).toContain("User prompt:\nWhat should I do next?");
+  });
+
   it("returns null when evaluator times out", () => {
     const script = join(tmp, "slow-englishask.sh");
     writeFileSync(script, "#!/bin/sh\nsleep 1\n", "utf-8");

--- a/src/__tests__/english-ask.test.ts
+++ b/src/__tests__/english-ask.test.ts
@@ -173,6 +173,57 @@ describe("EnglishAsk", () => {
     expect(content).toContain("What should I do next?");
   });
 
+  it("keeps stored prompt metadata on one Markdown list line", () => {
+    const filePath = join(tmp, "2026-03-02.md");
+    const feedback: EnglishAskFeedback = {
+      score: 3,
+      prompt: "What should I do next?\n[truncated]",
+      feedback: "Score: 3/5",
+    };
+
+    appendEnglishAskFeedback(
+      filePath,
+      feedback,
+      {
+        time: "10:53",
+        project: "js/agentlog",
+        cwd: "/Users/pray/work/js/agentlog",
+        sessionId: "abcdef12-3456",
+      },
+      { vault: tmp, englishAsk: { enabled: true } }
+    );
+
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toContain("- prompt: What should I do next? [truncated]");
+    expect(content).not.toContain("- prompt: What should I do next?\n[truncated]");
+  });
+
+  it("inserts new feedback inside an existing EnglishAsk section", () => {
+    const filePath = join(tmp, "2026-03-02.md");
+    writeFileSync(filePath, "## AgentLog\n- existing\n\n## EnglishAsk\n\n### old\n- score: 5/5\n\n## Other\n- keep\n", "utf-8");
+    const feedback: EnglishAskFeedback = {
+      score: 2,
+      prompt: "Needs section placement",
+      feedback: "Score: 2/5",
+    };
+
+    appendEnglishAskFeedback(
+      filePath,
+      feedback,
+      {
+        time: "10:54",
+        project: "js/agentlog",
+        cwd: "/Users/pray/work/js/agentlog",
+        sessionId: "abcdef12-3456",
+      },
+      { vault: tmp, englishAsk: { enabled: true } }
+    );
+
+    const content = readFileSync(filePath, "utf-8");
+    expect(content.indexOf("## EnglishAsk")).toBeLessThan(content.indexOf("Needs section placement"));
+    expect(content.indexOf("Needs section placement")).toBeLessThan(content.indexOf("## Other"));
+  });
+
   it("emits optional rewrite guidance in suggest mode", () => {
     const suggestion = englishAskSuggestion(
       { vault: tmp, englishAsk: { enabled: true, mode: "suggest", threshold: 3 } },

--- a/src/__tests__/english-ask.test.ts
+++ b/src/__tests__/english-ask.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  ENGLISHASK_GUARD_ENV,
+  appendEnglishAskFeedback,
+  englishAskSuggestion,
+  evaluateEnglishAsk,
+  shouldEvaluateEnglishAsk,
+} from "../english-ask.js";
+import type { AgentLogConfig, EnglishAskFeedback } from "../types.js";
+
+let tmp: string;
+
+function makeTmp(): string {
+  const dir = join(tmpdir(), `agentlog-englishask-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function fakeEvaluator(output: string): { command: string[]; inputPath: string } {
+  const script = join(tmp, "fake-englishask.sh");
+  const inputPath = join(tmp, "evaluator-input.txt");
+  writeFileSync(
+    script,
+    `#!/bin/sh
+test "$${ENGLISHASK_GUARD_ENV}" = "1" || exit 7
+cat > "$1"
+printf '%s' '${output.replace(/'/g, "'\\''")}'
+`,
+    "utf-8"
+  );
+  chmodSync(script, 0o755);
+  return { command: [script, inputPath], inputPath };
+}
+
+describe("EnglishAsk", () => {
+  beforeEach(() => {
+    tmp = makeTmp();
+  });
+
+  afterEach(() => {
+    delete process.env[ENGLISHASK_GUARD_ENV];
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("is off by default", () => {
+    expect(shouldEvaluateEnglishAsk({ vault: tmp }, "What should I do next?")).toBe(false);
+  });
+
+  it("skips recursive evaluator notify calls", () => {
+    process.env[ENGLISHASK_GUARD_ENV] = "1";
+    expect(
+      shouldEvaluateEnglishAsk({ vault: tmp, englishAsk: { enabled: true } }, "What should I do next?")
+    ).toBe(false);
+  });
+
+  it("skips non-English prompts", () => {
+    expect(
+      shouldEvaluateEnglishAsk({ vault: tmp, englishAsk: { enabled: true } }, "다음에 뭐 할까?")
+    ).toBe(false);
+  });
+
+  it("runs evaluator with recursion guard and parses score", () => {
+    const { command, inputPath } = fakeEvaluator(
+      "Score: 3/5\nNatural version: What should I do next?\nMissing context: target\nRewrite with: target/result"
+    );
+    const config: AgentLogConfig = {
+      vault: tmp,
+      englishAsk: {
+        enabled: true,
+        evaluatorCommand: command,
+      },
+    };
+
+    const result = evaluateEnglishAsk(config, "What should I do next?", tmp);
+
+    expect(result?.score).toBe(3);
+    expect(result?.feedback).toContain("Score: 3/5");
+    expect(readFileSync(inputPath, "utf-8")).toContain("User prompt:\nWhat should I do next?");
+  });
+
+  it("returns null when evaluator fails", () => {
+    const script = join(tmp, "fail-englishask.sh");
+    writeFileSync(script, "#!/bin/sh\nexit 42\n", "utf-8");
+    chmodSync(script, 0o755);
+
+    const result = evaluateEnglishAsk(
+      { vault: tmp, englishAsk: { enabled: true, evaluatorCommand: [script] } },
+      "What should I do next?",
+      tmp
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when evaluator times out", () => {
+    const script = join(tmp, "slow-englishask.sh");
+    writeFileSync(script, "#!/bin/sh\nsleep 1\n", "utf-8");
+    chmodSync(script, 0o755);
+
+    const result = evaluateEnglishAsk(
+      { vault: tmp, englishAsk: { enabled: true, evaluatorCommand: [script], timeoutMs: 20 } },
+      "What should I do next?",
+      tmp
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("redacts and truncates prompt before evaluator", () => {
+    const { command, inputPath } = fakeEvaluator(
+      "Score: 4/5\nNatural version: ok\nMissing context: none\nRewrite with: none"
+    );
+    const config: AgentLogConfig = {
+      vault: tmp,
+      englishAsk: {
+        enabled: true,
+        evaluatorCommand: command,
+        maxPromptChars: 40,
+      },
+    };
+
+    const result = evaluateEnglishAsk(config, "Use sk-abcdefghijklmnopqrstuvwxyz and explain the next action", tmp);
+
+    expect(result?.prompt).toContain("[redacted-api-key]");
+    expect(result?.prompt).toContain("[truncated]");
+    expect(readFileSync(inputPath, "utf-8")).not.toContain("sk-abcdefghijklmnopqrstuvwxyz");
+  });
+
+  it("appends feedback to an EnglishAsk Daily Note section", () => {
+    const filePath = join(tmp, "2026-03-02.md");
+    writeFileSync(filePath, "## AgentLog\n- existing\n", "utf-8");
+    const feedback: EnglishAskFeedback = {
+      score: 3,
+      prompt: "What should I do next?",
+      feedback: "Score: 3/5\nNatural version: What should I do next?",
+    };
+
+    appendEnglishAskFeedback(
+      filePath,
+      feedback,
+      {
+        time: "10:53",
+        project: "js/agentlog",
+        cwd: "/Users/pray/work/js/agentlog",
+        sessionId: "abcdef12-3456",
+      },
+      { vault: tmp, englishAsk: { enabled: true, mode: "log-only" } }
+    );
+
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toContain("## EnglishAsk");
+    expect(content).toContain("### 10:53 · js/agentlog");
+    expect(content).toContain("- session: [[codex_abcdef12]]");
+    expect(content).toContain("- score: 3/5");
+    expect(content).toContain("What should I do next?");
+  });
+
+  it("emits optional rewrite guidance in suggest mode", () => {
+    const suggestion = englishAskSuggestion(
+      { vault: tmp, englishAsk: { enabled: true, mode: "suggest", threshold: 3 } },
+      { score: 3, prompt: "What next?", feedback: "Score: 3/5" }
+    );
+
+    expect(suggestion).toContain("EnglishAsk score 3/5");
+  });
+});

--- a/src/__tests__/english-ask.test.ts
+++ b/src/__tests__/english-ask.test.ts
@@ -224,6 +224,32 @@ describe("EnglishAsk", () => {
     expect(content.indexOf("Needs section placement")).toBeLessThan(content.indexOf("## Other"));
   });
 
+  it("uses a longer Markdown fence when feedback contains backtick fences", () => {
+    const filePath = join(tmp, "2026-03-02.md");
+    const feedback: EnglishAskFeedback = {
+      score: 2,
+      prompt: "Needs fence safety",
+      feedback: "Score: 2/5\n```\n## Injected\n```",
+    };
+
+    appendEnglishAskFeedback(
+      filePath,
+      feedback,
+      {
+        time: "10:54",
+        project: "js/agentlog",
+        cwd: "/Users/pray/work/js/agentlog",
+        sessionId: "abcdef12-3456",
+      },
+      { vault: tmp, englishAsk: { enabled: true } }
+    );
+
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toContain("````text");
+    expect(content).toContain("  ```\n  ## Injected\n  ```");
+    expect(content.trimEnd().endsWith("````")).toBe(true);
+  });
+
   it("emits optional rewrite guidance in suggest mode", () => {
     const suggestion = englishAskSuggestion(
       { vault: tmp, englishAsk: { enabled: true, mode: "suggest", threshold: 3 } },

--- a/src/__tests__/english-ask.test.ts
+++ b/src/__tests__/english-ask.test.ts
@@ -224,6 +224,32 @@ describe("EnglishAsk", () => {
     expect(content.indexOf("Needs section placement")).toBeLessThan(content.indexOf("## Other"));
   });
 
+  it("inserts feedback before an immediately following top-level section", () => {
+    const filePath = join(tmp, "2026-03-02.md");
+    writeFileSync(filePath, "## AgentLog\n- existing\n\n## EnglishAsk\n## Other\n- keep\n", "utf-8");
+    const feedback: EnglishAskFeedback = {
+      score: 2,
+      prompt: "Needs immediate section placement",
+      feedback: "Score: 2/5",
+    };
+
+    appendEnglishAskFeedback(
+      filePath,
+      feedback,
+      {
+        time: "10:54",
+        project: "js/agentlog",
+        cwd: "/Users/pray/work/js/agentlog",
+        sessionId: "abcdef12-3456",
+      },
+      { vault: tmp, englishAsk: { enabled: true } }
+    );
+
+    const content = readFileSync(filePath, "utf-8");
+    expect(content.indexOf("## EnglishAsk")).toBeLessThan(content.indexOf("Needs immediate section placement"));
+    expect(content.indexOf("Needs immediate section placement")).toBeLessThan(content.indexOf("## Other"));
+  });
+
   it("uses a longer Markdown fence when feedback contains backtick fences", () => {
     const filePath = join(tmp, "2026-03-02.md");
     const feedback: EnglishAskFeedback = {

--- a/src/codex-notify.ts
+++ b/src/codex-notify.ts
@@ -71,7 +71,7 @@ export async function runCodexNotify(rawArg?: string): Promise<void> {
       now
     );
 
-    const feedback = evaluateEnglishAsk(config, prompt, parsed.cwd);
+    const feedback = evaluateEnglishAsk(config, parsed.prompt, parsed.cwd);
     if (feedback) {
       try {
         appendEnglishAskFeedback(result.filePath, feedback, entry, config);

--- a/src/codex-notify.ts
+++ b/src/codex-notify.ts
@@ -4,6 +4,7 @@ import { appendEntry } from "./note-writer.js";
 import { cwdToProject } from "./schema/daily-note.js";
 import { parseCodexNotifyInput } from "./schema/codex-notify-input.js";
 import { prettyPrompt } from "./schema/pretty-prompt.js";
+import { appendEnglishAskFeedback, englishAskSuggestion, evaluateEnglishAsk } from "./english-ask.js";
 
 function readStdin(): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -48,18 +49,27 @@ export async function runCodexNotify(rawArg?: string): Promise<void> {
     const hh = String(now.getHours()).padStart(2, "0");
     const mm = String(now.getMinutes()).padStart(2, "0");
 
-    appendEntry(
+    const entry = {
+      time: `${hh}:${mm}`,
+      prompt,
+      sessionId: parsed.sessionId,
+      project: cwdToProject(parsed.cwd),
+      cwd: parsed.cwd,
+      source: "codex" as const,
+    };
+
+    const result = appendEntry(
       config,
-      {
-        time: `${hh}:${mm}`,
-        prompt,
-        sessionId: parsed.sessionId,
-        project: cwdToProject(parsed.cwd),
-        cwd: parsed.cwd,
-        source: "codex",
-      },
+      entry,
       now
     );
+
+    const feedback = evaluateEnglishAsk(config, prompt, parsed.cwd);
+    if (feedback) {
+      appendEnglishAskFeedback(result.filePath, feedback, entry, config);
+      const suggestion = englishAskSuggestion(config, feedback);
+      if (suggestion) process.stderr.write(suggestion);
+    }
   } catch (err) {
     process.stderr.write(`[agentlog] codex notify error: ${err}\n`);
   } finally {

--- a/src/codex-notify.ts
+++ b/src/codex-notify.ts
@@ -49,7 +49,8 @@ export async function runCodexNotify(rawArg?: string): Promise<void> {
     const parsed = parseCodexNotifyInput(raw);
     if (!parsed) return;
 
-    const prompt = prettyPrompt(parsed.prompt);
+    const rawPrompt = parsed.prompt;
+    const prompt = prettyPrompt(rawPrompt);
     if (!prompt) return;
 
     const now = new Date();
@@ -71,7 +72,7 @@ export async function runCodexNotify(rawArg?: string): Promise<void> {
       now
     );
 
-    const feedback = evaluateEnglishAsk(config, prompt, parsed.cwd);
+    const feedback = evaluateEnglishAsk(config, rawPrompt, parsed.cwd);
     if (feedback) {
       try {
         appendEnglishAskFeedback(result.filePath, feedback, entry, config);

--- a/src/codex-notify.ts
+++ b/src/codex-notify.ts
@@ -4,7 +4,12 @@ import { appendEntry } from "./note-writer.js";
 import { cwdToProject } from "./schema/daily-note.js";
 import { parseCodexNotifyInput } from "./schema/codex-notify-input.js";
 import { prettyPrompt } from "./schema/pretty-prompt.js";
-import { appendEnglishAskFeedback, englishAskSuggestion, evaluateEnglishAsk } from "./english-ask.js";
+import {
+  ENGLISHASK_GUARD_ENV,
+  appendEnglishAskFeedback,
+  englishAskSuggestion,
+  evaluateEnglishAsk,
+} from "./english-ask.js";
 
 function readStdin(): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -30,8 +35,10 @@ function forwardNotify(raw: string, restore: string[] | null | undefined): void 
 }
 
 export async function runCodexNotify(rawArg?: string): Promise<void> {
-  const config = loadConfig();
   const raw = rawArg ?? await readStdin();
+  if (process.env[ENGLISHASK_GUARD_ENV] === "1") return;
+
+  const config = loadConfig();
 
   try {
     if (!config) {

--- a/src/codex-notify.ts
+++ b/src/codex-notify.ts
@@ -35,9 +35,9 @@ function forwardNotify(raw: string, restore: string[] | null | undefined): void 
 }
 
 export async function runCodexNotify(rawArg?: string): Promise<void> {
-  const raw = rawArg ?? await readStdin();
   if (process.env[ENGLISHASK_GUARD_ENV] === "1") return;
 
+  const raw = rawArg ?? await readStdin();
   const config = loadConfig();
 
   try {

--- a/src/codex-notify.ts
+++ b/src/codex-notify.ts
@@ -66,9 +66,13 @@ export async function runCodexNotify(rawArg?: string): Promise<void> {
 
     const feedback = evaluateEnglishAsk(config, prompt, parsed.cwd);
     if (feedback) {
-      appendEnglishAskFeedback(result.filePath, feedback, entry, config);
-      const suggestion = englishAskSuggestion(config, feedback);
-      if (suggestion) process.stderr.write(suggestion);
+      try {
+        appendEnglishAskFeedback(result.filePath, feedback, entry, config);
+        const suggestion = englishAskSuggestion(config, feedback);
+        if (suggestion) process.stderr.write(suggestion);
+      } catch {
+        // EnglishAsk is best-effort; the normal AgentLog entry is already written.
+      }
     }
   } catch (err) {
     process.stderr.write(`[agentlog] codex notify error: ${err}\n`);

--- a/src/english-ask.ts
+++ b/src/english-ask.ts
@@ -1,0 +1,156 @@
+import { existsSync, readFileSync, writeFileSync } from "fs";
+import { spawnSync } from "child_process";
+import type { AgentLogConfig, EnglishAskFeedback } from "./types.js";
+
+export const ENGLISHASK_GUARD_ENV = "AGENTLOG_ENGLISHASK_EVAL";
+
+const DEFAULT_TIMEOUT_MS = 8_000;
+const DEFAULT_THRESHOLD = 3;
+const DEFAULT_MAX_PROMPT_CHARS = 2_000;
+const DEFAULT_MAX_OUTPUT_CHARS = 4_000;
+
+function configured(config: AgentLogConfig): boolean {
+  return config.englishAsk?.enabled === true;
+}
+
+function looksLikeEnglish(prompt: string): boolean {
+  const letters = prompt.match(/[A-Za-z]/g)?.length ?? 0;
+  const hangul = /[가-힣]/.test(prompt);
+  return letters >= 3 && !hangul;
+}
+
+function truncate(value: string, max: number): string {
+  if (value.length <= max) return value;
+  return `${value.slice(0, max)}\n[truncated]`;
+}
+
+function redact(value: string): string {
+  return value
+    .replace(/(sk-[A-Za-z0-9_-]{12,})/g, "[redacted-api-key]")
+    .replace(/(gh[pousr]_[A-Za-z0-9_]{12,})/g, "[redacted-github-token]")
+    .replace(/(npm_[A-Za-z0-9]{12,})/g, "[redacted-npm-token]")
+    .replace(/(Bearer\s+)[A-Za-z0-9._-]{12,}/gi, "$1[redacted-token]");
+}
+
+function buildEvaluatorPrompt(prompt: string): string {
+  return `Evaluate this Codex user prompt for answerability from prior context, not grammar.
+
+Score rubric:
+5: directly answerable
+4: answerable with small assumptions
+3: missing key target, intent, or constraints
+2: unclear requested action
+1: impossible without context
+
+Output exactly:
+Score: N/5
+Natural version: ...
+Missing context: ...
+Rewrite with: ...
+
+User prompt:
+${prompt}`;
+}
+
+function scoreFrom(output: string): number | null {
+  const match = output.match(/Score:\s*([1-5])\s*\/\s*5/i);
+  return match ? Number(match[1]) : null;
+}
+
+export function shouldEvaluateEnglishAsk(config: AgentLogConfig, prompt: string): boolean {
+  if (!configured(config)) return false;
+  if (process.env[ENGLISHASK_GUARD_ENV] === "1") return false;
+  return looksLikeEnglish(prompt);
+}
+
+export function evaluateEnglishAsk(config: AgentLogConfig, prompt: string, cwd: string): EnglishAskFeedback | null {
+  if (!shouldEvaluateEnglishAsk(config, prompt)) return null;
+
+  const englishAsk = config.englishAsk ?? {};
+  const timeoutMs = englishAsk.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxPromptChars = englishAsk.maxPromptChars ?? DEFAULT_MAX_PROMPT_CHARS;
+  const maxOutputChars = englishAsk.maxOutputChars ?? DEFAULT_MAX_OUTPUT_CHARS;
+  const command = englishAsk.evaluatorCommand ?? ["codex", "exec", "-"];
+  const [bin, ...args] = command;
+  if (!bin) return null;
+
+  const sanitizedPrompt = truncate(redact(prompt), maxPromptChars);
+  const input = buildEvaluatorPrompt(sanitizedPrompt);
+
+  try {
+    const result = spawnSync(bin, args, {
+      cwd,
+      input,
+      encoding: "utf-8",
+      timeout: timeoutMs,
+      env: {
+        ...process.env,
+        [ENGLISHASK_GUARD_ENV]: "1",
+      },
+    });
+
+    if (result.error || result.status !== 0 || result.signal !== null) {
+      return null;
+    }
+
+    const raw = result.stdout ?? "";
+    const feedback = truncate(redact(raw.trim()), maxOutputChars);
+    if (!feedback) return null;
+
+    return {
+      score: scoreFrom(feedback),
+      feedback,
+      prompt: sanitizedPrompt,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function englishAskSuggestion(config: AgentLogConfig, feedback: EnglishAskFeedback): string | null {
+  const mode = config.englishAsk?.mode ?? "log-only";
+  const threshold = config.englishAsk?.threshold ?? DEFAULT_THRESHOLD;
+  if (mode !== "suggest") return null;
+  if (feedback.score === null || feedback.score > threshold) return null;
+  return `[agentlog] EnglishAsk score ${feedback.score}/5. Rewrite with target/result, relevant context, constraints, and expected output.\n`;
+}
+
+function indentFeedback(feedback: string): string {
+  return feedback
+    .split("\n")
+    .map((line) => `  ${line}`)
+    .join("\n");
+}
+
+export function appendEnglishAskFeedback(
+  filePath: string,
+  feedback: EnglishAskFeedback,
+  entry: { time: string; project: string; cwd: string; sessionId: string },
+  config: AgentLogConfig
+): void {
+  const mode = config.englishAsk?.mode ?? "log-only";
+  const threshold = config.englishAsk?.threshold ?? DEFAULT_THRESHOLD;
+  const scoreText = feedback.score === null ? "unknown" : `${feedback.score}/5`;
+  const rewriteHint = mode === "suggest" && feedback.score !== null && feedback.score <= threshold
+    ? "- action: rewrite suggested before next question"
+    : "";
+  const block = [
+    `### ${entry.time} · ${entry.project}`,
+    `<!-- cwd=${entry.cwd} -->`,
+    `- session: [[codex_${entry.sessionId.slice(0, 8)}]]`,
+    `- score: ${scoreText}`,
+    `- prompt: ${feedback.prompt}`,
+    `${rewriteHint}`,
+    "```text",
+    indentFeedback(feedback.feedback),
+    "```",
+  ].filter(Boolean).join("\n");
+
+  const content = existsSync(filePath) ? readFileSync(filePath, "utf-8") : "";
+  const separator = content.endsWith("\n") || content.length === 0 ? "" : "\n";
+  const section = content.includes("\n## EnglishAsk") || content.startsWith("## EnglishAsk")
+    ? ""
+    : `${separator}\n## EnglishAsk\n`;
+  const next = `${content}${section}${section ? "" : separator}\n${block}\n`;
+  writeFileSync(filePath, next, "utf-8");
+}

--- a/src/english-ask.ts
+++ b/src/english-ask.ts
@@ -130,6 +130,11 @@ function indentFeedback(feedback: string): string {
     .join("\n");
 }
 
+function codeFenceFor(feedback: string): string {
+  const longestBacktickRun = Math.max(2, ...(feedback.match(/`+/g) ?? []).map((run) => run.length));
+  return "`".repeat(Math.max(3, longestBacktickRun + 1));
+}
+
 function listItemValue(value: string): string {
   return value.replace(/\s+/g, " ").trim();
 }
@@ -163,6 +168,7 @@ export function appendEnglishAskFeedback(
   const rewriteHint = mode === "suggest" && feedback.score !== null && feedback.score <= threshold
     ? "- action: rewrite suggested before next question"
     : "";
+  const fence = codeFenceFor(feedback.feedback);
   const block = [
     `### ${entry.time} · ${entry.project}`,
     `<!-- cwd=${entry.cwd} -->`,
@@ -170,9 +176,9 @@ export function appendEnglishAskFeedback(
     `- score: ${scoreText}`,
     `- prompt: ${listItemValue(feedback.prompt)}`,
     `${rewriteHint}`,
-    "```text",
+    `${fence}text`,
     indentFeedback(feedback.feedback),
-    "```",
+    fence,
   ].filter(Boolean).join("\n");
 
   const content = existsSync(filePath) ? readFileSync(filePath, "utf-8") : "";

--- a/src/english-ask.ts
+++ b/src/english-ask.ts
@@ -130,6 +130,27 @@ function indentFeedback(feedback: string): string {
     .join("\n");
 }
 
+function listItemValue(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function insertFeedbackBlock(content: string, block: string): string {
+  const sectionMatch = /(^|\n)## EnglishAsk[ \t]*(?:\n|$)/.exec(content);
+  if (!sectionMatch) {
+    const prefix = content.length === 0 ? "" : content.endsWith("\n") ? "\n" : "\n\n";
+    return `${content}${prefix}## EnglishAsk\n\n${block}\n`;
+  }
+
+  const bodyStart = sectionMatch.index + sectionMatch[0].length;
+  const nextHeading = /\n## /.exec(content.slice(bodyStart));
+  const insertAt = nextHeading ? bodyStart + nextHeading.index : content.length;
+  const before = content.slice(0, insertAt);
+  const after = content.slice(insertAt);
+  const prefix = before.endsWith("\n") ? "\n" : "\n\n";
+
+  return `${before}${prefix}${block}\n${after}`;
+}
+
 export function appendEnglishAskFeedback(
   filePath: string,
   feedback: EnglishAskFeedback,
@@ -147,7 +168,7 @@ export function appendEnglishAskFeedback(
     `<!-- cwd=${entry.cwd} -->`,
     `- session: [[codex_${entry.sessionId.slice(0, 8)}]]`,
     `- score: ${scoreText}`,
-    `- prompt: ${feedback.prompt}`,
+    `- prompt: ${listItemValue(feedback.prompt)}`,
     `${rewriteHint}`,
     "```text",
     indentFeedback(feedback.feedback),
@@ -155,10 +176,6 @@ export function appendEnglishAskFeedback(
   ].filter(Boolean).join("\n");
 
   const content = existsSync(filePath) ? readFileSync(filePath, "utf-8") : "";
-  const separator = content.endsWith("\n") || content.length === 0 ? "" : "\n";
-  const section = content.includes("\n## EnglishAsk") || content.startsWith("## EnglishAsk")
-    ? ""
-    : `${separator}\n## EnglishAsk\n`;
-  const next = `${content}${section}${section ? "" : separator}\n${block}\n`;
+  const next = insertFeedbackBlock(content, block);
   writeFileSync(filePath, next, "utf-8");
 }

--- a/src/english-ask.ts
+++ b/src/english-ask.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync } from "fs";
+import { existsSync, readFileSync, statSync, writeFileSync } from "fs";
 import { spawnSync } from "child_process";
 import type { AgentLogConfig, EnglishAskFeedback } from "./types.js";
 
@@ -57,6 +57,14 @@ function scoreFrom(output: string): number | null {
   return match ? Number(match[1]) : null;
 }
 
+function runnableCwd(cwd: string): string {
+  try {
+    return statSync(cwd).isDirectory() ? cwd : process.cwd();
+  } catch {
+    return process.cwd();
+  }
+}
+
 export function shouldEvaluateEnglishAsk(config: AgentLogConfig, prompt: string): boolean {
   if (!configured(config)) return false;
   if (process.env[ENGLISHASK_GUARD_ENV] === "1") return false;
@@ -79,7 +87,7 @@ export function evaluateEnglishAsk(config: AgentLogConfig, prompt: string, cwd: 
 
   try {
     const result = spawnSync(bin, args, {
-      cwd,
+      cwd: runnableCwd(cwd),
       input,
       encoding: "utf-8",
       timeout: timeoutMs,

--- a/src/english-ask.ts
+++ b/src/english-ask.ts
@@ -147,7 +147,7 @@ function insertFeedbackBlock(content: string, block: string): string {
   }
 
   const bodyStart = sectionMatch.index + sectionMatch[0].length;
-  const nextHeading = /\n## /.exec(content.slice(bodyStart));
+  const nextHeading = /(^|\n)## /.exec(content.slice(bodyStart));
   const insertAt = nextHeading ? bodyStart + nextHeading.index : content.length;
   const before = content.slice(0, insertAt);
   const after = content.slice(insertAt);

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,23 @@ export interface AgentLogConfig {
   vault: string;
   plain?: boolean;
   codexNotifyRestore?: string[] | null;
+  englishAsk?: EnglishAskConfig;
+}
+
+export interface EnglishAskConfig {
+  enabled?: boolean;
+  mode?: "log-only" | "suggest";
+  threshold?: number;
+  timeoutMs?: number;
+  maxPromptChars?: number;
+  maxOutputChars?: number;
+  evaluatorCommand?: string[];
+}
+
+export interface EnglishAskFeedback {
+  score: number | null;
+  prompt: string;
+  feedback: string;
 }
 
 /** Source of the log entry — which AI tool produced it */


### PR DESCRIPTION
## Summary
- Add optional EnglishAsk evaluator for English Codex user prompts
- Keep feature disabled unless `englishAsk.enabled` is true
- Run evaluator with `AGENTLOG_ENGLISHASK_EVAL=1` recursion guard and timeout/fail-soft behavior
- Append results to the same Daily Note under `## EnglishAsk`
- Add optional suggest mode for score <= threshold guidance
- Promote evaluator guard/fail-soft checks into self-review rules

Closes #32

## Verification
- agentlog doctor (known Codex notify config mismatch only)
- bun test
- bun test src/__tests__/english-ask.test.ts src/__tests__/cli-codex.test.ts
- bun run typecheck
- bun run build
- bun run self-review -- --mode staged --no-history
