### PR TITLE
feat: store full session ids in note links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,10 +231,10 @@ EnglishAsk evaluates English Codex user prompts with `codex exec` after the norm
 
 #### 10:53 · js/agentlog
 <!-- cwd=/Users/you/work/js/agentlog -->
-- - - - [[claude_a1b2c3d4]]
+- - - - [[claude_a1b2c3d4-1111-2222-3333-444455556666]]
 - 10:53 start building agentlog
 - 11:07 open the spec document
-- - - - [[claude_e5f6a7b8]]
+- - - - [[claude_e5f6a7b8-1111-2222-3333-444455556666]]
 - 11:21 initialize git
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ Claude Code hook / Codex hook → Daily Note append
 
 #### 10:53 · js/agentlog
 <!-- cwd=/Users/you/work/js/agentlog -->
-- - - - [[claude_a1b2c3d4]]
+- - - - [[claude_a1b2c3d4-1111-2222-3333-444455556666]]
 - 10:53 start building agentlog
 - 11:07 open the spec document
-- - - - [[claude_e5f6a7b8]]
+- - - - [[claude_e5f6a7b8-1111-2222-3333-444455556666]]
 - 11:21 initialize git and open it in VS Code
 ```
 
@@ -139,13 +139,13 @@ Each working directory gets its own `#### project` subsection. Session changes i
 
 #### 10:53 · js/agentlog
 <!-- cwd=/Users/you/work/js/agentlog -->
-- - - - [[claude_a1b2c3d4]]
+- - - - [[claude_a1b2c3d4-1111-2222-3333-444455556666]]
 - 10:53 start building agentlog
 - 11:07 open the spec document
 
 #### 14:00 · kotlin/message-gate
 <!-- cwd=/Users/you/work/kotlin/message-gate -->
