### PR TITLE
refactor: extract shared CLI support layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,8 @@ bun run build         # compile to dist/ (optional)
 
 The `bin` entry points directly to `src/cli.ts`, so you do not need a build during development. Bun runs TypeScript natively.
 
+CLI command boundaries are documented in [docs/architecture/cli-layering.md](docs/architecture/cli-layering.md).
+
 ```bash
 # Link as a global command
 bun link

--- a/docs/architecture/cli-layering.md
+++ b/docs/architecture/cli-layering.md
@@ -1,0 +1,33 @@
+# CLI Layering
+
+AgentLog CLI code should keep the Commander edge thin. Command registration in
+`src/cli.ts` owns argument parsing and delegation; reusable workflow support
+lives outside that entrypoint.
+
+## Layers
+
+| Layer | Responsibility | Current modules |
+|---|---|---|
+| Command edge | Commander setup, option parsing, subcommand delegation | `src/cli.ts` |
+| Application support | prompt asking, vault validation, config merge, binary lookup, shared CLI status output | `src/cli-shared.ts` |
+| Domain/core | config shape, error taxonomy, Daily Note merge rules, prompt formatting | `src/config.ts`, `src/errors.ts`, `src/note-writer.ts`, `src/schema/*` |
+| Infra/adapters | filesystem/process-backed integrations with Claude, Codex, Obsidian | `src/claude-settings.ts`, `src/codex-hooks.ts`, `src/codex-settings.ts`, `src/obsidian-cli.ts` |
+| Presentation | human-readable command output and future machine-readable command schemas | command handlers in `src/cli.ts`, `SCHEMA_DATA` |
+
+## Rules
+
+- New command handlers should not add reusable validation or integration helpers
+  directly to `src/cli.ts`.
+- Shared command support goes in `src/cli-shared.ts` until a narrower
+  application module is justified.
+- External side effects stay behind adapter modules; command handlers should
+  orchestrate them, not parse their internal file formats.
+- Formatting that becomes reused by more than one command should move out of
+  the command handler with tests.
+
+## Next Cuts
+
+- Move `doctor` check modeling and formatting into a dedicated application module.
+- Move `uninstall` orchestration into a dedicated application module.
+- Keep `SCHEMA_DATA` aligned with command registration, or generate it from a
+  single command description source.

--- a/docs/review/SELF_REVIEW.md
+++ b/docs/review/SELF_REVIEW.md
@@ -120,6 +120,23 @@ Good evidence:
 - `appendEntry()` aborts missing-note writes when path resolution or CLI bootstrap cannot be confirmed.
 - Regression tests for missing-note bootstrap, no guessed fallback, and bootstrap failure.
 
+### CLI Layering
+
+`src/cli.ts` should stay the command edge, not the home for reusable application support.
+
+Check:
+
+- Commander registration stays in `src/cli.ts`.
+- Shared support such as prompt asking, vault validation, config merge, binary lookup, and repeated status formatting stays outside `src/cli.ts`.
+- External integrations remain behind adapter modules such as `claude-settings`, `codex-hooks`, `codex-settings`, and `obsidian-cli`.
+- Architecture docs are updated when a new CLI layer or module boundary is introduced.
+
+Good evidence:
+
+- `src/cli-shared.ts` owns reusable CLI support helpers.
+- `docs/architecture/cli-layering.md` explains the current layer map and next safe cuts.
+- targeted CLI tests pass after moving code across module boundaries.
+
 ### Session Link Fidelity
 
 Session links written to Daily Notes should preserve the full session id unless reading legacy data.

--- a/docs/review/SELF_REVIEW.md
+++ b/docs/review/SELF_REVIEW.md
@@ -127,7 +127,7 @@ Good evidence:
 Check:
 
 - Commander registration stays in `src/cli.ts`.
-- Shared support such as prompt asking, vault validation, config merge, binary lookup, and repeated status formatting stays outside `src/cli.ts`.
+- Shared support such as prompt asking, vault validation, config merge, binary lookup, and repeated status formatting stays outside `src/cli.ts`, regardless of whether it would be written as `function`, `const`, or `export const`.
 - External integrations remain behind adapter modules such as `claude-settings`, `codex-hooks`, `codex-settings`, and `obsidian-cli`.
 - Architecture docs are updated when a new CLI layer or module boundary is introduced.
 

--- a/docs/review/review-list.json
+++ b/docs/review/review-list.json
@@ -163,7 +163,7 @@
         {
           "type": "noneContentRegex",
           "paths": ["src/cli.ts"],
-          "pattern": "function\\s+(?:validateVault|validateVaultOrExit|saveMergedConfig|printSavedConfig|printObsidianCliStatus|detectBinary)\\b",
+          "pattern": "(?:function\\s+|(?:export\\s+)?const\\s+)(?:validateVault|validateVaultOrExit|saveMergedConfig|printSavedConfig|printObsidianCliStatus|detectBinary)\\b",
           "message": "Keep reusable CLI support helpers out of `src/cli.ts`; put them in `src/cli-shared.ts` or a narrower application module."
         },
         {

--- a/docs/review/review-list.json
+++ b/docs/review/review-list.json
@@ -152,6 +152,29 @@
       ]
     },
     {
+      "id": "cli-command-edge-thin",
+      "severity": "medium",
+      "title": "CLI command edge should not re-accumulate shared helpers",
+      "appliesTo": {
+        "paths": ["src/cli.ts", "src/cli-shared.ts", "docs/architecture/**/*.md"],
+        "diffIncludesAny": ["validateVault", "detectBinary", "printObsidianCliStatus", "cli-shared", "Command edge"]
+      },
+      "checks": [
+        {
+          "type": "noneContentRegex",
+          "paths": ["src/cli.ts"],
+          "pattern": "function\\s+(?:validateVault|validateVaultOrExit|saveMergedConfig|printSavedConfig|printObsidianCliStatus|detectBinary)\\b",
+          "message": "Keep reusable CLI support helpers out of `src/cli.ts`; put them in `src/cli-shared.ts` or a narrower application module."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["docs/architecture/cli-layering.md"],
+          "pattern": "Command edge[\\s\\S]*src/cli\\.ts[\\s\\S]*Application support[\\s\\S]*src/cli-shared\\.ts",
+          "message": "Document the CLI layer boundary when introducing or changing the shared CLI support module."
+        }
+      ]
+    },
+    {
       "id": "docs-session-divider-length",
       "severity": "medium",
       "title": "Documented source-prefixed session dividers must use full session ids",

--- a/src/cli-shared.ts
+++ b/src/cli-shared.ts
@@ -1,0 +1,93 @@
+import { spawnSync } from "child_process";
+import { existsSync } from "fs";
+import { resolve, join } from "path";
+import * as readline from "readline";
+import { detectCli } from "./detect.js";
+import { configPath, expandHome, loadConfig, saveConfig } from "./config.js";
+import { Errors, formatError } from "./errors.js";
+import { MIN_CLI_VERSION } from "./obsidian-cli.js";
+import type { AgentLogConfig } from "./types.js";
+
+export function ask(prompt: string): Promise<string> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolveAnswer) => {
+    rl.question(prompt, (answer) => {
+      rl.close();
+      resolveAnswer(answer.trim());
+    });
+  });
+}
+
+export function validateVault(vaultArg: string, plain: boolean): { vault: string; error?: string } {
+  const vault = resolve(expandHome(vaultArg));
+
+  if (!existsSync(vault)) {
+    return { vault, error: formatError(Errors.VAULT_NOT_FOUND(vault)) };
+  }
+
+  if (!plain) {
+    const obsidianDir = join(vault, ".obsidian");
+    if (!existsSync(obsidianDir)) {
+      return { vault, error: formatError(Errors.VAULT_NOT_OBSIDIAN(vault)) };
+    }
+  }
+
+  return { vault };
+}
+
+export function validateVaultOrExit(vaultArg: string, plain: boolean): string {
+  const { vault, error } = validateVault(vaultArg, plain);
+  if (error) {
+    console.error(error);
+    process.exit(1);
+  }
+  return vault;
+}
+
+export function saveMergedConfig(
+  vault: string,
+  plain: boolean,
+  extra: Partial<AgentLogConfig> = {}
+): AgentLogConfig {
+  const existing = loadConfig() ?? { vault };
+  const next: AgentLogConfig = {
+    ...existing,
+    ...extra,
+    vault,
+  };
+
+  if (plain) {
+    next.plain = true;
+  } else {
+    delete next.plain;
+  }
+
+  saveConfig(next);
+  return next;
+}
+
+export function printSavedConfig(vault: string, plain: boolean): void {
+  console.log(`Config saved: ${configPath()}`);
+  console.log(`  vault: ${vault}${plain ? " (plain mode)" : ""}`);
+}
+
+export function printObsidianCliStatus(plain: boolean): void {
+  if (plain) return;
+
+  const cli = detectCli();
+  if (cli.installed) {
+    console.log(`  Obsidian CLI: detected (${cli.version ?? "unknown version"})`);
+    console.log(`  Daily notes will be written via CLI when Obsidian is running.`);
+  } else {
+    console.log(`  Obsidian CLI: not detected (using direct file write)`);
+    console.log(`  For better integration, enable CLI in Obsidian ${MIN_CLI_VERSION}+ Settings.`);
+  }
+}
+
+export function detectBinary(bin: "agentlog" | "codex"): string {
+  const result = spawnSync("/bin/sh", ["-lc", `command -v ${bin}`], {
+    encoding: "utf-8",
+  });
+  if (result.status !== 0) return "";
+  return (result.stdout ?? "").trim().split("\n").filter(Boolean).pop() ?? "";
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,7 +12,7 @@
  *   agentlog codex-notify             — legacy Codex notify handler
  */
 
-import { existsSync, readFileSync, rmSync } from "fs";
+import { existsSync, rmSync } from "fs";
 import { join, resolve } from "path";
 import { homedir } from "os";
 import { spawnSync } from "child_process";
@@ -21,7 +21,15 @@ import type { AgentLogConfig } from "./types.js";
 import { detectVaults, detectCli } from "./detect.js";
 import { isVersionAtLeast, MIN_CLI_VERSION, resolveCliBin, parseCliVersion } from "./obsidian-cli.js";
 import { registerHook, unregisterHook, isHookRegistered, CLAUDE_SETTINGS_PATH } from "./claude-settings.js";
-import { Errors, formatError } from "./errors.js";
+import {
+  ask,
+  detectBinary,
+  printObsidianCliStatus,
+  printSavedConfig,
+  saveMergedConfig,
+  validateVault,
+  validateVaultOrExit,
+} from "./cli-shared.js";
 import {
   CODEX_HOOKS_PATH,
   type CodexHookMutationResult,
@@ -35,92 +43,7 @@ import {
   unregisterCodexNotify,
 } from "./codex-settings.js";
 import { formatVersionHeadline, formatVersionOutput, getRuntimeInfo, readVersion, resolvePackageRoot } from "./version-info.js";
-import * as readline from "readline";
 import { Command } from "commander";
-
-function ask(prompt: string): Promise<string> {
-  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-  return new Promise((resolve) => {
-    rl.question(prompt, (answer) => {
-      rl.close();
-      resolve(answer.trim());
-    });
-  });
-}
-
-function validateVault(vaultArg: string, plain: boolean): { vault: string; error?: string } {
-  const vault = resolve(expandHome(vaultArg));
-
-  if (!existsSync(vault)) {
-    return { vault, error: formatError(Errors.VAULT_NOT_FOUND(vault)) };
-  }
-
-  if (!plain) {
-    const obsidianDir = join(vault, ".obsidian");
-    if (!existsSync(obsidianDir)) {
-      return { vault, error: formatError(Errors.VAULT_NOT_OBSIDIAN(vault)) };
-    }
-  }
-
-  return { vault };
-}
-
-function validateVaultOrExit(vaultArg: string, plain: boolean): string {
-  const { vault, error } = validateVault(vaultArg, plain);
-  if (error) {
-    console.error(error);
-    process.exit(1);
-  }
-  return vault;
-}
-
-function saveMergedConfig(
-  vault: string,
-  plain: boolean,
-  extra: Partial<AgentLogConfig> = {}
-): AgentLogConfig {
-  const existing = loadConfig() ?? { vault };
-  const next: AgentLogConfig = {
-    ...existing,
-    ...extra,
-    vault,
-  };
-
-  if (plain) {
-    next.plain = true;
-  } else {
-    delete next.plain;
-  }
-
-  saveConfig(next);
-  return next;
-}
-
-function printSavedConfig(vault: string, plain: boolean): void {
-  console.log(`Config saved: ${configPath()}`);
-  console.log(`  vault: ${vault}${plain ? " (plain mode)" : ""}`);
-}
-
-function printObsidianCliStatus(plain: boolean): void {
-  if (plain) return;
-
-  const cli = detectCli();
-  if (cli.installed) {
-    console.log(`  Obsidian CLI: detected (${cli.version ?? "unknown version"})`);
-    console.log(`  Daily notes will be written via CLI when Obsidian is running.`);
-  } else {
-    console.log(`  Obsidian CLI: not detected (using direct file write)`);
-    console.log(`  For better integration, enable CLI in Obsidian ${MIN_CLI_VERSION}+ Settings.`);
-  }
-}
-
-function detectBinary(bin: "agentlog" | "codex"): string {
-  const result = spawnSync("/bin/sh", ["-lc", `command -v ${bin}`], {
-    encoding: "utf-8",
-  });
-  if (result.status !== 0) return "";
-  return (result.stdout ?? "").trim().split("\n").filter(Boolean).pop() ?? "";
-}
 
 type InitTarget = "claude" | "codex" | "all";
 type UninstallTarget = "claude" | "codex" | "all";


### PR DESCRIPTION
## Summary
- extract reusable CLI support helpers from `src/cli.ts` into `src/cli-shared.ts`
- document the current CLI layering boundary and next safe cuts
- add self-review memory/static gate so reusable helpers do not re-accumulate in the command edge

## Verification
- `jq empty docs/review/review-list.json`
- `bun run self-review -- --mode working`
- `bun test`
- `bun run typecheck`
- `bun run build`
- `git diff --check`
- `bun run self-review -- --mode staged`

Closes #23