### PR TITLE
fix: bootstrap missing daily notes via Obsidian CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,10 +190,11 @@ Legacy handler for older Codex `notify` installs on `agent-turn-complete`. Do no
 
 ### Obsidian CLI
 
-- Used to resolve the Daily Note path via `obsidian daily:path`
+- Used to resolve the Daily Note path from `.obsidian/daily-notes.json`, then `obsidian daily:path`
+- Used to bootstrap a missing Daily Note via `obsidian daily` before AgentLog writes, preserving the user's Daily Notes template
 - Minimum version: checked by `doctor` (1.12.4+)
 - Override binary path: `OBSIDIAN_BIN`
-- Fallback when CLI unavailable: `{vault}/Daily/YYYY-MM-DD-<weekday>.md`
+- No guessed `{vault}/Daily/...` fallback is created in Obsidian mode when no safe path or bootstrap is available
 
 ### Config File
 

--- a/README.md
+++ b/README.md
@@ -117,19 +117,20 @@ Use Claude Code or Codex normally. Claude and Codex prompts are logged from thei
 
 1. Claude Code or Codex fires the `UserPromptSubmit` hook
 2. AgentLog extracts the latest user-visible input and sanitizes it
-3. Finds your Daily Note via `obsidian daily:path` (Obsidian CLI 1.12.4+). If that fails, it falls back to `{vault}/Daily/YYYY-MM-DD-<Korean weekday>.md`
-4. Finds or creates a `## AgentLog` section
-5. Finds or creates a `#### project` subsection matching the current working directory
-6. Inserts a source-prefixed session divider such as `[[claude_...]]` or `[[codex_...]]` if the session changed, then appends the entry
-7. Updates the `> 🕐` latest-entry line at the top of the section
+3. Resolves your Daily Note path from `.obsidian/daily-notes.json`, then `obsidian daily:path` when needed
+4. If the Daily Note is missing in Obsidian mode, asks `obsidian daily` to create it before writing so your Daily Notes template is preserved
+5. Finds or creates a `## AgentLog` section
+6. Finds or creates a `#### project` subsection matching the current working directory
+7. Inserts a source-prefixed session divider such as `[[claude_...]]` or `[[codex_...]]` if the session changed, then appends the entry
+8. Updates the `> 🕐` latest-entry line at the top of the section
 
-Total overhead: < 50ms per prompt. Fire-and-forget, never blocks Claude Code.
+Steady-state overhead is under 50ms per prompt when the Daily Note already exists. Missing-note bootstrap depends on Obsidian CLI startup. Fire-and-forget, never blocks Claude Code.
 
 ## Daily Note Format
 
 ### Obsidian Mode (default)
 
-AgentLog resolves the Daily Note path via `obsidian daily:path` when the Obsidian CLI is available (1.12.4+). If the CLI is unavailable or Obsidian is not running, it falls back to `{vault}/Daily/YYYY-MM-DD-<Korean weekday>.md` such as `2026-03-01-일.md`.
+AgentLog resolves the Daily Note path from `.obsidian/daily-notes.json` first, then `obsidian daily:path` when the vault settings are unavailable or unsupported. If the resolved Daily Note is missing, AgentLog runs `obsidian daily` before writing and only appends after the file exists, preserving the user's Daily Notes template. Obsidian mode does not create a guessed `{vault}/Daily/...` fallback file; if no safe path can be resolved or the CLI cannot bootstrap a missing note, the hook fails softly and skips the write. Plain mode still writes directly to `{dir}/YYYY-MM-DD.md`.
 
 Each working directory gets its own `#### project` subsection. Session changes insert a source-prefixed wiki-link divider such as `[[claude_...]]` or `[[codex_...]]`. The `> 🕐` blockquote at the top always shows the latest entry across all projects.
 

--- a/docs/cc/hook-integration.md
+++ b/docs/cc/hook-integration.md
@@ -77,37 +77,32 @@ The `matcher` is empty string to match all prompts regardless of content.
 
 ## Daily Note Format
 
-AgentLog appends to `{vault}/Daily/{YYYY-MM-DD}-{요일}.md`.
+AgentLog resolves the Daily Note path from `.obsidian/daily-notes.json` first,
+then `obsidian daily:path` when the vault settings are unavailable or
+unsupported.
 
-### With time-block sections (Korean Daily Note format)
+If the Daily Note is missing in Obsidian mode, AgentLog runs `obsidian daily`
+first and only appends after the file exists. This lets Obsidian create the note
+and apply the user's Daily Notes template. AgentLog does not create a guessed
+`{vault}/Daily/...` fallback file in Obsidian mode when no safe path or
+bootstrap is available.
 
-If the file contains time-block checkbox lines, the entry is inserted under the
-matching 2-hour block:
-
-```markdown
-## 오전 (08-13)
-- [ ] 08 - 10
-- [x] 10 - 12
-  - 10:53 agentlog 개발을 위해서 작업 진행
-  - 11:07 스펙 문서 열어봐
-- [ ] 12 - 13
-```
-
-### Without time-block sections (fallback)
-
-If no time-block pattern is found, appended to an `## AgentLog` section at
-end of file:
+Entries are merged into an `## AgentLog` section:
 
 ```markdown
 ## AgentLog
+> 🕐 11:07 — js/agentlog › 스펙 문서 열어봐
+
+#### 10:53 · js/agentlog
+<!-- cwd=/Users/you/work/js/agentlog -->
+- - - - [[claude_abc12345-def6-7890-abcd-ef1234567890]]
 - 10:53 agentlog 개발을 위해서 작업 진행
 - 11:07 스펙 문서 열어봐
 ```
 
 ### `--plain` mode
 
