### PR TITLE
fix: validate Claude hook matcher format

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ Checks performed (in order):
 | `cli-ver` | CLI version meets minimum | warn |
 | `cli-app` | Obsidian app responds to CLI | warn |
 | `daily` | Today's Daily Note exists | warn |
-| `hook` | Hook registered in `~/.claude/settings.json` | error (warn if Codex-only) |
+| `hook` | Hook registered in `~/.claude/settings.json` and using a Claude-compatible string matcher | error (warn if Codex-only and missing) |
 | `codex-bin` | `codex` binary in PATH (if Codex configured) | error |
 | `codex` | Codex hook registered in `~/.codex/hooks.json` (if configured) | error |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,6 +216,7 @@ Legacy handler for older Codex `notify` installs on `agent-turn-complete`. Do no
 |-------|----------|-------------|
 | `vault` | yes | Absolute path to the Obsidian vault or plain output folder |
 | `plain` | no | If true, writes simple `YYYY-MM-DD.md` files without Obsidian section structure |
+| `claudeHookInstalled` | no | Marks that AgentLog expects the Claude hook to be installed for doctor/repair checks |
 | `codexHookInstalled` | no | Marks that AgentLog expects the Codex hook to be installed for doctor/repair checks |
 | `codexNotifyRestore` | no | Legacy metadata for older Codex `notify` installs |
 | `englishAsk` | no | Optional Codex prompt evaluator config. Disabled unless `englishAsk.enabled` is true |

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ agentlog init --plain ~/notes
 
 `agentlog init` does two things:
 1. Creates `~/.agentlog/config.json` with your vault path
-2. Registers a hook in `~/.claude/settings.json`
+2. Registers or repairs a Claude Code hook in `~/.claude/settings.json` using the string matcher format (`"matcher": ""`)
 
 Run `agentlog init` without arguments to auto-detect installed vaults.
 
@@ -169,7 +169,7 @@ Current CLI:
 | `agentlog init [vault] [--plain] [--claude\|--codex\|--all]` | Configure vault and install integrations. `--claude` (default): Claude hook, `--codex`: Codex hook, `--all`: both |
 | `agentlog detect` | List detected Obsidian vaults and CLI status |
 | `agentlog codex-debug <prompt>` | Run `codex exec "<prompt>"` with Codex hook auto-registered |
-| `agentlog doctor` | Run health checks for the binary, vault, hook, and Obsidian CLI. Also checks Codex hook status if configured |
+| `agentlog doctor` | Run health checks for the binary, vault, Claude hook registration/format, and Obsidian CLI. Also checks Codex hook status if configured |
 | `agentlog open` | Open today's Daily Note in Obsidian (requires CLI 1.12.4+) |
 | `agentlog version` | Print AgentLog version. In `dev` builds, also shows channel and commit |
 | `agentlog uninstall [-y] [--codex\|--all]` | `default`: Remove Claude hook + config, `--codex`: Remove Codex hook and unregister/restore legacy `~/.codex/config.toml` notify if AgentLog set it up, `--all`: Remove both |

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Current CLI:
 |-------|---------|-------------|
 | `vault` | (required) | Path to the Obsidian vault or plain output folder |
 | `plain` | `false` | Plain mode that writes simple markdown files without Obsidian integration |
+| `claudeHookInstalled` | `false` | Records that AgentLog expects the Claude hook to be installed, so `doctor` does not downgrade a missing Claude hook in `--all` installs |
 | `codexHookInstalled` | `false` | Records that AgentLog expects the Codex hook to be installed, so `doctor` can detect partial damage |
 | `codexNotifyRestore` | unset | Legacy metadata for older Codex `notify` installs |
 | `englishAsk` | unset | Optional Codex prompt evaluator config. Disabled unless `englishAsk.enabled` is `true` |