-- - - - [[codex_e5f6a7b8]]
+- - - - [[codex_e5f6a7b8-1111-2222-3333-444455556666]]
 - 14:00 adjust the API response
 - 14:30 run tests
 ```

--- a/docs/review/SELF_REVIEW.md
+++ b/docs/review/SELF_REVIEW.md
@@ -99,6 +99,21 @@ Check:
 - Old statements like "always uses Obsidian CLI" are removed or qualified.
 - README/CLAUDE/docs are updated only when they are in scope.
 
+### Session Link Fidelity
+
+Session links written to Daily Notes should preserve the full session id unless reading legacy data.
+
+Check:
+
+- New `[[claude_...]]`, `[[codex_...]]`, and EnglishAsk session links use full `sessionId`.
+- Truncation such as `sessionId.slice(0, 8)` remains only in legacy matching compatibility, not in new output builders.
+- Docs examples do not show short 6-8 character source-prefixed session links as the current output.
+
+Good evidence:
+
+- tests for full UUID-like session links in Claude and Codex dividers
+- tests showing legacy short dividers still match the current session without rewriting old notes
+
 ### Evaluator Hooks
 
 Any evaluator launched from a hook or notify path must be fail-soft and non-recursive.

--- a/docs/review/review-list.json
+++ b/docs/review/review-list.json
@@ -116,7 +116,7 @@
         {
           "type": "noneContentRegex",
           "paths": ["AGENTS.md", "README.md", "llms.txt", "docs/**/*.md"],
-          "pattern": "\\[\\[(?:claude|codex)_[A-Za-z0-9]{6,8}\\]\\]",
+          "pattern": "\\[\\[(?:claude|codex)_[A-Za-z0-9]{6,}\\]\\]",
           "message": "Use full session ids in source-prefixed divider examples, not truncated examples."
         },
         {

--- a/docs/review/review-list.json
+++ b/docs/review/review-list.json
@@ -107,17 +107,23 @@
     {
       "id": "docs-session-divider-length",
       "severity": "medium",
-      "title": "Documented source-prefixed session dividers must use runtime suffix length",
+      "title": "Documented source-prefixed session dividers must use full session ids",
       "appliesTo": {
-        "paths": ["AGENTS.md", "README.md", "llms.txt", "docs/**/*.md"],
-        "diffIncludesAny": ["[[claude_", "[[codex_", "session divider"]
+        "paths": ["AGENTS.md", "README.md", "llms.txt", "docs/**/*.md", "src/schema/daily-note.ts", "src/english-ask.ts"],
+        "diffIncludesAny": ["[[claude_", "[[codex_", "session divider", "buildSessionDivider", "sessionId"]
       },
       "checks": [
         {
           "type": "noneContentRegex",
           "paths": ["AGENTS.md", "README.md", "llms.txt", "docs/**/*.md"],
-          "pattern": "\\[\\[(?:claude|codex)_[A-Za-z0-9]{6}\\]\\]",
-          "message": "Use 8 session-id characters in source-prefixed divider examples, matching runtime `sessionId.slice(0, 8)`."
+          "pattern": "\\[\\[(?:claude|codex)_[A-Za-z0-9]{6,8}\\]\\]",
+          "message": "Use full session ids in source-prefixed divider examples, not truncated examples."
+        },
+        {
+          "type": "noneContentRegex",
+          "paths": ["src/schema/daily-note.ts", "src/english-ask.ts"],
+          "pattern": "sessionId\\.slice\\(0,\\s*8\\)",
+          "message": "New AgentLog/EnglishAsk session links must use the full session id. Keep truncation only for legacy matching code."
         }
       ]
     },

--- a/docs/review/review-list.json
+++ b/docs/review/review-list.json
@@ -116,7 +116,7 @@
         {
           "type": "noneContentRegex",
           "paths": ["AGENTS.md", "README.md", "llms.txt", "docs/**/*.md"],
-          "pattern": "\\[\\[(?:claude|codex)_[A-Za-z0-9]{6,8}\\]\\]",
+          "pattern": "\\[\\[(?:claude|codex)_[A-Za-z0-9]+\\]\\]",
           "message": "Use full session ids in source-prefixed divider examples, not truncated examples."
         },
         {

--- a/llms.txt
+++ b/llms.txt
@@ -97,10 +97,10 @@ Obsidian mode appends to a `## AgentLog` section, grouped by working directory:
 
 #### 10:53 · js/agentlog
 <!-- cwd=/Users/you/work/js/agentlog -->
-- - - - [[claude_a1b2c3d4]]
+- - - - [[claude_a1b2c3d4-1111-2222-3333-444455556666]]
 - 10:53 start building agentlog
 - 11:07 open the spec document
