### PR TITLE
fix: Codex 세션을 codex_ 링크로 정확히 라벨링 (closes #43)

### DIFF
--- a/src/__tests__/note-writer.test.ts
+++ b/src/__tests__/note-writer.test.ts
@@ -482,6 +482,52 @@ describe("appendEntry — session-grouped AgentLog section", () => {
     expect(content).not.toContain("claude_");
   });
 
+  // N5c: source differs but session id collides → insert a source-specific divider
+  // (Codex IDs can look UUID-like and collide with an existing claude_ id; must not be mislabeled.)
+  it("inserts a codex divider when source differs from an existing claude divider with the same id", () => {
+    const filePath = writeDailyFile();
+
+    const sharedId = "019abcde-1111-2222-3333-444455556666";
+    appendEntry(config, makeEntry({ time: "10:53", source: "claude", sessionId: sharedId }), TEST_DATE);
+    appendEntry(config, makeEntry({ time: "11:07", source: "codex", sessionId: sharedId }), TEST_DATE);
+
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toContain(`- - - - [[claude_${sharedId}]]`);
+    expect(content).toContain(`- - - - [[codex_${sharedId}]]`);
+    const dividerCount = (content.match(/- - - -/g) ?? []).length;
+    expect(dividerCount).toBe(2);
+  });
+
+  // N5d: legacy short claude divider must not absorb a codex entry whose id shares the 8-char prefix
+  it("does not file a codex entry under a legacy claude_ divider sharing the 8-char prefix", () => {
+    const filePath = dailyFilePath();
+    writeFileSync(
+      filePath,
+      [
+        "## AgentLog",
+        "> 🕐 10:53 — js/agentlog › 첫 번째 작업",
+        "",
+        "#### 10:53 · js/agentlog",
+        "<!-- cwd=/Users/pray/work/js/agentlog -->",
+        "- - - - [[claude_abc12345]]",
+        "- 10:53 첫 번째 작업",
+        "",
+      ].join("\n"),
+      "utf-8"
+    );
+
+    appendEntry(
+      config,
+      makeEntry({ time: "11:07", source: "codex", sessionId: "abc12345-def6-7890-abcd-ef1234567890", prompt: "codex 작업" }),
+      TEST_DATE
+    );
+
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toContain("- - - - [[codex_abc12345-def6-7890-abcd-ef1234567890]]");
+    const dividerCount = (content.match(/- - - -/g) ?? []).length;
+    expect(dividerCount).toBe(2);
+  });
+
   // N6: different projects → separate #### sections
   it("creates separate sections for different projects", () => {
     const filePath = writeDailyFile();

--- a/src/note-writer.ts
+++ b/src/note-writer.ts
@@ -201,8 +201,10 @@ function insertIntoAgentLogSection(content: string, entry: LogEntry): string {
   const metaRe = /^<!-- cwd=(.+?) -->$/;
   const legacyMetaRe = /^<!-- cwd=(.+?) ses=([\w-]+) -->$/;
   const legacyHeaderRe = /^#### .+ <!-- cwd=(.+?) ses=([\w-]+) -->$/;
-  // Match current [[claude_...]]/[[codex_...]] and legacy [[ses_...]]/(ses_...) dividers
-  const dividerRe = /^- - - - (?:\[\[(?:claude|codex|ses)_([\w-]+)\]\]|\(ses_([\w-]+)\))$/;
+  // Match current [[claude_...]]/[[codex_...]] and legacy [[ses_...]]/(ses_...) dividers.
+  // Captures the source prefix so session matching stays source-aware: a codex entry
+  // must never be filed under a claude_ divider (or vice versa) even when the ids collide.
+  const dividerRe = /^- - - - (?:\[\[(claude|codex|ses)_([\w-]+)\]\]|\((ses)_([\w-]+)\))$/;
 
   let projectIdx = -1;
   let projectMetaIdx = -1; // -1 means legacy inline format (no separate metadata line)
@@ -280,16 +282,24 @@ function insertIntoAgentLogSection(content: string, entry: LogEntry): string {
       insertAt--;
     }
 
-    // Determine current session from the last divider in this subsection.
+    // Determine current session + source from the last divider in this subsection.
     // Falls back to legacySes (from old metadata format) if no dividers found.
     let currentSes = "";
+    let currentSource = ""; // "claude" | "codex" | "ses" (legacy, source-agnostic) | ""
     for (let i = firstContentIdx; i < subsectionEnd; i++) {
       const m = lines[i].match(dividerRe);
-      if (m) currentSes = m[1] ?? m[2];
+      if (m) {
+        currentSource = m[1] ?? m[3];
+        currentSes = m[2] ?? m[4];
+      }
     }
     if (!currentSes) currentSes = legacySes;
 
-    const sameSession = currentSes === entry.sessionId || currentSes === entry.sessionId.slice(0, 8);
+    const idMatches = currentSes === entry.sessionId || currentSes === entry.sessionId.slice(0, 8);
+    // Legacy dividers ("ses") and metadata-only fallbacks ("") carry no source, so treat them
+    // as matching any source to preserve backward-compatible grouping.
+    const sourceMatches = currentSource === "" || currentSource === "ses" || currentSource === entry.source;
+    const sameSession = idMatches && sourceMatches;
 
     if (!sameSession) {
       // Session changed: insert divider + entry.


### PR DESCRIPTION
## 배경
이슈 #43 — Codex 세션이 Daily Note에 `[[claude_...]]` 로 잘못 라벨링됨.

## 원인
`insertIntoAgentLogSection` 의 세션 구분이 `sessionId` 만 비교하고 `source`(claude/codex)를 무시했다. divider 정규식(`dividerRe`)도 prefix를 버려서, codex 엔트리의 id 가 기존 `[[claude_<id>]]` divider 와 충돌(이슈가 말한 UUID 유사 edge case)하면 same-session 으로 판정되어 claude divider 밑으로 분류 → `claude_` 로 표기됨.

## 변경
- `dividerRe` 가 source prefix(`claude|codex|ses`)를 캡처
- `sameSession = idMatches && sourceMatches` — id 와 source 가 모두 일치해야 동일 세션
- 레거시 `ses_` divider 및 metadata-only fallback(source 미보유)은 any-source 로 처리해 기존 그룹핑 호환 유지

## 테스트
- N5c: 동일 id·다른 source → source별 divider 분리 생성
- N5d: 레거시 8자 `claude_` short divider 가 prefix 겹치는 codex 엔트리를 흡수하지 않음
- 전체 247 pass, `bun run typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)