--- a/docs/cc/hook-integration.md
+++ b/docs/cc/hook-integration.md
@@ -71,7 +71,11 @@ After running `npx agentlog init <vault>`, the hook is registered in
 }
 ```
 
-The `matcher` is empty string to match all prompts regardless of content.
+The `matcher` is an empty string to match all prompts regardless of content.
+Claude Code validates this field as a string; stale object matcher entries are
+not compatible with current Claude Code settings validation. Re-running
+`agentlog init` replaces AgentLog-owned stale hook entries with the canonical
+`"matcher": ""` entry, and `agentlog doctor` reports unsupported hook shapes.
 
 ---
 

--- a/docs/review/SELF_REVIEW.md
+++ b/docs/review/SELF_REVIEW.md
@@ -89,6 +89,25 @@ Good evidence:
 - tests for legacy notify removal when no restore command exists
 - docs that mention legacy `notify` cleanup for Codex uninstall
 
+### Claude Hook Matcher Compatibility
+
+Claude Code validates hook entries in `~/.claude/settings.json`. The `matcher` field must stay a string; stale object matchers can make the whole settings file invalid.
+
+Check:
+
+- AgentLog's `HOOK_ENTRY` uses `matcher: ""`, not an object matcher.
+- `agentlog init` removes AgentLog-owned stale hook entries before writing the canonical hook.
+- `agentlog doctor` and `agentlog validate` fail when the registered AgentLog hook has an unsupported matcher shape.
+- The migration preserves unrelated hook entries.
+- Docs that show the Claude hook settings example use the string matcher format.
+
+Good evidence:
+
+- a validator such as `inspectClaudeHookState()` reports unsupported Claude settings shapes
+- tests for stale AgentLog object matcher migration
+- tests for doctor failure when `matcher` is an object
+- hook integration docs showing `"matcher": ""`
+
 ### Docs Sync
 
 When runtime fallback order or behavior changes, developer docs must say the same thing.

--- a/docs/review/SELF_REVIEW.md
+++ b/docs/review/SELF_REVIEW.md
@@ -98,14 +98,17 @@ Check:
 - AgentLog's `HOOK_ENTRY` uses `matcher: ""`, not an object matcher.
 - `agentlog init` removes AgentLog-owned stale hook entries before writing the canonical hook.
 - `agentlog doctor` and `agentlog validate` fail when the registered AgentLog hook has an unsupported matcher shape.
+- `agentlog doctor` downgrades a missing Claude hook to warn-only only for Codex-only installs; `--all` installs must still fail if the Claude hook is missing.
 - The migration preserves unrelated hook entries.
 - Docs that show the Claude hook settings example use the string matcher format.
 
 Good evidence:
 
 - a validator such as `inspectClaudeHookState()` reports unsupported Claude settings shapes
+- config metadata such as `claudeHookInstalled` distinguishes Codex-only installs from both-hook installs
 - tests for stale AgentLog object matcher migration
 - tests for doctor failure when `matcher` is an object
+- tests for doctor failure when both hooks are expected but the Claude hook is missing
 - hook integration docs showing `"matcher": ""`
 
 ### Docs Sync

--- a/docs/review/review-list.json
+++ b/docs/review/review-list.json
@@ -307,6 +307,47 @@
       ]
     },
     {
+      "id": "claude-hook-matcher-string",
+      "severity": "high",
+      "title": "Claude hook matcher must use the string format",
+      "appliesTo": {
+        "paths": ["src/claude-settings.ts", "src/cli.ts", "src/__tests__/cli.test.ts", "README.md", "AGENTS.md", "docs/cc/**/*.md", "docs/review/SELF_REVIEW.md"],
+        "diffIncludesAny": ["HOOK_ENTRY", "matcher", "Claude Code", "UserPromptSubmit", "agentlog hook"]
+      },
+      "checks": [
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/claude-settings.ts"],
+          "pattern": "HOOK_ENTRY[\\s\\S]*matcher:\\s*\"\"",
+          "message": "Keep AgentLog's Claude hook on the documented string matcher format."
+        },
+        {
+          "type": "noneContentRegex",
+          "paths": ["src/claude-settings.ts"],
+          "pattern": "matcher:\\s*\\{",
+          "message": "Do not register object matchers in Claude Code settings."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/claude-settings.ts"],
+          "pattern": "validateClaudeHookSettings[\\s\\S]*matcher[\\s\\S]*string[\\s\\S]*inspectClaudeHookState[\\s\\S]*validateClaudeHookSettings",
+          "message": "Doctor/validate must inspect matcher type compatibility, not just command presence."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/__tests__/cli.test.ts"],
+          "pattern": "stale AgentLog hook matcher object[\\s\\S]*matcher must be a string",
+          "message": "Add regression coverage for stale object matcher migration and doctor failure."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["docs/cc/hook-integration.md"],
+          "pattern": "\"matcher\":\\s*\"\"",
+          "message": "Document the Claude hook settings example with an empty string matcher."
+        }
+      ]
+    },
+    {
       "id": "englishask-recursion-guard",
       "severity": "high",
       "title": "EnglishAsk evaluator must not recursively evaluate itself",

--- a/docs/review/review-list.json
+++ b/docs/review/review-list.json
@@ -311,7 +311,7 @@
       "severity": "high",
       "title": "Claude hook matcher must use the string format",
       "appliesTo": {
-        "paths": ["src/claude-settings.ts", "src/cli.ts", "src/__tests__/cli.test.ts", "README.md", "AGENTS.md", "docs/cc/**/*.md", "docs/review/SELF_REVIEW.md"],
+        "paths": ["src/claude-settings.ts", "src/cli.ts", "src/types.ts", "src/__tests__/cli.test.ts", "src/__tests__/cli-codex.test.ts", "README.md", "AGENTS.md", "docs/cc/**/*.md", "docs/review/SELF_REVIEW.md"],
         "diffIncludesAny": ["HOOK_ENTRY", "matcher", "Claude Code", "UserPromptSubmit", "agentlog hook"]
       },
       "checks": [
@@ -338,6 +338,18 @@
           "paths": ["src/__tests__/cli.test.ts"],
           "pattern": "stale AgentLog hook matcher object[\\s\\S]*matcher must be a string",
           "message": "Add regression coverage for stale object matcher migration and doctor failure."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/cli.ts"],
+          "pattern": "hasClaudeHookMetadata[\\s\\S]*hookState\\.kind === \"missing\"[\\s\\S]*!hasClaudeHookMetadata",
+          "message": "Do not use generic Codex relevance to downgrade missing Claude hook failures; require explicit Codex-only metadata."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/__tests__/cli-codex.test.ts"],
+          "pattern": "expects both hooks but the Claude hook is missing",
+          "message": "Add a regression test for `--all`/both-hook installs where the Claude hook is missing."
         },
         {
           "type": "anyContentRegex",

--- a/llms.txt
+++ b/llms.txt
@@ -23,7 +23,7 @@ agentlog init --all ~/path/to/vault    # Both
 agentlog init --plain ~/notes          # Plain folder (no Obsidian)
 ```
 
