### PR TITLE
chore: 릴리즈 0.2.0 버전 bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@albireo3754/agentlog",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Auto-log Claude Code prompts to Obsidian Daily Notes",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## 변경
package.json 0.1.3 → 0.2.0

## 배경
develop에 누적된 feat(EnglishAsk, Codex hooks 마이그레이션, full session id 등) 다수 → minor bump. main 머지 시 release 워크플로가 v0.2.0 태그·GitHub Release·npm publish 트리거.