-- - - - [[claude_e5f6a7b8]]
+- - - - [[claude_e5f6a7b8-1111-2222-3333-444455556666]]
 - 11:21 initialize git
 ```
 

--- a/src/__tests__/daily-note.test.ts
+++ b/src/__tests__/daily-note.test.ts
@@ -70,15 +70,21 @@ describe("buildAgentLogEntry", () => {
 
 describe("buildSessionDivider", () => {
   it("returns divider with claude prefix by default", () => {
-    expect(buildSessionDivider("abc12345-def6-7890-abcd-ef1234567890")).toBe("- - - - [[claude_abc12345]]");
+    expect(buildSessionDivider("abc12345-def6-7890-abcd-ef1234567890")).toBe(
+      "- - - - [[claude_abc12345-def6-7890-abcd-ef1234567890]]"
+    );
   });
 
   it("returns divider with claude prefix when source is claude", () => {
-    expect(buildSessionDivider("abc12345-def6-7890-abcd-ef1234567890", "claude")).toBe("- - - - [[claude_abc12345]]");
+    expect(buildSessionDivider("abc12345-def6-7890-abcd-ef1234567890", "claude")).toBe(
+      "- - - - [[claude_abc12345-def6-7890-abcd-ef1234567890]]"
+    );
   });
 
   it("returns divider with codex prefix when source is codex", () => {
-    expect(buildSessionDivider("abc12345-def6-7890-abcd-ef1234567890", "codex")).toBe("- - - - [[codex_abc12345]]");
+    expect(buildSessionDivider("abc12345-def6-7890-abcd-ef1234567890", "codex")).toBe(
+      "- - - - [[codex_abc12345-def6-7890-abcd-ef1234567890]]"
+    );
   });
 
   it("uses full sessionId when shorter than 8 chars", () => {

--- a/src/__tests__/english-ask.test.ts
+++ b/src/__tests__/english-ask.test.ts
@@ -168,7 +168,7 @@ describe("EnglishAsk", () => {
     const content = readFileSync(filePath, "utf-8");
     expect(content).toContain("## EnglishAsk");
     expect(content).toContain("### 10:53 · js/agentlog");
-    expect(content).toContain("- session: [[codex_abcdef12]]");
+    expect(content).toContain("- session: [[codex_abcdef12-3456]]");
     expect(content).toContain("- score: 3/5");
     expect(content).toContain("What should I do next?");
   });

--- a/src/__tests__/note-writer.test.ts
+++ b/src/__tests__/note-writer.test.ts
@@ -284,7 +284,7 @@ describe("appendEntry — session-grouped AgentLog section", () => {
     expect(content).toContain("> 🕐 10:53 — js/agentlog › 테스트 작업");
     expect(content).toContain("#### 10:53 · js/agentlog");
     expect(content).toContain("<!-- cwd=/Users/pray/work/js/agentlog -->");
-    expect(content).toContain("- - - - [[claude_abc12345]]");
+    expect(content).toContain("- - - - [[claude_abc12345-def6-7890-abcd-ef1234567890]]");
     expect(content).toContain("- 10:53 테스트 작업");
   });
 
@@ -342,6 +342,31 @@ describe("appendEntry — session-grouped AgentLog section", () => {
     expect(dividerCount).toBe(1);
   });
 
+  it("treats legacy short session divider as the same current session", () => {
+    const filePath = join(tmpDir, "Daily", "2026-03-01-일.md");
+    writeFileSync(
+      filePath,
+      [
+        "## AgentLog",
+        "> 🕐 10:53 — js/agentlog › 첫 번째 작업",
+        "",
+        "#### 10:53 · js/agentlog",
+        "<!-- cwd=/Users/pray/work/js/agentlog -->",
+        "- - - - [[claude_abc12345]]",
+        "- 10:53 첫 번째 작업",
+        "",
+      ].join("\n"),
+      "utf-8"
+    );
+
+    appendEntry(config, makeEntry({ time: "11:07", prompt: "두 번째 작업" }), TEST_DATE);
+
+    const content = readFileSync(filePath, "utf-8");
+    const dividerCount = (content.match(/- - - -/g) ?? []).length;
+    expect(dividerCount).toBe(1);
+    expect(content).toContain("- 11:07 두 번째 작업");
+  });
+
   // N5: same project, different session → insert divider
   it("inserts session divider when session changes within same project", () => {
     const filePath = join(tmpDir, "Daily", "2026-03-01-일.md");
@@ -353,8 +378,8 @@ describe("appendEntry — session-grouped AgentLog section", () => {
     appendEntry(config, entry2, TEST_DATE);
 
     const content = readFileSync(filePath, "utf-8");
-    expect(content).toContain("- - - - [[claude_session1]]");
-    expect(content).toContain("- - - - [[claude_session2]]");
+    expect(content).toContain("- - - - [[claude_session1-aaaa-bbbb-cccc-dddddddddddd]]");
+    expect(content).toContain("- - - - [[claude_session2-xxxx-yyyy-zzzz-111111111111]]");
     expect(content).toContain("- 10:53 테스트 작업");
     expect(content).toContain("- 15:00 테스트 작업");
   });
@@ -370,8 +395,8 @@ describe("appendEntry — session-grouped AgentLog section", () => {
     appendEntry(config, entry2, TEST_DATE);
 
     const content = readFileSync(filePath, "utf-8");
-    expect(content).toContain("- - - - [[codex_codex111]]");
-    expect(content).toContain("- - - - [[codex_codex222]]");
+    expect(content).toContain("- - - - [[codex_codex111-aaaa-bbbb-cccc-dddddddddddd]]");
+    expect(content).toContain("- - - - [[codex_codex222-xxxx-yyyy-zzzz-111111111111]]");
     expect(content).not.toContain("claude_");
   });
 

--- a/src/english-ask.ts
+++ b/src/english-ask.ts
@@ -172,7 +172,7 @@ export function appendEnglishAskFeedback(
   const block = [
     `### ${entry.time} · ${entry.project}`,
     `<!-- cwd=${entry.cwd} -->`,