-`init` writes `~/.agentlog/config.json` and registers the hook in `~/.claude/settings.json` (Claude) or `~/.codex/config.toml` (Codex). The `agentlog` binary must remain in PATH after setup.
+`init` writes `~/.agentlog/config.json` and registers the hook in `~/.claude/settings.json` (Claude) or `~/.codex/hooks.json` (Codex). The `agentlog` binary must remain in PATH after setup.
 
 Run without arguments for interactive vault auto-detection.
 
@@ -71,6 +71,8 @@ agentlog codex-notify (internal — called by Codex, not by users)
 {
   "vault": "/Users/you/Obsidian",
   "plain": false,
+  "claudeHookInstalled": true,
+  "codexHookInstalled": true,
   "codexNotifyRestore": null
 }
 ```
@@ -78,6 +80,8 @@ agentlog codex-notify (internal — called by Codex, not by users)
 Fields:
 - `vault` (required): absolute path to Obsidian vault or plain folder
 - `plain` (optional): if true, writes simple YYYY-MM-DD.md files
+- `claudeHookInstalled` (optional): marks that AgentLog expects the Claude hook to be installed
+- `codexHookInstalled` (optional): marks that AgentLog expects the Codex hook to be installed
 - `codexNotifyRestore` (optional): saved previous Codex notify value, restored on uninstall
 - `englishAsk` (optional): Codex prompt evaluator config. Disabled unless `englishAsk.enabled` is true. Results append under `## EnglishAsk`.
 

