### PR TITLE
fix: CLI 비활성 시 status 0 경고를 성공으로 오인하지 않도록 처리 (closes #42)

### DIFF
--- a/src/__tests__/note-writer.test.ts
+++ b/src/__tests__/note-writer.test.ts
@@ -362,6 +362,19 @@ describe("appendEntry — session-grouped AgentLog section", () => {
     expect(existsSync(dailyFilePath())).toBe(false);
   });
 
+  it("does not write a raw ## AgentLog note when the Obsidian CLI is disabled (exit 0 warning)", () => {
+    const mockBin = join(tmpDir, "mock-obsidian-disabled");
+    const warning =
+      "Command line interface is not enabled. Please turn it on in Settings > General > Advanced.";
+    // Disabled CLI: every subcommand prints the warning and exits 0 without doing anything.
+    writeFileSync(mockBin, `#!/bin/bash\necho ${JSON.stringify(warning)}\nexit 0`, "utf-8");
+    chmodSync(mockBin, 0o755);
+    process.env.OBSIDIAN_BIN = mockBin;
+
+    expect(() => appendEntry(config, makeEntry(), TEST_DATE)).toThrow("Daily Note is missing");
+    expect(existsSync(dailyFilePath())).toBe(false);
+  });
+
   // N2: file with existing content — appends ## AgentLog at end
   it("appends ## AgentLog section to existing file without modifying existing content", () => {
     const filePath = writeDailyFile();

--- a/src/__tests__/obsidian-cli.test.ts
+++ b/src/__tests__/obsidian-cli.test.ts
@@ -4,6 +4,7 @@ import {
   CLI_PROBE_TIMEOUT_MS,
   DAILY_BOOTSTRAP_TIMEOUT_MS,
   isVersionAtLeast,
+  isCliDisabledOutput,
   MIN_CLI_VERSION,
   resolveCliBin,
   cliDailyPath,
@@ -50,6 +51,31 @@ describe("isVersionAtLeast", () => {
   it("handles single-segment versions", () => {
     expect(isVersionAtLeast("2", "1")).toBe(true);
     expect(isVersionAtLeast("1", "2")).toBe(false);
+  });
+});
+
+describe("isCliDisabledOutput", () => {
+  it("detects the disabled-CLI warning in stdout", () => {
+    expect(
+      isCliDisabledOutput(
+        "Command line interface is not enabled. Please turn it on in Settings > General > Advanced."
+      )
+    ).toBe(true);
+  });
+
+  it("detects the warning regardless of surrounding noise/case", () => {
+    expect(
+      isCliDisabledOutput("Loading updated app package\nCOMMAND LINE INTERFACE IS NOT ENABLED.")
+    ).toBe(true);
+  });
+
+  it("returns false for a normal daily path", () => {
+    expect(isCliDisabledOutput("Daily/2026-06-16-화.md")).toBe(false);
+  });
+
+  it("returns false for empty/undefined output", () => {
+    expect(isCliDisabledOutput("")).toBe(false);
+    expect(isCliDisabledOutput(undefined)).toBe(false);
   });
 });
 
@@ -166,6 +192,19 @@ describe("cliDailyPath", () => {
     process.env.OBSIDIAN_BIN = mockBin;
     expect(cliDailyPath()).toBeNull();
   });
+
+  it("returns null when disabled CLI prints warning but exits 0", () => {
+    const mockBin = join(tmpDir, "mock-obsidian-path-disabled");
+    writeFileSync(
+      mockBin,
+      '#!/bin/bash\necho "Command line interface is not enabled. Please turn it on in Settings > General > Advanced."\nexit 0',
+      "utf-8"
+    );
+    chmodSync(mockBin, 0o755);
+
+    process.env.OBSIDIAN_BIN = mockBin;
+    expect(cliDailyPath()).toBeNull();
+  });
 });
 
 describe("cliEnsureDailyNoteExists", () => {
@@ -208,6 +247,32 @@ describe("cliEnsureDailyNoteExists", () => {
 
   it("returns false when CLI binary is not found", () => {
     process.env.OBSIDIAN_BIN = "/nonexistent/obsidian";
+    expect(cliEnsureDailyNoteExists()).toBe(false);
+  });
+
+  it("returns false when disabled CLI prints warning but exits 0 (stdout)", () => {
+    const mockBin = join(tmpDir, "mock-obsidian-daily-disabled");
+    writeFileSync(
+      mockBin,
+      '#!/bin/bash\necho "Command line interface is not enabled. Please turn it on in Settings > General > Advanced."\nexit 0',
+      "utf-8"
+    );
+    chmodSync(mockBin, 0o755);
+
+    process.env.OBSIDIAN_BIN = mockBin;
+    expect(cliEnsureDailyNoteExists()).toBe(false);
+  });
+
+  it("returns false when disabled CLI prints warning to stderr but exits 0", () => {
+    const mockBin = join(tmpDir, "mock-obsidian-daily-disabled-stderr");
+    writeFileSync(
+      mockBin,
+      '#!/bin/bash\necho "Command line interface is not enabled. Please turn it on in Settings > General > Advanced." >&2\nexit 0',
+      "utf-8"
+    );
+    chmodSync(mockBin, 0o755);
+
+    process.env.OBSIDIAN_BIN = mockBin;
     expect(cliEnsureDailyNoteExists()).toBe(false);
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,7 @@ import { spawnSync } from "child_process";
 import { saveConfig, loadConfig, expandHome, configPath, configDir } from "./config.js";
 import type { AgentLogConfig } from "./types.js";
 import { detectVaults, detectCli } from "./detect.js";
-import { isVersionAtLeast, MIN_CLI_VERSION, resolveCliBin, parseCliVersion } from "./obsidian-cli.js";
+import { isVersionAtLeast, isCliDisabledOutput, MIN_CLI_VERSION, resolveCliBin, parseCliVersion } from "./obsidian-cli.js";
 import { registerHook, unregisterHook, inspectClaudeHookState, CLAUDE_SETTINGS_PATH } from "./claude-settings.js";
 import {
   ask,
@@ -427,9 +427,13 @@ async function cmdDoctor(): Promise<void> {
     if (cliBinPath) {
       // 5a. CLI version + minimum version check
       const cliVer = spawnSync(cliBinPath, ["version"], { encoding: "utf-8", timeout: 3000 });
-      // stdout may contain warning lines before the version; take the last non-empty line
-      const version = cliVer.status === 0 ? (parseCliVersion(cliVer.stdout ?? "") ?? "") : "";
-      if (version) {
+      const cliVerDisabled = isCliDisabledOutput(cliVer.stdout) || isCliDisabledOutput(cliVer.stderr);
+      // stdout may contain warning lines before the version; take the last non-empty line.
+      // A disabled CLI emits only the warning, which must not be parsed as a version string.
+      const version = cliVer.status === 0 && !cliVerDisabled ? (parseCliVersion(cliVer.stdout ?? "") ?? "") : "";
+      if (cliVerDisabled) {
+        check("cli-ver", false, "CLI disabled in Obsidian settings", `Enable CLI in Obsidian ${MIN_CLI_VERSION}+ Settings > General > Command line interface`, true);
+      } else if (version) {
         const meetsMin = isVersionAtLeast(version, MIN_CLI_VERSION);
         check(
           "cli-ver",
@@ -442,20 +446,27 @@ async function cmdDoctor(): Promise<void> {
         check("cli-ver", false, "could not determine version", "Ensure Obsidian app is running", true);
       }
 
-      // 5b. CLI responsive (app running + can communicate)
+      // 5b. CLI responsive (app running + CLI enabled + can communicate).
+      // A disabled CLI exits 0 while only printing a warning, so status alone is not enough.
       const cliProbe = spawnSync(cliBinPath, ["daily:path"], { encoding: "utf-8", timeout: 3000 });
+      const cliDisabled = isCliDisabledOutput(cliProbe.stdout) || isCliDisabledOutput(cliProbe.stderr);
+      const cliResponsive = cliProbe.status === 0 && !cliDisabled;
       check(
         "cli-app",
-        cliProbe.status === 0,
-        cliProbe.status === 0 ? "responsive" : "app not responding",
-        "Start Obsidian app, or check CLI settings",
+        cliResponsive,
+        cliResponsive ? "responsive" : cliDisabled ? "CLI disabled in Obsidian settings" : "app not responding",
+        cliDisabled
+          ? `Enable CLI in Obsidian ${MIN_CLI_VERSION}+ Settings > General > Command line interface`
+          : "Start Obsidian app, or check CLI settings",
         true
       );
 
       // 5c. Daily note status (only when CLI is responsive)
-      if (cliProbe.status === 0) {
+      if (cliResponsive) {
         const dailyRead = spawnSync(cliBinPath, ["daily:read"], { encoding: "utf-8", timeout: 3000 });
-        const noteExists = dailyRead.status === 0 && (dailyRead.stdout ?? "").trim().length > 0;
+        const dailyDisabled = isCliDisabledOutput(dailyRead.stdout) || isCliDisabledOutput(dailyRead.stderr);
+        const noteExists =
+          dailyRead.status === 0 && !dailyDisabled && (dailyRead.stdout ?? "").trim().length > 0;
         check(
           "daily",
           noteExists,
@@ -546,7 +557,9 @@ async function cmdOpen(): Promise<void> {
     encoding: "utf-8",
     timeout: 5000,
   });
-  if (proc.status === 0) {
+  // A disabled CLI exits 0 while only printing a warning, so status alone is not success.
+  const disabled = isCliDisabledOutput(proc.stdout) || isCliDisabledOutput(proc.stderr);
+  if (proc.status === 0 && !disabled) {
     console.log("Opened today's Daily Note in Obsidian.");
   } else {
     console.error("Failed to open. Is Obsidian running with CLI enabled?");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -553,7 +553,16 @@ async function cmdDoctor(): Promise<void> {
 }
 
 async function cmdOpen(): Promise<void> {
-  const proc = spawnSync("obsidian", ["daily"], {
+  // Resolve via the shared lookup so OBSIDIAN_BIN and the macOS app-bundle
+  // fallback work here too, instead of relying on `obsidian` being on PATH.
+  const cliBin = resolveCliBin();
+  if (!cliBin) {
+    console.error("Failed to open. Obsidian CLI not found.");
+    console.error(`  Enable CLI in Obsidian ${MIN_CLI_VERSION}+ Settings > General > Command line interface`);
+    process.exit(1);
+    return;
+  }
+  const proc = spawnSync(cliBin, ["daily"], {
     encoding: "utf-8",
     timeout: 5000,
   });

--- a/src/obsidian-cli.ts
+++ b/src/obsidian-cli.ts
@@ -26,6 +26,21 @@ type CliBinCacheState =
 /** Cached CLI resolution state for PATH/macos fallback lookup. */
 let _cachedBinState: CliBinCacheState = { status: "unresolved" };
 
+/**
+ * Detect the Obsidian "CLI disabled" warning. When the command line interface
+ * is turned off in Obsidian settings, commands like `daily`, `daily:path`, and
+ * `daily:read` print this warning to stdout/stderr while still exiting with
+ * status 0 — so exit status alone is not a reliable success signal.
+ *
+ * Matches Obsidian's English warning text only; a localized CLI message would
+ * not be detected. The CLI currently emits this string in English regardless of
+ * the app's display language.
+ */
+export function isCliDisabledOutput(output: string | undefined | null): boolean {
+  if (!output) return false;
+  return /command line interface is not enabled/i.test(output);
+}
+
 function envOverrideBin(): string | null {
   const raw = process.env.OBSIDIAN_BIN?.trim();
   return raw ? raw : null;
@@ -74,6 +89,7 @@ export function cliDailyPath(): string | null {
   if (!bin) return null;
   const result = spawnSync(bin, ["daily:path"], { encoding: "utf-8", timeout: CLI_PROBE_TIMEOUT_MS });
   if (result.status !== 0) return null;
+  if (isCliDisabledOutput(result.stdout) || isCliDisabledOutput(result.stderr)) return null;
   // stdout may contain Electron noise lines (e.g. "Loading updated app package",
   // version warnings). The actual path is always the last non-empty line.
   const lines = result.stdout.trim().split("\n").filter(Boolean);
@@ -92,7 +108,10 @@ export function cliEnsureDailyNoteExists(): boolean {
   const bin = resolveCliBin();
   if (!bin) return false;
   const result = spawnSync(bin, ["daily"], { encoding: "utf-8", timeout: DAILY_BOOTSTRAP_TIMEOUT_MS });
-  return result.status === 0;
+  if (result.status !== 0) return false;
+  // A disabled CLI exits 0 while only printing a warning — never bootstraps the note.
+  if (isCliDisabledOutput(result.stdout) || isCliDisabledOutput(result.stderr)) return false;
+  return true;
 }
 
 /** Minimum Obsidian version that supports CLI */


### PR DESCRIPTION
## 문제
Obsidian CLI가 설정에서 비활성화되면 `daily` / `daily:path` / `daily:read` / `version` 명령이 exit status 0 + `Command line interface is not enabled` 경고만 출력한다. 기존 코드는 exit status만 보고 성공으로 처리해서:
- 템플릿 없는 raw `## AgentLog` Daily Note를 생성 (#42 본문 증상)
- `agentlog doctor`가 CLI를 `responsive` / 노트 존재로 오탐
- `agentlog open`도 실제로는 안 열렸는데 "Opened..." 출력

## 변경
- `isCliDisabledOutput()` 헬퍼 추가 — stdout/stderr의 비활성 경고 탐지 (영어 메시지 기준, JSDoc에 가정 명시)
- `cliDailyPath()` / `cliEnsureDailyNoteExists()` — 비활성 출력이면 status 0이어도 null/false 반환 → `appendEntry`가 write 전에 fail-soft
- `doctor`의 `cli-app` / `cli-ver` / `daily` 체크 — 비활성 CLI를 정확히 보고
- `cmdOpen()` — 동일 status-0 false-success 결함 함께 수정 (서브에이전트 리뷰 지적)

## 테스트
- `isCliDisabledOutput` 단위 테스트 (stdout / 대소문자·노이즈 / empty·undefined)
- `cliDailyPath`, `cliEnsureDailyNoteExists` 비활성 status-0 케이스 (stdout + stderr)
- `note-writer`: 비활성 CLI에서 missing 노트가 raw `## AgentLog`로 생성되지 않음 (AC #1)
- 전체 245 tests pass, `tsc --noEmit` clean

## Acceptance Criteria
- [x] Missing Obsidian-mode Daily Note가 CLI 비활성 시 raw `## AgentLog`로 생성되지 않음
- [x] status 0 + 비활성 경고를 CLI unavailable로 처리
- [x] doctor가 비활성 CLI를 정확히 보고
- [x] 비활성 status-0 회귀 테스트 추가

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)