-With `--plain` flag during init, writes to `{dir}/{YYYY-MM-DD}.md` with no
-time-block logic:
+With `--plain` flag during init, writes directly to `{dir}/{YYYY-MM-DD}.md`:
 
 ```markdown
 - 10:53 agentlog 개발을 위해서 작업 진행

--- a/docs/obsidian/06-official-cli-research.md
+++ b/docs/obsidian/06-official-cli-research.md
@@ -87,6 +87,9 @@ OS별 포인트(문서 기준):
 ### 5.1 현재 구조와의 관계
 
 - AgentLog 핵심(`agentlog hook`)은 이미 파일 직접 쓰기라 REST API 의존이 없다.
+- Daily Note 경로는 `.obsidian/daily-notes.json`을 먼저 읽고, 설정을 해석할 수 없을 때 `obsidian daily:path`로 보완한다.
+- Missing Daily Note 생성은 `obsidian daily`가 담당한다. `daily:path`는 경로 조회일 뿐이며 템플릿 적용 생성 흐름을 보장하지 않는다.
+- AgentLog의 markdown merge는 파일이 존재한 뒤에만 수행한다. Obsidian mode에서는 안전 경로/CLI bootstrap이 없을 때 guessed `{vault}/Daily/...` 파일을 직접 만들지 않는다.
 - 영향 범위는 주로 문서/운영 자동화 레이어(`obs`, `obs-daily`, `obs-cmd`, `obs-open`류)다.
 
 ### 5.2 권장 전략
@@ -110,7 +113,7 @@ OS별 포인트(문서 기준):
 | 특정 명령 실행 | `obsidian command id="..."` |
 | 명령 목록 조회 | `obsidian commands` |
 | vault 검색 | `obsidian search query="..."` |
-| Daily 경로 확인 | `obsidian daily:path` |
+| Daily 경로 확인(생성 아님) | `obsidian daily:path` |
 
 > 참고: 실제 명령/파라미터는 1.12.x에서 빠르게 변경된 이력이 있으니, 도입 시점에 `obsidian help`로 재검증 필요.
 
@@ -175,4 +178,3 @@ OS별 포인트(문서 기준):
     https://raw.githubusercontent.com/coddingtonbear/obsidian-local-rest-api/main/manifest.json
 14. Local REST API README (HTTPS+API key 모델)  
     https://raw.githubusercontent.com/coddingtonbear/obsidian-local-rest-api/main/README.md
-

--- a/docs/obsidian/README.md
+++ b/docs/obsidian/README.md
@@ -15,5 +15,4 @@
 5. [05-project-judgement-extra-docs.md](./05-project-judgement-extra-docs.md)
    - 운영/확장 문서 백로그 및 2주 로드맵
 6. [06-official-cli-research.md](./06-official-cli-research.md)
-   - Obsidian 공식 CLI 조사, REST API 대비, AgentLog 권장 운영안
-
+   - Obsidian 공식 CLI 조사, REST API 대비, Daily Note bootstrap 결정, AgentLog 권장 운영안

--- a/docs/review/SELF_REVIEW.md
+++ b/docs/review/SELF_REVIEW.md
@@ -107,6 +107,7 @@ Check:
 
 - Missing Daily Notes in Obsidian mode are created through `obsidian daily` before AgentLog writes.
 - AgentLog re-checks that the resolved file exists after CLI bootstrap before reading or writing.
+- The `obsidian daily` bootstrap path has a longer timeout than lightweight probes such as `daily:path`, because it may start or wake Obsidian.
 - Non-plain mode does not create a guessed `{vault}/Daily/...` fallback when no safe path source is available.
 - Plain mode remains direct-file append and is not accidentally routed through Obsidian CLI.
 - Tests prove template content created by the bootstrap is preserved after AgentLog merges `## AgentLog`.
@@ -115,6 +116,7 @@ Check:
 Good evidence:
 
 - `cliEnsureDailyNoteExists()` calls `obsidian daily`.
+- tests or constants prove Daily bootstrap timeout is greater than the probe timeout.
 - `appendEntry()` aborts missing-note writes when path resolution or CLI bootstrap cannot be confirmed.
 - Regression tests for missing-note bootstrap, no guessed fallback, and bootstrap failure.
 

--- a/docs/review/SELF_REVIEW.md
+++ b/docs/review/SELF_REVIEW.md
@@ -99,6 +99,25 @@ Check:
 - Old statements like "always uses Obsidian CLI" are removed or qualified.
 - README/CLAUDE/docs are updated only when they are in scope.
 