-    `- session: [[codex_${entry.sessionId.slice(0, 8)}]]`,
+    `- session: [[codex_${entry.sessionId}]]`,
     `- score: ${scoreText}`,
     `- prompt: ${listItemValue(feedback.prompt)}`,
     `${rewriteHint}`,

--- a/src/note-writer.ts
+++ b/src/note-writer.ts
@@ -147,7 +147,7 @@ export function appendEntry(
  *   ## AgentLog
  *   > 🕐 HH:MM — project › prompt        ← latest entry (always updated)
  *
- *   #### project · HH:MM                  ← one section per cwd
+ *   #### HH:MM · project                  ← one section per cwd
  *   - HH:MM entry
  *   - - - - [[claude_<session_id>]]      ← divider when session changes
  *   - HH:MM entry

--- a/src/note-writer.ts
+++ b/src/note-writer.ts
@@ -149,11 +149,10 @@ export function appendEntry(
  *
  *   #### project · HH:MM                  ← one section per cwd
  *   - HH:MM entry
- *   - - - - [[claude_XXXXXXXX]]          ← divider when session changes
+ *   - - - - [[claude_<session_id>]]      ← divider when session changes
  *   - HH:MM entry
  */
 function insertIntoAgentLogSection(content: string, entry: LogEntry): string {
-  const sessionShort = entry.sessionId.slice(0, 8);
   const entryLine = buildAgentLogEntry(entry.time, entry.prompt);
   const latestLine = buildLatestLine(entry.time, entry.project, entry.prompt);
 
@@ -283,7 +282,9 @@ function insertIntoAgentLogSection(content: string, entry: LogEntry): string {
     }
     if (!currentSes) currentSes = legacySes;
 
-    if (currentSes !== sessionShort) {
+    const sameSession = currentSes === entry.sessionId || currentSes === entry.sessionId.slice(0, 8);
+
+    if (!sameSession) {
       // Session changed: insert divider + entry.
       lines.splice(insertAt, 0, buildSessionDivider(entry.sessionId, entry.source), entryLine);
       // Migrate legacy metadata format to new format (remove ses=).

--- a/src/schema/daily-note.ts
+++ b/src/schema/daily-note.ts
@@ -47,10 +47,10 @@ export function buildAgentLogEntry(time: string, prompt: string): string {
 /**
  * Session divider line inserted when session_id changes within a project section.
  * Uses Obsidian wiki-link format so the session ID becomes a navigable link.
- * Format: "- - - - [[claude_XXXXXXXX]]" or "- - - - [[codex_XXXXXXXX]]"
+ * Format: "- - - - [[claude_<session_id>]]" or "- - - - [[codex_<session_id>]]"
  */
 export function buildSessionDivider(sessionId: string, source: SourceType = "claude"): string {
-  return `- - - - [[${source}_${sessionId.slice(0, 8)}]]`;
+  return `- - - - [[${source}_${sessionId}]]`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- write full session_id in AgentLog source-prefixed session dividers
- write full session_id in EnglishAsk session links
- preserve legacy short-divider matching without rewriting old notes
- update docs and self-review gate to prevent truncated session-link examples

## Verification
- bun test
- bun run typecheck
- bun run build
- bun run self-review -- --mode staged

Closes #29