--- a/src/__tests__/cli-codex.test.ts
+++ b/src/__tests__/cli-codex.test.ts
@@ -147,6 +147,9 @@ describe("cli codex commands", () => {
     });
     expect(readFileSync(join(tmpHome, ".codex", "config.toml"), "utf-8")).not.toContain("agentlog\", \"codex-notify");
     expect(existsSync(join(tmpHome, ".claude", "settings.json"))).toBe(false);
+    const config = JSON.parse(readFileSync(join(cfgDir, "config.json"), "utf-8"));
+    expect(config.codexHookInstalled).toBe(true);
+    expect(config.claudeHookInstalled).toBeUndefined();
   });
 
   it("init --codex preserves existing Codex hooks and records hook metadata", async () => {
@@ -178,6 +181,7 @@ describe("cli codex commands", () => {
     expect(hooks.hooks.UserPromptSubmit).toHaveLength(2);
     const config = JSON.parse(readFileSync(join(cfgDir, "config.json"), "utf-8"));
     expect(config.codexHookInstalled).toBe(true);
+    expect(config.claudeHookInstalled).toBeUndefined();
   });
 
   it("init --codex aborts on unsupported hooks.json", async () => {
@@ -226,6 +230,8 @@ describe("cli codex commands", () => {
     expect(stdout).toContain("Hook registered");
     expect(existsSync(join(tmpHome, ".claude", "settings.json"))).toBe(true);
     expect(existsSync(join(tmpHome, ".codex", "hooks.json"))).toBe(false);
+    const config = JSON.parse(readFileSync(join(tmpHome, ".agentlog", "config.json"), "utf-8"));
+    expect(config.claudeHookInstalled).toBe(true);
   });
 
   it("legacy codex-init command is rejected", async () => {
@@ -263,6 +269,9 @@ describe("cli codex commands", () => {
         ],
       },
     });
+    const config = JSON.parse(readFileSync(join(cfgDir, "config.json"), "utf-8"));
+    expect(config.codexHookInstalled).toBe(true);
+    expect(config.claudeHookInstalled).toBe(true);
   });
 
   it("codex-notify writes a Daily Note entry and forwards the saved notify command", async () => {
@@ -751,6 +760,35 @@ describe("cli codex commands", () => {
     expect(exitCode).toBe(0);
     expect(stdout).toContain("codex");
     expect(stdout).toContain("hook registered");
+  });
+
+  it("doctor fails when config expects both hooks but the Claude hook is missing", async () => {
+    const vault = join(tmpHome, "notes");
+    const cfgDir = join(tmpHome, ".agentlog");
+    const pathWithCodex = makeFakeCodexPath(tmpHome);
+    mkdirSync(vault, { recursive: true });
+    mkdirSync(cfgDir, { recursive: true });
+    writeAgentlogCodexHook(tmpHome);
+    writeFileSync(
+      join(cfgDir, "config.json"),
+      JSON.stringify({
+        vault,
+        plain: true,
+        codexHookInstalled: true,
+        claudeHookInstalled: true,
+      }),
+      "utf-8"
+    );
+
+    const { stdout, exitCode } = await runCli(["doctor"], {
+      HOME: tmpHome,
+      AGENTLOG_CONFIG_DIR: cfgDir,
+      PATH: pathWithCodex,
+    });
+
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toContain("❌ hook");
+    expect(stdout).toContain("not registered");
   });
 
   it("doctor fails for partial damage when AgentLog config expects Codex hook but it is missing", async () => {

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -136,7 +136,8 @@ describe("cli init command", () => {
     expect(Array.isArray(settings.hooks.UserPromptSubmit)).toBe(true);
 
     const hasHook = settings.hooks.UserPromptSubmit.some(
-      (entry: { hooks?: Array<{ command?: string }> }) =>
+      (entry: { matcher?: unknown; hooks?: Array<{ command?: string }> }) =>
+        entry.matcher === "" &&
         Array.isArray(entry.hooks) &&
         entry.hooks.some((h) => h.command === "agentlog hook")
     );
@@ -164,6 +165,45 @@ describe("cli init command", () => {
     expect(settings.theme).toBe("dark");
     expect(settings.model).toBe("sonnet");
     expect(settings.hooks).toBeDefined();
+  });
+
+  it("migrates a stale AgentLog hook matcher object to the Claude string matcher format", async () => {
+    const vault = join(tmpHome, "Obsidian");
+    mkdirSync(join(vault, ".obsidian"), { recursive: true });
+    mkdirSync(join(tmpHome, ".claude"), { recursive: true });
+    writeFileSync(
+      join(tmpHome, ".claude", "settings.json"),
+      JSON.stringify({
+        hooks: {
+          UserPromptSubmit: [
+            {
+              matcher: { tools: ["UserPromptSubmit"] },
+              hooks: [{ type: "command", command: "agentlog hook" }],
+            },
+            {
+              matcher: "keep",
+              hooks: [{ type: "command", command: "echo keep" }],
+            },
+          ],
+        },
+      }),
+      "utf-8"
+    );
+
+    const { exitCode } = await runCli(["init", vault], { HOME: tmpHome });
+
+    expect(exitCode).toBe(0);
+    const settings = JSON.parse(readFileSync(join(tmpHome, ".claude", "settings.json"), "utf-8"));
+    expect(settings.hooks.UserPromptSubmit).toEqual([
+      {
+        matcher: "keep",
+        hooks: [{ type: "command", command: "echo keep" }],
+      },
+      {
+        matcher: "",
+        hooks: [{ type: "command", command: "agentlog hook" }],
+      },
+    ]);
   });
 
   // CL8: init expands ~/
@@ -295,6 +335,39 @@ describe("cli doctor command", () => {
     expect(stdout).toContain("plain mode");
     // obsidian line should not appear when plain mode
     expect(stdout).not.toContain("obsidian");
+  });
+
+  it("exits 1 when the registered AgentLog hook uses a stale object matcher", async () => {
+    const notes = join(tmpHome, "notes");
+    mkdirSync(notes, { recursive: true });
+    mkdirSync(join(tmpHome, ".agentlog"), { recursive: true });
+    writeFileSync(
+      join(tmpHome, ".agentlog", "config.json"),
+      JSON.stringify({ vault: notes, plain: true }),
+      "utf-8"
+    );
+    mkdirSync(join(tmpHome, ".claude"), { recursive: true });
+    writeFileSync(
+      join(tmpHome, ".claude", "settings.json"),
+      JSON.stringify({
+        hooks: {
+          UserPromptSubmit: [
+            {
+              matcher: { tools: ["UserPromptSubmit"] },
+              hooks: [{ type: "command", command: "agentlog hook" }],
+            },
+          ],
+        },
+      }),
+      "utf-8"
+    );
+
+    const { stdout, exitCode } = await runCli(["doctor"], { HOME: tmpHome });
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("hook");
+    expect(stdout).toContain("matcher must be a string");
+    expect(stdout).toContain("agentlog init");
   });
 });
 
@@ -544,6 +617,38 @@ describe("cli validate", () => {
 
     expect(exitCode).toBe(1);
     expect(stdout).toContain("hook: fail");
+  });
+
+  it("exits 1 with hook: fail when the registered hook matcher is unsupported", async () => {
+    const vault = join(tmpHome, "Obsidian");
+    mkdirSync(join(vault, ".obsidian"), { recursive: true });
+    mkdirSync(join(tmpHome, ".agentlog"), { recursive: true });
+    writeFileSync(
+      join(tmpHome, ".agentlog", "config.json"),
+      JSON.stringify({ vault }),
+      "utf-8"
+    );
+    mkdirSync(join(tmpHome, ".claude"), { recursive: true });
+    writeFileSync(
+      join(tmpHome, ".claude", "settings.json"),
+      JSON.stringify({
+        hooks: {
+          UserPromptSubmit: [
+            {
+              matcher: { tools: ["UserPromptSubmit"] },
+              hooks: [{ type: "command", command: "agentlog hook" }],
+            },
+          ],
+        },
+      }),
+      "utf-8"
+    );
+
+    const { stdout, exitCode } = await runCli(["validate"], { HOME: tmpHome });
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("hook: fail");
+    expect(stdout).toContain("matcher must be a string");
   });
 });
 

--- a/src/claude-settings.ts
+++ b/src/claude-settings.ts
@@ -20,16 +20,23 @@ export const HOOK_ENTRY = {
   ],
 };
 
+export type ClaudeHookState =
+  | { kind: "registered" }
+  | { kind: "missing" }
+  | { kind: "unsupported"; reason: string };
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 /** Returns true if the given hook entry contains an "agentlog hook" command. */
 function isAgentlogHookEntry(entry: unknown): boolean {
   return (
-    typeof entry === "object" &&
-    entry !== null &&
+    isPlainObject(entry) &&
     Array.isArray((entry as Record<string, unknown>)["hooks"]) &&
     ((entry as Record<string, unknown>)["hooks"] as unknown[]).some(
       (h) =>
-        typeof h === "object" &&
-        h !== null &&
+        isPlainObject(h) &&
         (h as Record<string, unknown>)["command"] === "agentlog hook"
     )
   );
@@ -38,14 +45,54 @@ function isAgentlogHookEntry(entry: unknown): boolean {
 function readClaudeSettings(): Record<string, unknown> | null {
   if (!existsSync(CLAUDE_SETTINGS_PATH)) return null;
   try {
-    return JSON.parse(readFileSync(CLAUDE_SETTINGS_PATH, "utf-8"));
+    const parsed = JSON.parse(readFileSync(CLAUDE_SETTINGS_PATH, "utf-8"));
+    return isPlainObject(parsed) ? parsed : null;
   } catch {
     return null;
   }
 }
 
+function readClaudeSettingsState():
+  | { kind: "missing" }
+  | { kind: "ok"; settings: Record<string, unknown> }
+  | { kind: "unsupported"; reason: string } {
+  if (!existsSync(CLAUDE_SETTINGS_PATH)) return { kind: "missing" };
+  try {
+    const parsed = JSON.parse(readFileSync(CLAUDE_SETTINGS_PATH, "utf-8"));
+    if (!isPlainObject(parsed)) {
+      return { kind: "unsupported", reason: "settings.json must be an object" };
+    }
+    return { kind: "ok", settings: parsed };
+  } catch {
+    return { kind: "unsupported", reason: "settings.json is invalid JSON" };
+  }
+}
+
 function writeClaudeSettings(settings: Record<string, unknown>): void {
   writeFileSync(CLAUDE_SETTINGS_PATH, JSON.stringify(settings, null, 2), "utf-8");
+}
+
+export function validateClaudeHookSettings(settings: Record<string, unknown>): string | null {
+  const hooks = settings["hooks"];
+  if (hooks === undefined) return null;
+  if (!isPlainObject(hooks)) return "hooks must be an object";
+
+  for (const [eventName, entries] of Object.entries(hooks)) {
+    if (!Array.isArray(entries)) return `hooks.${eventName} must be an array`;
+
+    for (let index = 0; index < entries.length; index++) {
+      const entry = entries[index];
+      if (!isPlainObject(entry)) return `hooks.${eventName}.${index} must be an object`;
+      if ("matcher" in entry && typeof entry["matcher"] !== "string") {
+        return `hooks.${eventName}.${index}.matcher must be a string`;
+      }
+      if (!Array.isArray(entry["hooks"])) {
+        return `hooks.${eventName}.${index}.hooks must be an array`;
+      }
+    }
+  }
+
+  return null;
 }
 
 export function unregisterHook(): boolean {
@@ -96,21 +143,32 @@ export function registerHook(): void {
   }
   const upsArr = hooks["UserPromptSubmit"] as unknown[];
 
-  // Idempotent: only add if not already registered
-  if (!upsArr.some(isAgentlogHookEntry)) {
-    upsArr.push(HOOK_ENTRY);
-  }
+  // Replace any AgentLog-owned stale hook entry with the canonical matcher string format.
+  hooks["UserPromptSubmit"] = [
+    ...upsArr.filter((entry) => !isAgentlogHookEntry(entry)),
+    HOOK_ENTRY,
+  ];
 
   writeClaudeSettings(settings);
 }
 
+export function inspectClaudeHookState(): ClaudeHookState {
+  const state = readClaudeSettingsState();
+  if (state.kind === "missing") return { kind: "missing" };
+  if (state.kind === "unsupported") return { kind: "unsupported", reason: state.reason };
+
+  const validationError = validateClaudeHookSettings(state.settings);
+  if (validationError) return { kind: "unsupported", reason: validationError };
+
+  const hooks = state.settings["hooks"] as Record<string, unknown> | undefined;
+  if (!hooks || !Array.isArray(hooks["UserPromptSubmit"])) return { kind: "missing" };
+
+  return (hooks["UserPromptSubmit"] as unknown[]).some(isAgentlogHookEntry)
+    ? { kind: "registered" }
+    : { kind: "missing" };
+}
+
 /** Returns true if the agentlog hook is registered in ~/.claude/settings.json */
 export function isHookRegistered(): boolean {
-  const settings = readClaudeSettings();
-  if (!settings) return false;
-
-  const hooks = settings["hooks"] as Record<string, unknown> | undefined;
-  if (!hooks || !Array.isArray(hooks["UserPromptSubmit"])) return false;
-
-  return (hooks["UserPromptSubmit"] as unknown[]).some(isAgentlogHookEntry);
+  return inspectClaudeHookState().kind === "registered";
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -51,7 +51,7 @@ type UninstallTarget = "claude" | "codex" | "all";
 async function runInit(vaultArg: string, plain: boolean): Promise<void> {
   const vault = validateVaultOrExit(vaultArg, plain);
 
-  saveMergedConfig(vault, plain);
+  saveMergedConfig(vault, plain, { claudeHookInstalled: true });
   printSavedConfig(vault, plain);
   printObsidianCliStatus(plain);
 
@@ -105,7 +105,7 @@ async function runAllInit(vaultArg: string, plain: boolean): Promise<void> {
     process.exit(1);
   }
 
-  saveMergedConfig(vault, plain, { codexHookInstalled: true });
+  saveMergedConfig(vault, plain, { codexHookInstalled: true, claudeHookInstalled: true });
   printSavedConfig(vault, plain);
   printObsidianCliStatus(plain);
 
@@ -468,6 +468,7 @@ async function cmdDoctor(): Promise<void> {
   }
 
   const hasCodexHookMetadata = config?.codexHookInstalled === true;
+  const hasClaudeHookMetadata = config?.claudeHookInstalled === true;
   const hasRestoreMetadata = !!config && Object.prototype.hasOwnProperty.call(config, "codexNotifyRestore");
   const codexHookState = readCodexHookState();
   const legacyNotifyState = readCodexNotifyState();
@@ -492,7 +493,7 @@ async function cmdDoctor(): Promise<void> {
     hookState.kind === "unsupported"
       ? "run: agentlog init to migrate AgentLog hook, or fix Claude settings"
       : "run: agentlog init to re-register",
-    codexRelevant && hookState.kind === "missing"
+    codexRelevant && hookState.kind === "missing" && !hasClaudeHookMetadata
   );
 
   // 7. Codex hook checks (only when configured or explicitly requested)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,7 +20,7 @@ import { saveConfig, loadConfig, expandHome, configPath, configDir } from "./con
 import type { AgentLogConfig } from "./types.js";
 import { detectVaults, detectCli } from "./detect.js";
 import { isVersionAtLeast, MIN_CLI_VERSION, resolveCliBin, parseCliVersion } from "./obsidian-cli.js";
-import { registerHook, unregisterHook, isHookRegistered, CLAUDE_SETTINGS_PATH } from "./claude-settings.js";
+import { registerHook, unregisterHook, inspectClaudeHookState, CLAUDE_SETTINGS_PATH } from "./claude-settings.js";
 import {
   ask,
   detectBinary,
@@ -477,14 +477,22 @@ async function cmdDoctor(): Promise<void> {
     codexHookState.kind !== "missing" ||
     legacyNotifyState.kind !== "missing";
 
-  // 6. Hook registered
-  const hookOk = isHookRegistered();
+  // 6. Claude hook registered and compatible with Claude Code matcher validation.
+  const hookState = inspectClaudeHookState();
+  const hookOk = hookState.kind === "registered";
+  const hookDetail = hookState.kind === "registered"
+    ? CLAUDE_SETTINGS_PATH
+    : hookState.kind === "unsupported"
+      ? `${CLAUDE_SETTINGS_PATH} — ${hookState.reason}`
+      : "not registered";
   check(
     "hook",
     hookOk,
-    hookOk ? CLAUDE_SETTINGS_PATH : "not registered",
-    "run: agentlog init  to re-register",
-    codexRelevant
+    hookDetail,
+    hookState.kind === "unsupported"
+      ? "run: agentlog init to migrate AgentLog hook, or fix Claude settings"
+      : "run: agentlog init to re-register",
+    codexRelevant && hookState.kind === "missing"
   );
 
   // 7. Codex hook checks (only when configured or explicitly requested)
@@ -671,11 +679,12 @@ async function cmdValidate(): Promise<void> {
   }
 
   // 2. Hook check
-  const hookOk = isHookRegistered();
-  if (hookOk) {
+  const hookState = inspectClaudeHookState();
+  if (hookState.kind === "registered") {
     console.log(`hook: ok — ${CLAUDE_SETTINGS_PATH}`);
   } else {
-    console.log("hook: fail — not registered");
+    const detail = hookState.kind === "unsupported" ? hookState.reason : "not registered";
+    console.log(`hook: fail — ${detail}`);
     allOk = false;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@
 export interface AgentLogConfig {
   vault: string;
   plain?: boolean;
+  claudeHookInstalled?: boolean;
   codexHookInstalled?: boolean;
   /** Legacy metadata for pre-hook Codex notify installs. */
   codexNotifyRestore?: string[] | null;


### PR DESCRIPTION
## Summary
- keep AgentLog Claude hook registration on the Claude Code string matcher format (`matcher: ""`)
- migrate AgentLog-owned stale hook entries during `agentlog init`
- make `agentlog doctor` and `agentlog validate` report unsupported Claude hook matcher shapes
- add review memory/static gate coverage for future hook matcher regressions

## Validation
- `jq empty docs/review/review-list.json`
- `bun test src/__tests__/cli.test.ts`
- `bun run self-review -- --mode working`
- `bun test`
- `bun run typecheck`
- `bun run build`
- `git diff --check`

Closes #15