+### Daily Bootstrap Safety
+
+`obsidian daily:path` resolves a path; it does not create the Daily Note or apply the user's template.
+
+Check:
+
+- Missing Daily Notes in Obsidian mode are created through `obsidian daily` before AgentLog writes.
+- AgentLog re-checks that the resolved file exists after CLI bootstrap before reading or writing.
+- Non-plain mode does not create a guessed `{vault}/Daily/...` fallback when no safe path source is available.
+- Plain mode remains direct-file append and is not accidentally routed through Obsidian CLI.
+- Tests prove template content created by the bootstrap is preserved after AgentLog merges `## AgentLog`.
+- Tests prove CLI-unavailable/bootstrap-failure cases do not create raw Daily files.
+
+Good evidence:
+
+- `cliEnsureDailyNoteExists()` calls `obsidian daily`.
+- `appendEntry()` aborts missing-note writes when path resolution or CLI bootstrap cannot be confirmed.
+- Regression tests for missing-note bootstrap, no guessed fallback, and bootstrap failure.
+
 ### Session Link Fidelity
 
 Session links written to Daily Notes should preserve the full session id unless reading legacy data.

--- a/docs/review/review-list.json
+++ b/docs/review/review-list.json
@@ -105,6 +105,41 @@
       ]
     },
     {
+      "id": "daily-bootstrap-safe-creation",
+      "severity": "high",
+      "title": "Missing Obsidian Daily Notes must be bootstrapped through the CLI",
+      "appliesTo": {
+        "paths": ["src/note-writer.ts", "src/obsidian-cli.ts", "src/__tests__/note-writer.test.ts", "README.md", "AGENTS.md", "llms.txt", "docs/**/*.md"],
+        "diffIncludesAny": ["dailyNotePath", "cliEnsureDailyNoteExists", "daily:path", "Daily Note", "bootstrap"]
+      },
+      "checks": [
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/obsidian-cli.ts"],
+          "pattern": "function\\s+cliEnsureDailyNoteExists[\\s\\S]*\\[\"daily\"\\]",
+          "message": "Add an Obsidian CLI bootstrap helper that runs `obsidian daily`, not only `daily:path`."
+        },
+        {
+          "type": "noneContentRegex",
+          "paths": ["src/note-writer.ts"],
+          "pattern": "return\\s+join\\(config\\.vault,\\s*\"Daily\",\\s*dailyNoteFileName\\(",
+          "message": "Do not create a guessed `{vault}/Daily/...` fallback in Obsidian mode when no safe path source is available."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/__tests__/note-writer.test.ts"],
+          "pattern": "bootstraps a missing Daily Note through Obsidian before appending",
+          "message": "Add a regression test proving missing notes are created through Obsidian before AgentLog writes."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/__tests__/note-writer.test.ts"],
+          "pattern": "does not create a guessed fallback file when no safe path resolves",
+          "message": "Add a regression test proving unsafe fallback creation is skipped."
+        }
+      ]
+    },
+    {
       "id": "docs-session-divider-length",
       "severity": "medium",
       "title": "Documented source-prefixed session dividers must use full session ids",

--- a/docs/review/review-list.json
+++ b/docs/review/review-list.json
@@ -120,6 +120,18 @@
           "message": "Add an Obsidian CLI bootstrap helper that runs `obsidian daily`, not only `daily:path`."
         },
         {
+          "type": "anyContentRegex",
+          "paths": ["src/obsidian-cli.ts"],
+          "pattern": "DAILY_BOOTSTRAP_TIMEOUT_MS[\\s\\S]*CLI_PROBE_TIMEOUT_MS|CLI_PROBE_TIMEOUT_MS[\\s\\S]*DAILY_BOOTSTRAP_TIMEOUT_MS",
+          "message": "Keep a distinct longer timeout for `obsidian daily` bootstrap than for lightweight CLI probes."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/__tests__/obsidian-cli.test.ts"],
+          "pattern": "DAILY_BOOTSTRAP_TIMEOUT_MS\\)\\.toBeGreaterThan\\(CLI_PROBE_TIMEOUT_MS",
+          "message": "Test that Daily bootstrap timeout stays longer than lightweight probe timeout."
+        },
+        {
           "type": "noneContentRegex",
           "paths": ["src/note-writer.ts"],
           "pattern": "return\\s+join\\(config\\.vault,\\s*\"Daily\",\\s*dailyNoteFileName\\(",

--- a/llms.txt
+++ b/llms.txt
@@ -112,12 +112,14 @@ Plain mode appends to `{folder}/YYYY-MM-DD.md`:
 ```
 
 Daily Note path resolution order:
-1. `obsidian daily:path` (Obsidian CLI 1.12.4+, app must be running)
-2. Fallback: `{vault}/Daily/YYYY-MM-DD-<weekday>.md`
+1. `.obsidian/daily-notes.json` when it contains a supported in-vault folder/format
+2. `obsidian daily:path` (Obsidian CLI 1.12.4+, app must be running)
+
+In Obsidian mode, missing Daily Notes are bootstrapped with `obsidian daily` before AgentLog writes so user templates are preserved. AgentLog does not create a guessed `{vault}/Daily/...` fallback file when no safe path or bootstrap is available. Plain mode still writes directly to `{dir}/YYYY-MM-DD.md`.
 
 ## How the Hook Works
 
-Claude Code fires `UserPromptSubmit` with JSON on stdin containing `prompt`, `session_id`, and `cwd`. AgentLog sanitizes the prompt, resolves the Daily Note path, and appends the entry. Fails silently — never interrupts Claude Code. Total overhead: under 50ms per prompt.
+Claude Code fires `UserPromptSubmit` with JSON on stdin containing `prompt`, `session_id`, and `cwd`. AgentLog sanitizes the prompt, resolves the Daily Note path, and appends the entry. Fails silently — never interrupts Claude Code. Steady-state overhead is under 50ms when the Daily Note already exists; missing-note bootstrap depends on Obsidian CLI startup.
 
 Codex fires `agent-turn-complete` notify. Entries are logged when the turn completes (not at prompt submission time).
 

--- a/src/__tests__/note-writer.test.ts
+++ b/src/__tests__/note-writer.test.ts
@@ -54,11 +54,11 @@ describe("dailyNotePath", () => {
     }
   });
 
-  it("returns Obsidian Daily path with Korean day name (CLI unavailable)", () => {
+  it("returns null when no non-plain path source is available", () => {
     process.env.OBSIDIAN_BIN = "/nonexistent/obsidian";
     const config: AgentLogConfig = { vault: "/vault" };
     const path = dailyNotePath(config, TEST_DATE);
-    expect(path).toBe("/vault/Daily/2026-03-01-일.md");
+    expect(path).toBeNull();
   });
 
   it("returns plain path without Daily subdir", () => {
@@ -219,7 +219,7 @@ describe("dailyNotePath", () => {
     );
 
     const path = dailyNotePath({ vault }, TEST_DATE);
-    expect(path).toBe(join(vault, "Daily/2026-03-01-일.md"));
+    expect(path).toBeNull();
 
     rmSync(vault, { recursive: true, force: true });
   });
@@ -232,18 +232,18 @@ describe("dailyNotePath", () => {
     process.env.OBSIDIAN_BIN = mockBin;
 
     const path = dailyNotePath({ vault }, TEST_DATE);
-    expect(path).toBe(join(vault, "Daily/2026-03-01-일.md"));
+    expect(path).toBeNull();
 
     rmSync(mockBin, { force: true });
     rmSync(vault, { recursive: true, force: true });
   });
 
-  it("falls back to hardcoded path when CLI fails", () => {
+  it("returns null when CLI fails and config is unavailable", () => {
     process.env.OBSIDIAN_BIN = "/nonexistent/obsidian";
 
     const config: AgentLogConfig = { vault: "/vault" };
     const path = dailyNotePath(config, TEST_DATE);
-    expect(path).toBe("/vault/Daily/2026-03-01-일.md");
+    expect(path).toBeNull();
   });
 
 });
@@ -256,8 +256,14 @@ describe("appendEntry — session-grouped AgentLog section", () => {
   beforeEach(() => {
     tmpDir = makeTmpDir();
     config = { vault: tmpDir };
-    // Disable CLI so tests use hardcoded Daily/ path with the test date
+    // Disable CLI; most tests resolve the Daily path through vault settings.
     process.env.OBSIDIAN_BIN = "/nonexistent/obsidian";
+    mkdirSync(join(tmpDir, ".obsidian"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, ".obsidian", "daily-notes.json"),
+      JSON.stringify({ folder: "Daily", format: "YYYY-MM-DD-ddd" }),
+      "utf-8"
+    );
     mkdirSync(join(tmpDir, "Daily"), { recursive: true });
   });
 
@@ -270,8 +276,45 @@ describe("appendEntry — session-grouped AgentLog section", () => {
     }
   });
 
+  function dailyFilePath(): string {
+    return join(tmpDir, "Daily", "2026-03-01-일.md");
+  }
+
+  function writeDailyFile(content = FIXTURE_NO_TIMEBLOCKS): string {
+    const filePath = dailyFilePath();
+    writeFileSync(filePath, content, "utf-8");
+    return filePath;
+  }
+
+  function installDailyBootstrapCli(template: string): string {
+    const mockBin = join(tmpDir, "mock-obsidian");
+    const filePath = dailyFilePath();
+    writeFileSync(
+      mockBin,
+      [
+        "#!/bin/bash",
+        "if [ \"$1\" = \"daily:path\" ]; then",
+        "  echo \"Daily/2026-03-01-일.md\"",
+        "  exit 0",
+        "fi",
+        "if [ \"$1\" = \"daily\" ]; then",
+        `  mkdir -p ${JSON.stringify(join(tmpDir, "Daily"))}`,
+        `  printf '%s' ${JSON.stringify(template)} > ${JSON.stringify(filePath)}`,
+        "  exit 0",
+        "fi",
+        "exit 1",
+      ].join("\n"),
+      "utf-8"
+    );
+    chmodSync(mockBin, 0o755);
+    process.env.OBSIDIAN_BIN = mockBin;
+    return filePath;
+  }
+
   // N1: new file — creates ## AgentLog + > 🕐 + #### section
-  it("creates ## AgentLog with latest line and project section on new file", () => {
+  it("bootstraps a missing Daily Note through Obsidian before appending", () => {
+    installDailyBootstrapCli("# 2026-03-01\n\n## Template\n- keep me\n");
+
     const entry = makeEntry();
     const result = appendEntry(config, entry, TEST_DATE);
 
@@ -280,6 +323,8 @@ describe("appendEntry — session-grouped AgentLog section", () => {
     expect(existsSync(result.filePath)).toBe(true);
 
     const content = readFileSync(result.filePath, "utf-8");
+    expect(content).toContain("## Template");
+    expect(content).toContain("- keep me");
     expect(content).toContain("## AgentLog");
     expect(content).toContain("> 🕐 10:53 — js/agentlog › 테스트 작업");
     expect(content).toContain("#### 10:53 · js/agentlog");
@@ -288,10 +333,38 @@ describe("appendEntry — session-grouped AgentLog section", () => {
     expect(content).toContain("- 10:53 테스트 작업");
   });
 
+  it("does not create a guessed fallback file when no safe path resolves", () => {
+    process.env.OBSIDIAN_BIN = "/nonexistent/obsidian";
+    rmSync(join(tmpDir, ".obsidian", "daily-notes.json"), { force: true });
+
+    expect(() => appendEntry(config, makeEntry(), TEST_DATE)).toThrow("Daily Note path could not be resolved");
+    expect(existsSync(dailyFilePath())).toBe(false);
+  });
+
+  it("aborts missing-note writes when Obsidian bootstrap fails", () => {
+    const mockBin = join(tmpDir, "mock-obsidian-fail");
+    writeFileSync(
+      mockBin,
+      [
+        "#!/bin/bash",
+        "if [ \"$1\" = \"daily:path\" ]; then",
+        "  echo \"Daily/2026-03-01-일.md\"",
+        "  exit 0",
+        "fi",
+        "exit 1",
+      ].join("\n"),
+      "utf-8"
+    );
+    chmodSync(mockBin, 0o755);
+    process.env.OBSIDIAN_BIN = mockBin;
+
+    expect(() => appendEntry(config, makeEntry(), TEST_DATE)).toThrow("Daily Note is missing");
+    expect(existsSync(dailyFilePath())).toBe(false);
+  });
+
   // N2: file with existing content — appends ## AgentLog at end
   it("appends ## AgentLog section to existing file without modifying existing content", () => {
-    const filePath = join(tmpDir, "Daily", "2026-03-01-일.md");
-    writeFileSync(filePath, FIXTURE_NO_TIMEBLOCKS, "utf-8");
+    const filePath = writeDailyFile();
 
     const entry = makeEntry();
     appendEntry(config, entry, TEST_DATE);
@@ -304,8 +377,7 @@ describe("appendEntry — session-grouped AgentLog section", () => {
 
   // N3: file with timeblocks — entries go to ## AgentLog, NOT into timeblocks
   it("writes to ## AgentLog section even when timeblocks exist (no timeblock insertion)", () => {
-    const filePath = join(tmpDir, "Daily", "2026-03-01-일.md");
-    writeFileSync(filePath, FIXTURE_WITH_TIMEBLOCKS, "utf-8");
+    const filePath = writeDailyFile(FIXTURE_WITH_TIMEBLOCKS);
 
     const entry = makeEntry();
     const result = appendEntry(config, entry, TEST_DATE);
@@ -323,8 +395,7 @@ describe("appendEntry — session-grouped AgentLog section", () => {
 
   // N4: same project, same session → append to existing section
   it("appends to existing project section when project and session match", () => {
-    const filePath = join(tmpDir, "Daily", "2026-03-01-일.md");
-    writeFileSync(filePath, FIXTURE_NO_TIMEBLOCKS, "utf-8");
+    const filePath = writeDailyFile();
 
     const entry1 = makeEntry({ time: "10:53", prompt: "첫 번째 작업" });
     const entry2 = makeEntry({ time: "11:07", prompt: "두 번째 작업" });
@@ -343,7 +414,7 @@ describe("appendEntry — session-grouped AgentLog section", () => {
   });
 
   it("treats legacy short session divider as the same current session", () => {
-    const filePath = join(tmpDir, "Daily", "2026-03-01-일.md");
+    const filePath = dailyFilePath();
     writeFileSync(
       filePath,
       [
@@ -369,8 +440,7 @@ describe("appendEntry — session-grouped AgentLog section", () => {
 
   // N5: same project, different session → insert divider
   it("inserts session divider when session changes within same project", () => {
-    const filePath = join(tmpDir, "Daily", "2026-03-01-일.md");
-    writeFileSync(filePath, FIXTURE_NO_TIMEBLOCKS, "utf-8");
+    const filePath = writeDailyFile();
 
     const entry1 = makeEntry({ time: "10:53", sessionId: "session1-aaaa-bbbb-cccc-dddddddddddd" });
     const entry2 = makeEntry({ time: "15:00", sessionId: "session2-xxxx-yyyy-zzzz-111111111111" });
@@ -386,8 +456,7 @@ describe("appendEntry — session-grouped AgentLog section", () => {
 
   // N5b: codex source emits [[codex_...]] dividers
   it("emits codex-prefixed divider when source is codex", () => {
-    const filePath = join(tmpDir, "Daily", "2026-03-01-일.md");
-    writeFileSync(filePath, FIXTURE_NO_TIMEBLOCKS, "utf-8");
+    const filePath = writeDailyFile();
 
     const entry1 = makeEntry({ time: "10:53", source: "codex", sessionId: "codex111-aaaa-bbbb-cccc-dddddddddddd" });
     const entry2 = makeEntry({ time: "15:00", source: "codex", sessionId: "codex222-xxxx-yyyy-zzzz-111111111111" });
@@ -402,8 +471,7 @@ describe("appendEntry — session-grouped AgentLog section", () => {
 
   // N6: different projects → separate #### sections
   it("creates separate sections for different projects", () => {
-    const filePath = join(tmpDir, "Daily", "2026-03-01-일.md");
-    writeFileSync(filePath, FIXTURE_NO_TIMEBLOCKS, "utf-8");
+    const filePath = writeDailyFile();
 
     const entry1 = makeEntry({
       time: "10:53",
@@ -425,8 +493,7 @@ describe("appendEntry — session-grouped AgentLog section", () => {
 
   // N7: > 🕐 latest line always reflects the most recent entry
   it("updates > 🕐 latest line to the most recent entry on each write", () => {
-    const filePath = join(tmpDir, "Daily", "2026-03-01-일.md");
-    writeFileSync(filePath, FIXTURE_NO_TIMEBLOCKS, "utf-8");
+    const filePath = writeDailyFile();
 
     appendEntry(config, makeEntry({ time: "10:53", prompt: "첫 번째" }), TEST_DATE);
     appendEntry(config, makeEntry({ time: "11:07", prompt: "두 번째" }), TEST_DATE);
@@ -439,8 +506,7 @@ describe("appendEntry — session-grouped AgentLog section", () => {
 
   // N8: project header preserves original start time when session updates
   it("preserves original project start time in header when session changes", () => {
-    const filePath = join(tmpDir, "Daily", "2026-03-01-일.md");
-    writeFileSync(filePath, FIXTURE_NO_TIMEBLOCKS, "utf-8");
+    const filePath = writeDailyFile();
 
     appendEntry(config, makeEntry({ time: "10:53", sessionId: "session1-aaaa-bbbb-cccc-dddddddddddd" }), TEST_DATE);
     appendEntry(config, makeEntry({ time: "15:00", sessionId: "session2-xxxx-yyyy-zzzz-111111111111" }), TEST_DATE);
@@ -453,7 +519,7 @@ describe("appendEntry — session-grouped AgentLog section", () => {
 
   // N9: ## AgentLog already exists → append project section inside it
   it("appends to existing ## AgentLog section", () => {
-    const filePath = join(tmpDir, "Daily", "2026-03-01-일.md");
+    const filePath = dailyFilePath();
     writeFileSync(
       filePath,
       "# 2026-03-01\n\n## AgentLog\n> 🕐 09:00 — js/old › old entry\n\n#### 09:00 · js/old\n<!-- cwd=/old/path ses=abc00000 -->\n- 09:00 old entry\n",
@@ -472,7 +538,7 @@ describe("appendEntry — session-grouped AgentLog section", () => {
 
   // N10: empty file
   it("handles empty file without crashing", () => {
-    const filePath = join(tmpDir, "Daily", "2026-03-01-일.md");
+    const filePath = dailyFilePath();
     writeFileSync(filePath, "", "utf-8");
 
     const entry = makeEntry();
@@ -484,6 +550,7 @@ describe("appendEntry — session-grouped AgentLog section", () => {
 
   // N11: WriteResult fields
   it("returns section=agentlog and correct filePath", () => {
+    writeDailyFile();
     const entry = makeEntry();
     const result = appendEntry(config, entry, TEST_DATE);
     expect(result.section).toBe("agentlog");
@@ -492,10 +559,11 @@ describe("appendEntry — session-grouped AgentLog section", () => {
 
   // N12: section header contains cwd (no ses in metadata)
   it("embeds full cwd in section header comment (ses tracked via dividers)", () => {
+    writeDailyFile();
     const entry = makeEntry();
     appendEntry(config, entry, TEST_DATE);
 
-    const filePath = join(tmpDir, "Daily", "2026-03-01-일.md");
+    const filePath = dailyFilePath();
     const content = readFileSync(filePath, "utf-8");
     expect(content).toContain("<!-- cwd=/Users/pray/work/js/agentlog -->");
     expect(content).not.toContain("ses=");
@@ -503,6 +571,7 @@ describe("appendEntry — session-grouped AgentLog section", () => {
 
   // N13: cwd with spaces — section matching must not break
   it("handles cwd with spaces in path correctly", () => {
+    writeDailyFile();
     const entry = makeEntry({
       cwd: "/Users/John Doe/work/js/agentlog",
       project: "js/agentlog",
@@ -518,7 +587,7 @@ describe("appendEntry — session-grouped AgentLog section", () => {
     });
     appendEntry(config, entry2, TEST_DATE);
 
-    const filePath = join(tmpDir, "Daily", "2026-03-01-일.md");
+    const filePath = dailyFilePath();
     const content = readFileSync(filePath, "utf-8");
     // Should have only one #### section (not two)
     const sections = content.split("#### ");
@@ -530,8 +599,7 @@ describe("appendEntry — session-grouped AgentLog section", () => {
 
   // N14: 3 entries in same session — all appended in order within the section
   it("appends three entries in same session in insertion order", () => {
-    const filePath = join(tmpDir, "Daily", "2026-03-01-일.md");
-    writeFileSync(filePath, FIXTURE_NO_TIMEBLOCKS, "utf-8");
+    const filePath = writeDailyFile();
 
     appendEntry(config, makeEntry({ time: "10:00", prompt: "첫 번째" }), TEST_DATE);
     appendEntry(config, makeEntry({ time: "10:30", prompt: "두 번째" }), TEST_DATE);

--- a/src/__tests__/obsidian-cli.test.ts
+++ b/src/__tests__/obsidian-cli.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 
-import { isVersionAtLeast, MIN_CLI_VERSION, resolveCliBin, cliDailyPath } from "../obsidian-cli.js";
-import { writeFileSync, mkdirSync, chmodSync, rmSync } from "fs";
+import { isVersionAtLeast, MIN_CLI_VERSION, resolveCliBin, cliDailyPath, cliEnsureDailyNoteExists } from "../obsidian-cli.js";
+import { writeFileSync, readFileSync, mkdirSync, chmodSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 
@@ -151,5 +151,49 @@ describe("cliDailyPath", () => {
 
     process.env.OBSIDIAN_BIN = mockBin;
     expect(cliDailyPath()).toBeNull();
+  });
+});
+
+describe("cliEnsureDailyNoteExists", () => {
+  const originalBin = process.env.OBSIDIAN_BIN;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `agentlog-cli-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (originalBin === undefined) {
+      delete process.env.OBSIDIAN_BIN;
+    } else {
+      process.env.OBSIDIAN_BIN = originalBin;
+    }
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns true when obsidian daily exits 0", () => {
+    const mockBin = join(tmpDir, "mock-obsidian-daily");
+    const called = join(tmpDir, "called");
+    writeFileSync(mockBin, `#!/bin/bash\necho "$1" > ${JSON.stringify(called)}\nexit 0`, "utf-8");
+    chmodSync(mockBin, 0o755);
+
+    process.env.OBSIDIAN_BIN = mockBin;
+    expect(cliEnsureDailyNoteExists()).toBe(true);
+    expect(readFileSync(called, "utf-8")).toBe("daily\n");
+  });
+
+  it("returns false when obsidian daily exits non-zero", () => {
+    const mockBin = join(tmpDir, "mock-obsidian-daily-fail");
+    writeFileSync(mockBin, "#!/bin/bash\nexit 1", "utf-8");
+    chmodSync(mockBin, 0o755);
+
+    process.env.OBSIDIAN_BIN = mockBin;
+    expect(cliEnsureDailyNoteExists()).toBe(false);
+  });
+
+  it("returns false when CLI binary is not found", () => {
+    process.env.OBSIDIAN_BIN = "/nonexistent/obsidian";
+    expect(cliEnsureDailyNoteExists()).toBe(false);
   });
 });

--- a/src/__tests__/obsidian-cli.test.ts
+++ b/src/__tests__/obsidian-cli.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 
-import { isVersionAtLeast, MIN_CLI_VERSION, resolveCliBin, cliDailyPath, cliEnsureDailyNoteExists } from "../obsidian-cli.js";
+import {
+  CLI_PROBE_TIMEOUT_MS,
+  DAILY_BOOTSTRAP_TIMEOUT_MS,
+  isVersionAtLeast,
+  MIN_CLI_VERSION,
+  resolveCliBin,
+  cliDailyPath,
+  cliEnsureDailyNoteExists,
+} from "../obsidian-cli.js";
 import { writeFileSync, readFileSync, mkdirSync, chmodSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
@@ -48,6 +56,12 @@ describe("isVersionAtLeast", () => {
 describe("MIN_CLI_VERSION", () => {
   it("is set to 1.12.4", () => {
     expect(MIN_CLI_VERSION).toBe("1.12.4");
+  });
+});
+
+describe("Obsidian CLI timeouts", () => {
+  it("gives Daily bootstrap more time than lightweight probes", () => {
+    expect(DAILY_BOOTSTRAP_TIMEOUT_MS).toBeGreaterThan(CLI_PROBE_TIMEOUT_MS);
   });
 });
 

--- a/src/note-writer.ts
+++ b/src/note-writer.ts
@@ -10,7 +10,7 @@ import {
   buildProjectHeader,
   buildProjectMetadata,
 } from "./schema/daily-note.js";
-import { cliDailyPath } from "./obsidian-cli.js";
+import { cliDailyPath, cliEnsureDailyNoteExists } from "./obsidian-cli.js";
 
 type DailyNotesConfig = {
   folder?: string;
@@ -87,8 +87,8 @@ function pad2(n: number): string {
   return String(n).padStart(2, "0");
 }
 
-/** Returns daily note file path for a given date. */
-export function dailyNotePath(config: AgentLogConfig, date: Date): string {
+/** Returns daily note file path for a given date, or null when non-plain mode has no safe path source. */
+export function dailyNotePath(config: AgentLogConfig, date: Date): string | null {
   if (config.plain) {
     const yyyy = date.getFullYear();
     const mm = pad2(date.getMonth() + 1);
@@ -105,8 +105,7 @@ export function dailyNotePath(config: AgentLogConfig, date: Date): string {
   const cliPath = relativePath ? safeVaultJoin(config.vault, relativePath) : null;
   if (cliPath) return cliPath;
 
-  // Fallback: hardcoded {vault}/Daily/
-  return join(config.vault, "Daily", dailyNoteFileName(date));
+  return null;
 }
 
 /**
@@ -124,6 +123,9 @@ export function appendEntry(
   date: Date = new Date()
 ): WriteResult {
   const filePath = dailyNotePath(config, date);
+  if (!filePath) {
+    throw new Error("Daily Note path could not be resolved. Enable the Obsidian CLI or configure Daily Notes settings.");
+  }
 
   if (config.plain) {
     return appendPlain(filePath, entry, date);
@@ -131,10 +133,15 @@ export function appendEntry(
 
   const created = !existsSync(filePath);
   if (created) {
-    mkdirSync(dirname(filePath), { recursive: true });
+    if (!cliEnsureDailyNoteExists()) {
+      throw new Error("Daily Note is missing and Obsidian CLI could not create it.");
+    }
+    if (!existsSync(filePath)) {
+      throw new Error("Daily Note is missing after Obsidian CLI bootstrap.");
+    }
   }
 
-  const content = created ? "" : readFileSync(filePath, "utf-8");
+  const content = readFileSync(filePath, "utf-8");
   const newContent = insertIntoAgentLogSection(content, entry);
   writeFileSync(filePath, newContent, "utf-8");
   return { filePath, created, section: "agentlog" };

--- a/src/obsidian-cli.ts
+++ b/src/obsidian-cli.ts
@@ -12,6 +12,12 @@ const MACOS_CLI_PATHS = [
   "/Applications/Obsidian.app/Contents/MacOS/obsidian",
 ];
 
+/** Timeout for lightweight CLI probes such as `which`, `version`, and `daily:path`. */
+export const CLI_PROBE_TIMEOUT_MS = 3000;
+
+/** Missing-note bootstrap can start or wake Obsidian, so it gets a longer timeout. */
+export const DAILY_BOOTSTRAP_TIMEOUT_MS = 10000;
+
 type CliBinCacheState =
   | { status: "unresolved" }
   | { status: "resolved"; bin: string }
@@ -39,7 +45,7 @@ export function resolveCliBin(): string | null {
   if (_cachedBinState.status === "resolved") return _cachedBinState.bin;
   if (_cachedBinState.status === "not-found") return null;
 
-  const which = spawnSync("which", ["obsidian"], { encoding: "utf-8", timeout: 3000 });
+  const which = spawnSync("which", ["obsidian"], { encoding: "utf-8", timeout: CLI_PROBE_TIMEOUT_MS });
   if (which.status === 0 && which.stdout.trim()) {
     _cachedBinState = { status: "resolved", bin: which.stdout.trim() };
     return _cachedBinState.bin;
@@ -66,7 +72,7 @@ export function resolveCliBin(): string | null {
 export function cliDailyPath(): string | null {
   const bin = resolveCliBin();
   if (!bin) return null;
-  const result = spawnSync(bin, ["daily:path"], { encoding: "utf-8", timeout: 3000 });
+  const result = spawnSync(bin, ["daily:path"], { encoding: "utf-8", timeout: CLI_PROBE_TIMEOUT_MS });
   if (result.status !== 0) return null;
   // stdout may contain Electron noise lines (e.g. "Loading updated app package",
   // version warnings). The actual path is always the last non-empty line.
@@ -85,7 +91,7 @@ export function cliDailyPath(): string | null {
 export function cliEnsureDailyNoteExists(): boolean {
   const bin = resolveCliBin();
   if (!bin) return false;
-  const result = spawnSync(bin, ["daily"], { encoding: "utf-8", timeout: 3000 });
+  const result = spawnSync(bin, ["daily"], { encoding: "utf-8", timeout: DAILY_BOOTSTRAP_TIMEOUT_MS });
   return result.status === 0;
 }
 

--- a/src/obsidian-cli.ts
+++ b/src/obsidian-cli.ts
@@ -78,6 +78,17 @@ export function cliDailyPath(): string | null {
   return path || null;
 }
 
+/**
+ * Ask Obsidian to create/open today's Daily Note through its official flow.
+ * This lets Obsidian apply the user's Daily Notes template before AgentLog writes.
+ */
+export function cliEnsureDailyNoteExists(): boolean {
+  const bin = resolveCliBin();
+  if (!bin) return false;
+  const result = spawnSync(bin, ["daily"], { encoding: "utf-8", timeout: 3000 });
+  return result.status === 0;
+}
+
 /** Minimum Obsidian version that supports CLI */
 export const MIN_CLI_VERSION = "1.12.4";
 


### PR DESCRIPTION
## Summary
- resolve Obsidian Daily Note paths from vault settings, then `obsidian daily:path`, without guessed fallback creation
- bootstrap missing Obsidian-mode Daily Notes through `obsidian daily` before AgentLog writes so templates are preserved
- add regression tests, docs updates, and self-review memory/static gate for Daily bootstrap safety

## Verification
- `jq empty docs/review/review-list.json`
- `bun run self-review -- --mode working`
- `bun test`
- `bun run typecheck`
- `bun run build`
- `git diff --check`
- `bun run self-review -- --mode staged`

Closes #26