### PR TITLE
release: v0.2.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,10 +231,10 @@ EnglishAsk evaluates English Codex user prompts with `codex exec` after the norm
 
 #### 10:53 · js/agentlog
 <!-- cwd=/Users/you/work/js/agentlog -->
-- - - - [[claude_a1b2c3d4]]
+- - - - [[claude_a1b2c3d4-1111-2222-3333-444455556666]]
 - 10:53 start building agentlog
 - 11:07 open the spec document
-- - - - [[claude_e5f6a7b8]]
+- - - - [[claude_e5f6a7b8-1111-2222-3333-444455556666]]
 - 11:21 initialize git
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ Checks performed (in order):
 | `cli-ver` | CLI version meets minimum | warn |
 | `cli-app` | Obsidian app responds to CLI | warn |
 | `daily` | Today's Daily Note exists | warn |
-| `hook` | Hook registered in `~/.claude/settings.json` | error (warn if Codex-only) |
+| `hook` | Hook registered in `~/.claude/settings.json` and using a Claude-compatible string matcher | error (warn if Codex-only and missing) |
 | `codex-bin` | `codex` binary in PATH (if Codex configured) | error |
 | `codex` | Codex hook registered in `~/.codex/hooks.json` (if configured) | error |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -216,6 +216,7 @@ Legacy handler for older Codex `notify` installs on `agent-turn-complete`. Do no
 |-------|----------|-------------|
 | `vault` | yes | Absolute path to the Obsidian vault or plain output folder |
 | `plain` | no | If true, writes simple `YYYY-MM-DD.md` files without Obsidian section structure |
+| `claudeHookInstalled` | no | Marks that AgentLog expects the Claude hook to be installed for doctor/repair checks |
 | `codexHookInstalled` | no | Marks that AgentLog expects the Codex hook to be installed for doctor/repair checks |
 | `codexNotifyRestore` | no | Legacy metadata for older Codex `notify` installs |
 | `englishAsk` | no | Optional Codex prompt evaluator config. Disabled unless `englishAsk.enabled` is true |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,7 +203,11 @@ Invoked automatically by Codex on `agent-turn-complete`. Do not call directly.
 {
   "vault": "/Users/you/Obsidian",
   "plain": false,
-  "codexNotifyRestore": null
+  "codexNotifyRestore": null,
+  "englishAsk": {
+    "enabled": false,
+    "mode": "log-only"
+  }
 }
 ```
 
@@ -212,6 +216,9 @@ Invoked automatically by Codex on `agent-turn-complete`. Do not call directly.
 | `vault` | yes | Absolute path to the Obsidian vault or plain output folder |
 | `plain` | no | If true, writes simple `YYYY-MM-DD.md` files without Obsidian section structure |
 | `codexNotifyRestore` | no | Previous Codex `notify` value, restored on `uninstall --codex` |
+| `englishAsk` | no | Optional Codex prompt evaluator config. Disabled unless `englishAsk.enabled` is true |
+
+EnglishAsk evaluates English Codex user prompts with `codex exec` after the normal Daily Note append. Results are written under `## EnglishAsk`; evaluator failures and timeouts are fail-soft. `AGENTLOG_ENGLISHASK_EVAL=1` skips evaluator child notify turns.
 
 ## Daily Note Output Format
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,10 +190,11 @@ Legacy handler for older Codex `notify` installs on `agent-turn-complete`. Do no
 
 ### Obsidian CLI
 
-- Used to resolve the Daily Note path via `obsidian daily:path`
+- Used to resolve the Daily Note path from `.obsidian/daily-notes.json`, then `obsidian daily:path`
+- Used to bootstrap a missing Daily Note via `obsidian daily` before AgentLog writes, preserving the user's Daily Notes template
 - Minimum version: checked by `doctor` (1.12.4+)
 - Override binary path: `OBSIDIAN_BIN`
-- Fallback when CLI unavailable: `{vault}/Daily/YYYY-MM-DD-<weekday>.md`
+- No guessed `{vault}/Daily/...` fallback is created in Obsidian mode when no safe path or bootstrap is available
 
 ### Config File
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ AgentLog captures Claude Code prompts and Codex CLI turn inputs, then appends th
 
 - Config: `~/.agentlog/config.json`
 - Hook registered in: `~/.claude/settings.json`
-- Codex notify registered in: `~/.codex/config.toml`
+- Codex hook registered in: `~/.codex/hooks.json`
 - Sessions dir: `~/.agentlog/` (config only; no session JSONL in current version)
 - Config dir override: `AGENTLOG_CONFIG_DIR`
 
@@ -22,8 +22,8 @@ Saves config and registers the integration hook(s).
 |------|--------|
 | (none) | Claude hook only (default) |
 | `--claude` | Claude hook only (explicit) |
-| `--codex` | Codex notify only; requires `codex` binary in PATH |
-| `--all` | Claude hook + Codex notify; requires `codex` binary in PATH |
+| `--codex` | Codex hook only; requires `codex` binary in PATH |
+| `--all` | Claude hook + Codex hook; requires `codex` binary in PATH |
 | `--plain` | Write to a plain folder instead of an Obsidian vault |
 
 - `vault` argument is optional. Without it, the command auto-detects installed Obsidian vaults.
@@ -37,8 +37,8 @@ What `init` does (Claude target):
 
 What `init --codex` does additionally:
 1. Verifies `codex` binary is in PATH
-2. Registers `notify = ["agentlog", "codex-notify"]` in `~/.codex/config.toml`
-3. Preserves any existing `notify` command for forwarding at runtime
+2. Registers a `UserPromptSubmit` command hook in `~/.codex/hooks.json`
+3. The hook command is `agentlog hook --source codex`; review/trust it in Codex with `/hooks` if prompted
 
 Example:
 ```
@@ -95,7 +95,7 @@ Checks performed (in order):
 | `daily` | Today's Daily Note exists | warn |
 | `hook` | Hook registered in `~/.claude/settings.json` | error (warn if Codex-only) |
 | `codex-bin` | `codex` binary in PATH (if Codex configured) | error |
-| `codex` | Codex notify registered in config (if configured) | error |
+| `codex` | Codex hook registered in `~/.codex/hooks.json` (if configured) | error |
 
 Warnings (⚠️) do not affect the exit code. Errors (❌) cause exit code 1.
 
@@ -120,8 +120,8 @@ Removes AgentLog integration(s).
 | Flag | Effect |
 |------|--------|
 | (none) | Remove Claude hook from `~/.claude/settings.json` + delete `~/.agentlog/` |
-| `--codex` | Remove Codex notify from `~/.codex/config.toml` only |
-| `--all` | Remove both Claude hook + Codex notify + delete `~/.agentlog/` |
+| `--codex` | Remove Codex hook from `~/.codex/hooks.json`; also unregister/restore legacy AgentLog `notify` in `~/.codex/config.toml` when present |
+| `--all` | Remove Claude hook + Codex hook + legacy Codex notify + delete `~/.agentlog/` |
 | `-y` | Skip confirmation prompt |
 
 Example:
@@ -142,19 +142,19 @@ Override channel with `AGENTLOG_PHASE=dev` or `AGENTLOG_PHASE=prod`.
 
 ### `agentlog hook` (internal)
 
-Invoked automatically by Claude Code on `UserPromptSubmit`. Do not call directly.
+Invoked automatically by Claude Code or Codex on `UserPromptSubmit`. Do not call directly.
 
-Reads JSON from stdin (Claude Code hook format), extracts prompt and cwd, and appends an entry to the Daily Note. Fails silently — never interrupts Claude Code.
+Reads JSON from stdin, extracts prompt and cwd, and appends an entry to the Daily Note. Use `agentlog hook --source codex` for Codex hook registration. Fails silently — never interrupts the host agent.
 
-### `agentlog codex-notify` (internal)
+### `agentlog codex-notify` (legacy internal)
 
-Invoked automatically by Codex on `agent-turn-complete`. Do not call directly.
+Legacy handler for older Codex `notify` installs on `agent-turn-complete`. Do not use for new Codex installs.
 
 ## Operational Rules
 
 1. Run `agentlog doctor` before other commands to verify the setup is healthy.
 2. Run `agentlog init` before `agentlog hook` will work. The hook exits silently if config is missing.
-3. Do not call `agentlog hook` or `agentlog codex-notify` manually — they are registered as callbacks.
+3. Do not call `agentlog hook` or `agentlog codex-notify` manually — they are registered as callbacks. New Codex installs use `agentlog hook --source codex`.
 4. The `agentlog` binary must stay in PATH after `init`, because Claude Code invokes `agentlog hook` by name.
 5. Re-running `agentlog init` is safe — it merges into the existing config.
 6. `--claude` and `--codex` flags are mutually exclusive. Use `--all` for both.
@@ -171,7 +171,7 @@ Invoked automatically by Codex on `agent-turn-complete`. Do not call directly.
 | `Error: Codex CLI not found in PATH` on `init --codex` | Install Codex CLI first |
 | `Warning: Obsidian vault not detected at: ...` on `init` | Pass `--plain` for a plain folder, or open the folder in Obsidian first |
 | `doctor` exits 1, all checks pass for ⚠️ only | Warnings are non-fatal; only ❌ errors block completion |
-| Codex notify is still registered after `uninstall` | `agentlog uninstall --all -y` |
+| Codex hook is still registered after `uninstall` | `agentlog uninstall --all -y` |
 
 ## Integration Points
 
@@ -182,11 +182,11 @@ Invoked automatically by Codex on `agent-turn-complete`. Do not call directly.
 - Invocation: `agentlog hook` (receives JSON on stdin)
 - Input fields used: `prompt`, `session_id`, `cwd`
 
-### Codex CLI Notify
+### Codex CLI Hook
 
-- Event: `agent-turn-complete`
-- Registered in: `~/.codex/config.toml` as `notify = ["agentlog", "codex-notify"]`
-- Existing `notify` is preserved for forwarding
+- Event: `UserPromptSubmit`
+- Registered in: `~/.codex/hooks.json` as `agentlog hook --source codex`
+- Codex may require hook review/trust through `/hooks` before non-managed hooks run
 
 ### Obsidian CLI
 
@@ -215,7 +215,8 @@ Invoked automatically by Codex on `agent-turn-complete`. Do not call directly.
 |-------|----------|-------------|
 | `vault` | yes | Absolute path to the Obsidian vault or plain output folder |
 | `plain` | no | If true, writes simple `YYYY-MM-DD.md` files without Obsidian section structure |
-| `codexNotifyRestore` | no | Previous Codex `notify` value, restored on `uninstall --codex` |
+| `codexHookInstalled` | no | Marks that AgentLog expects the Codex hook to be installed for doctor/repair checks |
+| `codexNotifyRestore` | no | Legacy metadata for older Codex `notify` installs |
 | `englishAsk` | no | Optional Codex prompt evaluator config. Disabled unless `englishAsk.enabled` is true |
 
 EnglishAsk evaluates English Codex user prompts with `codex exec` after the normal Daily Note append. Results are written under `## EnglishAsk`; evaluator failures and timeouts are fail-soft. `AGENTLOG_ENGLISHASK_EVAL=1` skips evaluator child notify turns.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Install it once, start using Claude Code, and your Daily Note fills itself.
 ## What It Does
 
 ```
-Claude Code hook / Codex notify → Daily Note append
+Claude Code hook / Codex hook → Daily Note append
 ```
 
 ## Why AgentLog
@@ -71,7 +71,7 @@ AgentLog registers the Claude Code hook as `agentlog hook`, so the `agentlog` bi
 
 ### Requirements
 
-- [Claude Code](https://claude.ai/code) (hook integration) or [Codex CLI](https://developers.openai.com/codex) (`notify` integration)
+- [Claude Code](https://claude.ai/code) (hook integration) or [Codex CLI](https://developers.openai.com/codex) (hook integration)
 - [Obsidian](https://obsidian.md) (Daily Note target)
 - [Bun](https://bun.sh) (>=1.0.0) or [Node.js](https://nodejs.org) >=20
 
@@ -104,18 +104,18 @@ Run `agentlog init` without arguments to auto-detect installed vaults.
 `agentlog init --codex`:
 1. Verifies that Codex CLI is installed and available in `PATH`
 2. Creates or updates `~/.agentlog/config.json`
-3. Registers `notify = ["agentlog", "codex-notify"]` in `~/.codex/config.toml`
-4. Preserves an existing Codex `notify` command for runtime forwarding
+3. Registers a Codex `UserPromptSubmit` command hook in `~/.codex/hooks.json`
+4. Prints a reminder to review/trust the hook in Codex with `/hooks` if prompted
 
 The `default = --all` variant is intentionally not supported. `agentlog init` stays Claude-first for backward compatibility and to avoid failing on machines without Codex CLI.
 
 ### That's It
 
-Use Claude Code or Codex normally. Claude prompts are logged at prompt-submit time; Codex entries are logged when the turn completes because `notify` currently fires on `agent-turn-complete`.
+Use Claude Code or Codex normally. Claude and Codex prompts are logged from their `UserPromptSubmit` hook payloads.
 
 ### How It Works
 
-1. Claude Code fires `UserPromptSubmit`, or Codex invokes `notify` on `agent-turn-complete`
+1. Claude Code or Codex fires the `UserPromptSubmit` hook
 2. AgentLog extracts the latest user-visible input and sanitizes it
 3. Finds your Daily Note via `obsidian daily:path` (Obsidian CLI 1.12.4+). If that fails, it falls back to `{vault}/Daily/YYYY-MM-DD-<Korean weekday>.md`
 4. Finds or creates a `## AgentLog` section
@@ -165,15 +165,15 @@ Current CLI:
 
 | Command | Description |
 |---------|-------------|
-| `agentlog init [vault] [--plain] [--claude\|--codex\|--all]` | Configure vault and install integrations. `--claude` (default): Claude hook, `--codex`: Codex notify, `--all`: both |
+| `agentlog init [vault] [--plain] [--claude\|--codex\|--all]` | Configure vault and install integrations. `--claude` (default): Claude hook, `--codex`: Codex hook, `--all`: both |
 | `agentlog detect` | List detected Obsidian vaults and CLI status |
-| `agentlog codex-debug <prompt>` | Run `codex exec "<prompt>"` with notify auto-registered |
-| `agentlog doctor` | Run health checks for the binary, vault, hook, and Obsidian CLI. Also checks Codex notify status if configured |
+| `agentlog codex-debug <prompt>` | Run `codex exec "<prompt>"` with Codex hook auto-registered |
+| `agentlog doctor` | Run health checks for the binary, vault, hook, and Obsidian CLI. Also checks Codex hook status if configured |
 | `agentlog open` | Open today's Daily Note in Obsidian (requires CLI 1.12.4+) |
 | `agentlog version` | Print AgentLog version. In `dev` builds, also shows channel and commit |
-| `agentlog uninstall [-y] [--codex\|--all]` | `default`: Remove Claude hook + config, `--codex`: Remove Codex notify only, `--all`: Remove both |
-| `agentlog hook` | Invoked automatically by Claude Code (not for direct use) |
-| `agentlog codex-notify` | Invoked automatically by Codex (not for direct use) |
+| `agentlog uninstall [-y] [--codex\|--all]` | `default`: Remove Claude hook + config, `--codex`: Remove Codex hook and unregister/restore legacy `~/.codex/config.toml` notify if AgentLog set it up, `--all`: Remove both |
+| `agentlog hook` | Invoked automatically by Claude Code or Codex (not for direct use) |
+| `agentlog codex-notify` | Legacy handler for older Codex `notify` installs |
 
 ## Configuration
 
@@ -183,7 +183,8 @@ Current CLI:
 |-------|---------|-------------|
 | `vault` | (required) | Path to the Obsidian vault or plain output folder |
 | `plain` | `false` | Plain mode that writes simple markdown files without Obsidian integration |
-| `codexNotifyRestore` | unset | Previous Codex `notify` command. Used to forward/restore on Codex uninstall |
+| `codexHookInstalled` | `false` | Records that AgentLog expects the Codex hook to be installed, so `doctor` can detect partial damage |
+| `codexNotifyRestore` | unset | Legacy metadata for older Codex `notify` installs |
 | `englishAsk` | unset | Optional Codex prompt evaluator config. Disabled unless `englishAsk.enabled` is `true` |
 
 Example EnglishAsk config:
@@ -243,6 +244,8 @@ Codex-only uninstall:
 ```bash
 agentlog uninstall --codex
 ```
+
+This removes the Codex hook and also restores or removes AgentLog's legacy `notify` entry in `~/.codex/config.toml` when present.
 
 Or remove both integrations:
 

--- a/README.md
+++ b/README.md
@@ -268,6 +268,8 @@ bun run build         # compile to dist/ (optional)
 
 The `bin` entry points directly to `src/cli.ts`, so you do not need a build during development. Bun runs TypeScript natively.
 
+CLI command boundaries are documented in [docs/architecture/cli-layering.md](docs/architecture/cli-layering.md).
+
 ```bash
 # Link as a global command
 bun link

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ agentlog init --plain ~/notes
 
 `agentlog init` does two things:
 1. Creates `~/.agentlog/config.json` with your vault path
-2. Registers a hook in `~/.claude/settings.json`
+2. Registers or repairs a Claude Code hook in `~/.claude/settings.json` using the string matcher format (`"matcher": ""`)
 
 Run `agentlog init` without arguments to auto-detect installed vaults.
 
@@ -169,7 +169,7 @@ Current CLI:
 | `agentlog init [vault] [--plain] [--claude\|--codex\|--all]` | Configure vault and install integrations. `--claude` (default): Claude hook, `--codex`: Codex hook, `--all`: both |
 | `agentlog detect` | List detected Obsidian vaults and CLI status |
 | `agentlog codex-debug <prompt>` | Run `codex exec "<prompt>"` with Codex hook auto-registered |
-| `agentlog doctor` | Run health checks for the binary, vault, hook, and Obsidian CLI. Also checks Codex hook status if configured |
+| `agentlog doctor` | Run health checks for the binary, vault, Claude hook registration/format, and Obsidian CLI. Also checks Codex hook status if configured |
 | `agentlog open` | Open today's Daily Note in Obsidian (requires CLI 1.12.4+) |
 | `agentlog version` | Print AgentLog version. In `dev` builds, also shows channel and commit |
 | `agentlog uninstall [-y] [--codex\|--all]` | `default`: Remove Claude hook + config, `--codex`: Remove Codex hook and unregister/restore legacy `~/.codex/config.toml` notify if AgentLog set it up, `--all`: Remove both |

--- a/README.md
+++ b/README.md
@@ -184,12 +184,29 @@ Current CLI:
 | `vault` | (required) | Path to the Obsidian vault or plain output folder |
 | `plain` | `false` | Plain mode that writes simple markdown files without Obsidian integration |
 | `codexNotifyRestore` | unset | Previous Codex `notify` command. Used to forward/restore on Codex uninstall |
+| `englishAsk` | unset | Optional Codex prompt evaluator config. Disabled unless `englishAsk.enabled` is `true` |
+
+Example EnglishAsk config:
+
+```json
+{
+  "englishAsk": {
+    "enabled": true,
+    "mode": "log-only",
+    "threshold": 3,
+    "timeoutMs": 8000
+  }
+}
+```
+
+When enabled, AgentLog evaluates English Codex user prompts with `codex exec` after writing the normal AgentLog entry. Results are appended to the same Daily Note under `## EnglishAsk`. Evaluator failures and timeouts are ignored. Child evaluator runs set `AGENTLOG_ENGLISHASK_EVAL=1` so AgentLog skips evaluator child notify turns.
 
 Environment variables:
 
 | Variable | Description |
 |----------|-------------|
 | `AGENTLOG_CONFIG_DIR` | Override the config directory (default: `~/.agentlog`) |
+| `AGENTLOG_ENGLISHASK_EVAL` | Internal recursion guard for EnglishAsk evaluator runs |
 | `AGENTLOG_PHASE` | Force the runtime channel (`dev` or `prod`), overriding auto-detection |
 | `OBSIDIAN_BIN` | Override the Obsidian CLI binary path |
 

--- a/README.md
+++ b/README.md
@@ -117,19 +117,20 @@ Use Claude Code or Codex normally. Claude and Codex prompts are logged from thei
 
 1. Claude Code or Codex fires the `UserPromptSubmit` hook
 2. AgentLog extracts the latest user-visible input and sanitizes it
-3. Finds your Daily Note via `obsidian daily:path` (Obsidian CLI 1.12.4+). If that fails, it falls back to `{vault}/Daily/YYYY-MM-DD-<Korean weekday>.md`
-4. Finds or creates a `## AgentLog` section
-5. Finds or creates a `#### project` subsection matching the current working directory
-6. Inserts a source-prefixed session divider such as `[[claude_...]]` or `[[codex_...]]` if the session changed, then appends the entry
-7. Updates the `> 🕐` latest-entry line at the top of the section
+3. Resolves your Daily Note path from `.obsidian/daily-notes.json`, then `obsidian daily:path` when needed
+4. If the Daily Note is missing in Obsidian mode, asks `obsidian daily` to create it before writing so your Daily Notes template is preserved
+5. Finds or creates a `## AgentLog` section
+6. Finds or creates a `#### project` subsection matching the current working directory
+7. Inserts a source-prefixed session divider such as `[[claude_...]]` or `[[codex_...]]` if the session changed, then appends the entry
+8. Updates the `> 🕐` latest-entry line at the top of the section
 
-Total overhead: < 50ms per prompt. Fire-and-forget, never blocks Claude Code.
+Steady-state overhead is under 50ms per prompt when the Daily Note already exists. Missing-note bootstrap depends on Obsidian CLI startup. Fire-and-forget, never blocks Claude Code.
 
 ## Daily Note Format
 
 ### Obsidian Mode (default)
 
-AgentLog resolves the Daily Note path via `obsidian daily:path` when the Obsidian CLI is available (1.12.4+). If the CLI is unavailable or Obsidian is not running, it falls back to `{vault}/Daily/YYYY-MM-DD-<Korean weekday>.md` such as `2026-03-01-일.md`.
+AgentLog resolves the Daily Note path from `.obsidian/daily-notes.json` first, then `obsidian daily:path` when the vault settings are unavailable or unsupported. If the resolved Daily Note is missing, AgentLog runs `obsidian daily` before writing and only appends after the file exists, preserving the user's Daily Notes template. Obsidian mode does not create a guessed `{vault}/Daily/...` fallback file; if no safe path can be resolved or the CLI cannot bootstrap a missing note, the hook fails softly and skips the write. Plain mode still writes directly to `{dir}/YYYY-MM-DD.md`.
 
 Each working directory gets its own `#### project` subsection. Session changes insert a source-prefixed wiki-link divider such as `[[claude_...]]` or `[[codex_...]]`. The `> 🕐` blockquote at the top always shows the latest entry across all projects.
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Current CLI:
 |-------|---------|-------------|
 | `vault` | (required) | Path to the Obsidian vault or plain output folder |
 | `plain` | `false` | Plain mode that writes simple markdown files without Obsidian integration |
+| `claudeHookInstalled` | `false` | Records that AgentLog expects the Claude hook to be installed, so `doctor` does not downgrade a missing Claude hook in `--all` installs |
 | `codexHookInstalled` | `false` | Records that AgentLog expects the Codex hook to be installed, so `doctor` can detect partial damage |
 | `codexNotifyRestore` | unset | Legacy metadata for older Codex `notify` installs |
 | `englishAsk` | unset | Optional Codex prompt evaluator config. Disabled unless `englishAsk.enabled` is `true` |

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ Claude Code hook / Codex hook → Daily Note append
 
 #### 10:53 · js/agentlog
 <!-- cwd=/Users/you/work/js/agentlog -->
-- - - - [[claude_a1b2c3d4]]
+- - - - [[claude_a1b2c3d4-1111-2222-3333-444455556666]]
 - 10:53 start building agentlog
 - 11:07 open the spec document
-- - - - [[claude_e5f6a7b8]]
+- - - - [[claude_e5f6a7b8-1111-2222-3333-444455556666]]
 - 11:21 initialize git and open it in VS Code
 ```
 
@@ -139,13 +139,13 @@ Each working directory gets its own `#### project` subsection. Session changes i
 
 #### 10:53 · js/agentlog
 <!-- cwd=/Users/you/work/js/agentlog -->
-- - - - [[claude_a1b2c3d4]]
+- - - - [[claude_a1b2c3d4-1111-2222-3333-444455556666]]
 - 10:53 start building agentlog
 - 11:07 open the spec document
 
 #### 14:00 · kotlin/message-gate
 <!-- cwd=/Users/you/work/kotlin/message-gate -->
-- - - - [[codex_e5f6a7b8]]
+- - - - [[codex_e5f6a7b8-1111-2222-3333-444455556666]]
 - 14:00 adjust the API response
 - 14:30 run tests
 ```

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -102,3 +102,65 @@ main          ← 릴리즈
        ├─ feat/29-full-session-id
        └─ ...
 ```
+
+---
+
+## SCM 주의: GH_HOST
+
+이 머신은 `GH_HOST=github.dktechin.in` 환경변수가 기본이라, agentlog의 `gh` 명령은
+모두 `GH_HOST=github.com` 접두사를 붙여야 한다 (origin이 github.com이기 때문).
+
+```bash
+GH_HOST=github.com gh issue view 43
+GH_HOST=github.com gh pr create --base develop ...
+```
+
+---
+
+## TDD (test-first)
+
+버그 수정·기능 추가는 **실패 테스트 먼저** 작성한다.
+
+1. 재현/요구사항을 드러내는 테스트를 추가 → `bun test`로 **올바른 이유로 실패**(red) 확인
+2. 통과시키는 **최소 구현**(green)
+3. 필요 시 리팩토링 (테스트 green 유지)
+
+---
+
+## 검증 (커밋 전 필수)
+
+```bash
+bun run typecheck   # tsc --noEmit, exit 0
+bun test            # 전체 green
+```
+
+둘 다 통과해야 커밋한다.
+
+---
+
+## 리뷰 (PR 전후 2단계)
+
+작성과 리뷰는 분리한다 — 자기 코드를 자기가 승인하지 않는다.
+
+1. **서브에이전트 리뷰**: `code-reviewer`(또는 OMC `oh-my-claudecode:code-reviewer`)에게
+   diff를 넘겨 리뷰받고, 지적사항 반영.
+2. **Copilot 리뷰**: PR 생성 후 Copilot 리뷰 요청 → 피드백 반영.
+
+```bash
+GH_HOST=github.com gh api repos/<owner>/agentlog/pulls/<PR#>/requested_reviewers \
+  -X POST -f "reviewers[]=copilot-pull-request-reviewer[bot]"
+```
+
+---
+
+## 머지
+
+리뷰 반영 + CI green 후:
+
+```bash
+GH_HOST=github.com gh pr merge <PR#> --squash --delete-branch
+```
+
+- **squash** 머지 → develop fast-forward
+- 머지 후 feature 브랜치(local + remote) 삭제, `git fetch --prune`
+- PR 제목/본문의 `Closes #N`으로 이슈 자동 close 확인

--- a/docs/architecture/cli-layering.md
+++ b/docs/architecture/cli-layering.md
@@ -1,0 +1,33 @@
+# CLI Layering
+
+AgentLog CLI code should keep the Commander edge thin. Command registration in
+`src/cli.ts` owns argument parsing and delegation; reusable workflow support
+lives outside that entrypoint.
+
+## Layers
+
+| Layer | Responsibility | Current modules |
+|---|---|---|
+| Command edge | Commander setup, option parsing, subcommand delegation | `src/cli.ts` |
+| Application support | prompt asking, vault validation, config merge, binary lookup, shared CLI status output | `src/cli-shared.ts` |
+| Domain/core | config shape, error taxonomy, Daily Note merge rules, prompt formatting | `src/config.ts`, `src/errors.ts`, `src/note-writer.ts`, `src/schema/*` |
+| Infra/adapters | filesystem/process-backed integrations with Claude, Codex, Obsidian | `src/claude-settings.ts`, `src/codex-hooks.ts`, `src/codex-settings.ts`, `src/obsidian-cli.ts` |
+| Presentation | human-readable command output and future machine-readable command schemas | command handlers in `src/cli.ts`, `SCHEMA_DATA` |
+
+## Rules
+
+- New command handlers should not add reusable validation or integration helpers
+  directly to `src/cli.ts`.
+- Shared command support goes in `src/cli-shared.ts` until a narrower
+  application module is justified.
+- External side effects stay behind adapter modules; command handlers should
+  orchestrate them, not parse their internal file formats.
+- Formatting that becomes reused by more than one command should move out of
+  the command handler with tests.
+
+## Next Cuts
+
+- Move `doctor` check modeling and formatting into a dedicated application module.
+- Move `uninstall` orchestration into a dedicated application module.
+- Keep `SCHEMA_DATA` aligned with command registration, or generate it from a
+  single command description source.

--- a/docs/cc/hook-integration.md
+++ b/docs/cc/hook-integration.md
@@ -71,7 +71,11 @@ After running `npx agentlog init <vault>`, the hook is registered in
 }
 ```
 
-The `matcher` is empty string to match all prompts regardless of content.
+The `matcher` is an empty string to match all prompts regardless of content.
+Claude Code validates this field as a string; stale object matcher entries are
+not compatible with current Claude Code settings validation. Re-running
+`agentlog init` replaces AgentLog-owned stale hook entries with the canonical
+`"matcher": ""` entry, and `agentlog doctor` reports unsupported hook shapes.
 
 ---
 

--- a/docs/cc/hook-integration.md
+++ b/docs/cc/hook-integration.md
@@ -77,37 +77,32 @@ The `matcher` is empty string to match all prompts regardless of content.
 
 ## Daily Note Format
 
-AgentLog appends to `{vault}/Daily/{YYYY-MM-DD}-{요일}.md`.
+AgentLog resolves the Daily Note path from `.obsidian/daily-notes.json` first,
+then `obsidian daily:path` when the vault settings are unavailable or
+unsupported.
 
-### With time-block sections (Korean Daily Note format)
+If the Daily Note is missing in Obsidian mode, AgentLog runs `obsidian daily`
+first and only appends after the file exists. This lets Obsidian create the note
+and apply the user's Daily Notes template. AgentLog does not create a guessed
+`{vault}/Daily/...` fallback file in Obsidian mode when no safe path or
+bootstrap is available.
 
-If the file contains time-block checkbox lines, the entry is inserted under the
-matching 2-hour block:
-
-```markdown
-## 오전 (08-13)
-- [ ] 08 - 10
-- [x] 10 - 12
-  - 10:53 agentlog 개발을 위해서 작업 진행
-  - 11:07 스펙 문서 열어봐
-- [ ] 12 - 13
-```
-
-### Without time-block sections (fallback)
-
-If no time-block pattern is found, appended to an `## AgentLog` section at
-end of file:
+Entries are merged into an `## AgentLog` section:
 
 ```markdown
 ## AgentLog
+> 🕐 11:07 — js/agentlog › 스펙 문서 열어봐
+
+#### 10:53 · js/agentlog
+<!-- cwd=/Users/you/work/js/agentlog -->
+- - - - [[claude_abc12345-def6-7890-abcd-ef1234567890]]
 - 10:53 agentlog 개발을 위해서 작업 진행
 - 11:07 스펙 문서 열어봐
 ```
 
 ### `--plain` mode
 
-With `--plain` flag during init, writes to `{dir}/{YYYY-MM-DD}.md` with no
-time-block logic:
+With `--plain` flag during init, writes directly to `{dir}/{YYYY-MM-DD}.md`:
 
 ```markdown
 - 10:53 agentlog 개발을 위해서 작업 진행

--- a/docs/codex-hook-spec.md
+++ b/docs/codex-hook-spec.md
@@ -1,0 +1,135 @@
+# Codex Hook Integration Spec
+
+AgentLog's Codex integration MUST use Codex lifecycle hooks, not the legacy
+`notify` command path, for new installs. This document records the release
+behavior AgentLog implements and tests.
+
+Sources:
+
+- Codex Hooks reference: <https://developers.openai.com/codex/hooks.md>
+- Codex Advanced Configuration hooks section: <https://developers.openai.com/codex/config-advanced.md#hooks>
+
+## Scope
+
+AgentLog logs the user prompt that starts a Codex turn. The Codex hook event
+that exposes this prompt before model submission is `UserPromptSubmit`.
+
+Out of scope for the first hook migration:
+
+- Tool-policy enforcement hooks such as `PreToolUse` or `PermissionRequest`.
+- Stop/continuation hooks such as `Stop` and `SubagentStop`.
+- Transcript parsing. Codex documents `transcript_path` as convenient but not a
+  stable hook interface.
+- Hook trust automation. Codex requires users to review/trust non-managed hooks
+  through `/hooks`; AgentLog can install the hook definition, but Codex owns the
+  trust prompt/state.
+
+## Hook discovery and registration
+
+Codex discovers hooks next to active config layers as either `hooks.json` or
+inline `[hooks]` TOML tables. For AgentLog's user-level install, write:
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "agentlog hook --source codex"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Registration rules:
+
+1. Use `~/.codex/hooks.json` for user-level Codex integration.
+2. Preserve unrelated hook events and unrelated `UserPromptSubmit` hook groups.
+3. Add the AgentLog hook idempotently; never duplicate the same command.
+4. Omit `matcher` for `UserPromptSubmit`; Codex currently ignores matchers for
+   this event.
+5. Command hooks run with the Codex session `cwd`, but AgentLog still reads
+   `cwd` from hook stdin because it is part of the documented common input.
+6. `type: "command"` is the only handler type AgentLog should emit today.
+7. Do not configure `notify` for new Codex installs. Codex project-local config
+   also cannot override `notify`; user-level notification/hook behavior belongs
+   in user-level Codex config.
+
+## UserPromptSubmit input contract
+
+Every Codex command hook receives one JSON object on stdin. AgentLog depends on
+these fields:
+
+| Field | Required | AgentLog use |
+| --- | --- | --- |
+| `hook_event_name` | yes | Must be `UserPromptSubmit` |
+| `session_id` | yes | Daily Note session grouping |
+| `cwd` | yes | Daily Note project/section grouping |
+| `prompt` | yes | Prompt text to log |
+| `turn_id` | no | Codex turn identity; retained for future diagnostics |
+| `transcript_path` | no | Ignored; not a stable parsing interface |
+| `permission_mode` | no | Ignored |
+| `model` | no | Ignored |
+
+Representative fixture:
+
+```json
+{
+  "session_id": "019cb123-ac48-7d22-b5bf-195ee34699af",
+  "transcript_path": "/Users/pray/.codex/sessions/example.jsonl",
+  "cwd": "/Users/pray/opensource/agentlog",
+  "hook_event_name": "UserPromptSubmit",
+  "model": "gpt-5.5",
+  "turn_id": "019cb123-ac4f-7800-a1f9-a953dc2ce3f5",
+  "permission_mode": "default",
+  "prompt": "Reply with exactly: OK"
+}
+```
+
+AgentLog may continue to accept Claude/backward-compatibility fallback shapes
+(`message.content` and `parts[].text`) in its generic hook parser. Those
+fallbacks are not part of the Codex contract. When the handler runs with
+`--source codex`, a missing `prompt` is invalid.
+
+## Output behavior
+
+AgentLog should normally exit `0` with no stdout. Codex treats that as success
+and continues. AgentLog must not block or modify prompts in normal logging mode.
+
+Allowed but unused Codex `UserPromptSubmit` outputs include:
+
+- Plain text stdout as extra developer context.
+- JSON common output fields such as `continue`, `stopReason`, `systemMessage`,
+  and `suppressOutput`.
+- `hookSpecificOutput.additionalContext`.
+- Legacy block output (`decision: "block"`) or exit code `2` to block a prompt.
+
+AgentLog intentionally does not emit these because prompt logging must be
+non-interrupting.
+
+## Codebase mapping
+
+| Spec concept | Code artifact |
+| --- | --- |
+| User-level hook file | `src/codex-hooks.ts` (`CODEX_HOOKS_PATH`) |
+| AgentLog hook command | `src/codex-hooks.ts` (`AGENTLOG_CODEX_HOOK_COMMAND`) |
+| Hook stdin parser | `src/schema/hook-input.ts` (`parseHookInput`) |
+| Codex source tagging | `src/hook.ts` (`agentlog hook --source codex`) |
+| CLI install path | `src/cli.ts` (`init --codex`, `init --all`) |
+| CLI uninstall path | `src/cli.ts` (`uninstall --codex`, `uninstall --all`) |
+| Doctor verification | `src/cli.ts` (`codex` check reads hooks state) |
+| Hook registration tests | `src/__tests__/codex-hooks.test.ts` |
+| Hook input fixture/tests | `src/__tests__/fixtures/codex-hook-user-prompt-submit.json`, `src/__tests__/hook-input.test.ts` |
+
+## Backward compatibility
+
+The legacy `agentlog codex-notify` command and notify parser may remain for
+users who already have an old Codex `notify` command configured. New install,
+doctor, and uninstall behavior should be hook-based. Legacy notify forwarding is
+not part of the hook spec and must not be used as evidence that the latest Codex
+integration is installed.

--- a/docs/obsidian/06-official-cli-research.md
+++ b/docs/obsidian/06-official-cli-research.md
@@ -87,6 +87,9 @@ OS별 포인트(문서 기준):
 ### 5.1 현재 구조와의 관계
 
 - AgentLog 핵심(`agentlog hook`)은 이미 파일 직접 쓰기라 REST API 의존이 없다.
+- Daily Note 경로는 `.obsidian/daily-notes.json`을 먼저 읽고, 설정을 해석할 수 없을 때 `obsidian daily:path`로 보완한다.
+- Missing Daily Note 생성은 `obsidian daily`가 담당한다. `daily:path`는 경로 조회일 뿐이며 템플릿 적용 생성 흐름을 보장하지 않는다.
+- AgentLog의 markdown merge는 파일이 존재한 뒤에만 수행한다. Obsidian mode에서는 안전 경로/CLI bootstrap이 없을 때 guessed `{vault}/Daily/...` 파일을 직접 만들지 않는다.
 - 영향 범위는 주로 문서/운영 자동화 레이어(`obs`, `obs-daily`, `obs-cmd`, `obs-open`류)다.
 
 ### 5.2 권장 전략
@@ -110,7 +113,7 @@ OS별 포인트(문서 기준):
 | 특정 명령 실행 | `obsidian command id="..."` |
 | 명령 목록 조회 | `obsidian commands` |
 | vault 검색 | `obsidian search query="..."` |
-| Daily 경로 확인 | `obsidian daily:path` |
+| Daily 경로 확인(생성 아님) | `obsidian daily:path` |
 
 > 참고: 실제 명령/파라미터는 1.12.x에서 빠르게 변경된 이력이 있으니, 도입 시점에 `obsidian help`로 재검증 필요.
 
@@ -175,4 +178,3 @@ OS별 포인트(문서 기준):
     https://raw.githubusercontent.com/coddingtonbear/obsidian-local-rest-api/main/manifest.json
 14. Local REST API README (HTTPS+API key 모델)  
     https://raw.githubusercontent.com/coddingtonbear/obsidian-local-rest-api/main/README.md
-

--- a/docs/obsidian/README.md
+++ b/docs/obsidian/README.md
@@ -15,5 +15,4 @@
 5. [05-project-judgement-extra-docs.md](./05-project-judgement-extra-docs.md)
    - 운영/확장 문서 백로그 및 2주 로드맵
 6. [06-official-cli-research.md](./06-official-cli-research.md)
-   - Obsidian 공식 CLI 조사, REST API 대비, AgentLog 권장 운영안
-
+   - Obsidian 공식 CLI 조사, REST API 대비, Daily Note bootstrap 결정, AgentLog 권장 운영안

--- a/docs/plans/2026-03-08-bun-link-install-smoke.md
+++ b/docs/plans/2026-03-08-bun-link-install-smoke.md
@@ -1,5 +1,11 @@
 # Bun Link Install Smoke Test Implementation Plan
 
+> Superseded: Codex integration now uses the `UserPromptSubmit` hook in
+> `~/.codex/hooks.json` (`agentlog hook --source codex`) instead of the legacy
+> `notify` command path. Use `docs/codex-hook-spec.md` as the current source of
+> truth for Codex hook install behavior. The original plan below is retained as
+> historical context only.
+
 > **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
 **Goal:** `bun link` 이후 실제 전역 `agentlog` 명령이 설치되고, `init --codex` 중심 설치 흐름이 격리된 환경에서 자동 검증되도록 한다.

--- a/docs/plans/2026-03-08-codex-host-integration-smoke.md
+++ b/docs/plans/2026-03-08-codex-host-integration-smoke.md
@@ -1,5 +1,10 @@
 # Codex Host Integration Smoke Test Plan
 
+> Superseded: Codex integration now uses the `UserPromptSubmit` hook in
+> `~/.codex/hooks.json` (`agentlog hook --source codex`) instead of the legacy
+> `notify` command path. Use `docs/codex-hook-spec.md` as the current source of
+> truth. The original plan below is retained as historical context only.
+
 > Scope: later host integration verification only. This document does not implement the test.
 
 **Goal:** 실제 Codex CLI/TUI 세션에서 turn complete 시 `notify = ["agentlog", "codex-notify"]`가 자동 호출되는지 입증하는 host integration smoke test를 설계한다.

--- a/docs/review/SELF_REVIEW.md
+++ b/docs/review/SELF_REVIEW.md
@@ -120,6 +120,23 @@ Good evidence:
 - `appendEntry()` aborts missing-note writes when path resolution or CLI bootstrap cannot be confirmed.
 - Regression tests for missing-note bootstrap, no guessed fallback, and bootstrap failure.
 
+### CLI Layering
+
+`src/cli.ts` should stay the command edge, not the home for reusable application support.
+
+Check:
+
+- Commander registration stays in `src/cli.ts`.
+- Shared support such as prompt asking, vault validation, config merge, binary lookup, and repeated status formatting stays outside `src/cli.ts`, regardless of whether it would be written as `function`, `const`, or `export const`.
+- External integrations remain behind adapter modules such as `claude-settings`, `codex-hooks`, `codex-settings`, and `obsidian-cli`.
+- Architecture docs are updated when a new CLI layer or module boundary is introduced.
+
+Good evidence:
+
+- `src/cli-shared.ts` owns reusable CLI support helpers.
+- `docs/architecture/cli-layering.md` explains the current layer map and next safe cuts.
+- targeted CLI tests pass after moving code across module boundaries.
+
 ### Session Link Fidelity
 
 Session links written to Daily Notes should preserve the full session id unless reading legacy data.

--- a/docs/review/SELF_REVIEW.md
+++ b/docs/review/SELF_REVIEW.md
@@ -83,6 +83,28 @@ Check:
 - Old statements like "always uses Obsidian CLI" are removed or qualified.
 - README/CLAUDE/docs are updated only when they are in scope.
 
+### Evaluator Hooks
+
+Any evaluator launched from a hook or notify path must be fail-soft and non-recursive.
+
+Check:
+
+- Child evaluator runs set an env guard before invoking Codex or other agent tooling.
+- The notify/hook path checks that guard before reading stdin, normal writes, and forwarding, then skips evaluator child turns entirely.
+- Notify payload `cwd` can be stale or unavailable on CI/another machine; evaluator cwd must fall back safely.
+- Evaluator failure, non-zero exit, timeout, and feedback append failures cannot prevent the normal AgentLog write or surface as generic notify errors.
+- Evaluators receive the raw user prompt for semantic review; display-only formatting such as `prettyPrompt(...)` is used only for Daily Note entries.
+- Prompts and evaluator output are redacted and bounded before storage.
+- Stored prompt metadata is flattened before being written as a Markdown list item.
+- Stored evaluator feedback cannot break out of its Markdown code fence.
+- New feedback is inserted inside the existing `## EnglishAsk` section, before the next top-level heading, including when the next heading immediately follows the section header.
+
+Good evidence:
+
+- env guard such as `AGENTLOG_ENGLISHASK_EVAL`
+- tests for guarded notify no-write/no-forward, raw evaluator input vs display prompt, missing cwd fallback, evaluator failure, timeout, append failure, prompt flattening, feedback fence safety, and existing-section insertion
+- config defaults that keep evaluator features off unless explicitly enabled
+
 ### Plan and Design Contract Drift
 
 Implementation plans and design docs must not drift from the current code contract.

--- a/docs/review/SELF_REVIEW.md
+++ b/docs/review/SELF_REVIEW.md
@@ -99,6 +99,27 @@ Check:
 - Old statements like "always uses Obsidian CLI" are removed or qualified.
 - README/CLAUDE/docs are updated only when they are in scope.
 
+### Daily Bootstrap Safety
+
+`obsidian daily:path` resolves a path; it does not create the Daily Note or apply the user's template.
+
+Check:
+
+- Missing Daily Notes in Obsidian mode are created through `obsidian daily` before AgentLog writes.
+- AgentLog re-checks that the resolved file exists after CLI bootstrap before reading or writing.
+- The `obsidian daily` bootstrap path has a longer timeout than lightweight probes such as `daily:path`, because it may start or wake Obsidian.
+- Non-plain mode does not create a guessed `{vault}/Daily/...` fallback when no safe path source is available.
+- Plain mode remains direct-file append and is not accidentally routed through Obsidian CLI.
+- Tests prove template content created by the bootstrap is preserved after AgentLog merges `## AgentLog`.
+- Tests prove CLI-unavailable/bootstrap-failure cases do not create raw Daily files.
+
+Good evidence:
+
+- `cliEnsureDailyNoteExists()` calls `obsidian daily`.
+- tests or constants prove Daily bootstrap timeout is greater than the probe timeout.
+- `appendEntry()` aborts missing-note writes when path resolution or CLI bootstrap cannot be confirmed.
+- Regression tests for missing-note bootstrap, no guessed fallback, and bootstrap failure.
+
 ### Session Link Fidelity
 
 Session links written to Daily Notes should preserve the full session id unless reading legacy data.

--- a/docs/review/SELF_REVIEW.md
+++ b/docs/review/SELF_REVIEW.md
@@ -89,6 +89,25 @@ Good evidence:
 - tests for legacy notify removal when no restore command exists
 - docs that mention legacy `notify` cleanup for Codex uninstall
 
+### Claude Hook Matcher Compatibility
+
+Claude Code validates hook entries in `~/.claude/settings.json`. The `matcher` field must stay a string; stale object matchers can make the whole settings file invalid.
+
+Check:
+
+- AgentLog's `HOOK_ENTRY` uses `matcher: ""`, not an object matcher.
+- `agentlog init` removes AgentLog-owned stale hook entries before writing the canonical hook.
+- `agentlog doctor` and `agentlog validate` fail when the registered AgentLog hook has an unsupported matcher shape.
+- The migration preserves unrelated hook entries.
+- Docs that show the Claude hook settings example use the string matcher format.
+
+Good evidence:
+
+- a validator such as `inspectClaudeHookState()` reports unsupported Claude settings shapes
+- tests for stale AgentLog object matcher migration
+- tests for doctor failure when `matcher` is an object
+- hook integration docs showing `"matcher": ""`
+
 ### Docs Sync
 
 When runtime fallback order or behavior changes, developer docs must say the same thing.

--- a/docs/review/SELF_REVIEW.md
+++ b/docs/review/SELF_REVIEW.md
@@ -99,6 +99,21 @@ Check:
 - Old statements like "always uses Obsidian CLI" are removed or qualified.
 - README/CLAUDE/docs are updated only when they are in scope.
 
+### Session Link Fidelity
+
+Session links written to Daily Notes should preserve the full session id unless reading legacy data.
+
+Check:
+
+- New `[[claude_...]]`, `[[codex_...]]`, and EnglishAsk session links use full `sessionId`.
+- Truncation such as `sessionId.slice(0, 8)` remains only in legacy matching compatibility, not in new output builders.
+- Docs examples do not show short 6-8 character source-prefixed session links as the current output.
+
+Good evidence:
+
+- tests for full UUID-like session links in Claude and Codex dividers
+- tests showing legacy short dividers still match the current session without rewriting old notes
+
 ### Evaluator Hooks
 
 Any evaluator launched from a hook or notify path must be fail-soft and non-recursive.

--- a/docs/review/SELF_REVIEW.md
+++ b/docs/review/SELF_REVIEW.md
@@ -98,14 +98,17 @@ Check:
 - AgentLog's `HOOK_ENTRY` uses `matcher: ""`, not an object matcher.
 - `agentlog init` removes AgentLog-owned stale hook entries before writing the canonical hook.
 - `agentlog doctor` and `agentlog validate` fail when the registered AgentLog hook has an unsupported matcher shape.
+- `agentlog doctor` downgrades a missing Claude hook to warn-only only for Codex-only installs; `--all` installs must still fail if the Claude hook is missing.
 - The migration preserves unrelated hook entries.
 - Docs that show the Claude hook settings example use the string matcher format.
 
 Good evidence:
 
 - a validator such as `inspectClaudeHookState()` reports unsupported Claude settings shapes
+- config metadata such as `claudeHookInstalled` distinguishes Codex-only installs from both-hook installs
 - tests for stale AgentLog object matcher migration
 - tests for doctor failure when `matcher` is an object
+- tests for doctor failure when both hooks are expected but the Claude hook is missing
 - hook integration docs showing `"matcher": ""`
 
 ### Docs Sync

--- a/docs/review/SELF_REVIEW.md
+++ b/docs/review/SELF_REVIEW.md
@@ -73,6 +73,22 @@ Good evidence:
 - mock script with `touch <sentinel>`
 - assertion such as `expect(existsSync(sentinel)).toBe(false)`
 
+### Integration Uninstall and Migration Cleanup
+
+Install/uninstall paths mutate user-level integration files. Treat those files as external input and keep migration-era side effects explicit.
+
+Check:
+
+- Uninstall paths catch invalid or unsupported external config, such as malformed Codex `hooks.json`, and exit with a single clear message instead of a stack trace.
+- User-facing uninstall output distinguishes restoring a previous command from removing an AgentLog-owned legacy entry.
+- Docs and CLI help mention both current integration cleanup and legacy migration cleanup when a command performs both.
+
+Good evidence:
+
+- tests for invalid `hooks.json` during `uninstall --codex`
+- tests for legacy notify removal when no restore command exists
+- docs that mention legacy `notify` cleanup for Codex uninstall
+
 ### Docs Sync
 
 When runtime fallback order or behavior changes, developer docs must say the same thing.

--- a/docs/review/review-list.json
+++ b/docs/review/review-list.json
@@ -107,17 +107,23 @@
     {
       "id": "docs-session-divider-length",
       "severity": "medium",
-      "title": "Documented source-prefixed session dividers must use runtime suffix length",
+      "title": "Documented source-prefixed session dividers must use full session ids",
       "appliesTo": {
-        "paths": ["AGENTS.md", "README.md", "llms.txt", "docs/**/*.md"],
-        "diffIncludesAny": ["[[claude_", "[[codex_", "session divider"]
+        "paths": ["AGENTS.md", "README.md", "llms.txt", "docs/**/*.md", "src/schema/daily-note.ts", "src/english-ask.ts"],
+        "diffIncludesAny": ["[[claude_", "[[codex_", "session divider", "buildSessionDivider", "sessionId"]
       },
       "checks": [
         {
           "type": "noneContentRegex",
           "paths": ["AGENTS.md", "README.md", "llms.txt", "docs/**/*.md"],
-          "pattern": "\\[\\[(?:claude|codex)_[A-Za-z0-9]{6}\\]\\]",
-          "message": "Use 8 session-id characters in source-prefixed divider examples, matching runtime `sessionId.slice(0, 8)`."
+          "pattern": "\\[\\[(?:claude|codex)_[A-Za-z0-9]+\\]\\]",
+          "message": "Use full session ids in source-prefixed divider examples, not truncated examples."
+        },
+        {
+          "type": "noneContentRegex",
+          "paths": ["src/schema/daily-note.ts", "src/english-ask.ts"],
+          "pattern": "sessionId\\.slice\\(0,\\s*8\\)",
+          "message": "New AgentLog/EnglishAsk session links must use the full session id. Keep truncation only for legacy matching code."
         }
       ]
     },

--- a/docs/review/review-list.json
+++ b/docs/review/review-list.json
@@ -307,6 +307,47 @@
       ]
     },
     {
+      "id": "claude-hook-matcher-string",
+      "severity": "high",
+      "title": "Claude hook matcher must use the string format",
+      "appliesTo": {
+        "paths": ["src/claude-settings.ts", "src/cli.ts", "src/__tests__/cli.test.ts", "README.md", "AGENTS.md", "docs/cc/**/*.md", "docs/review/SELF_REVIEW.md"],
+        "diffIncludesAny": ["HOOK_ENTRY", "matcher", "Claude Code", "UserPromptSubmit", "agentlog hook"]
+      },
+      "checks": [
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/claude-settings.ts"],
+          "pattern": "HOOK_ENTRY[\\s\\S]*matcher:\\s*\"\"",
+          "message": "Keep AgentLog's Claude hook on the documented string matcher format."
+        },
+        {
+          "type": "noneContentRegex",
+          "paths": ["src/claude-settings.ts"],
+          "pattern": "matcher:\\s*\\{",
+          "message": "Do not register object matchers in Claude Code settings."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/claude-settings.ts"],
+          "pattern": "validateClaudeHookSettings[\\s\\S]*matcher[\\s\\S]*string[\\s\\S]*inspectClaudeHookState[\\s\\S]*validateClaudeHookSettings",
+          "message": "Doctor/validate must inspect matcher type compatibility, not just command presence."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/__tests__/cli.test.ts"],
+          "pattern": "stale AgentLog hook matcher object[\\s\\S]*matcher must be a string",
+          "message": "Add regression coverage for stale object matcher migration and doctor failure."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["docs/cc/hook-integration.md"],
+          "pattern": "\"matcher\":\\s*\"\"",
+          "message": "Document the Claude hook settings example with an empty string matcher."
+        }
+      ]
+    },
+    {
       "id": "englishask-recursion-guard",
       "severity": "high",
       "title": "EnglishAsk evaluator must not recursively evaluate itself",

--- a/docs/review/review-list.json
+++ b/docs/review/review-list.json
@@ -173,6 +173,173 @@
       ]
     },
     {
+      "id": "englishask-recursion-guard",
+      "severity": "high",
+      "title": "EnglishAsk evaluator must not recursively evaluate itself",
+      "appliesTo": {
+        "paths": ["src/**/*.ts"],
+        "diffIncludesAny": ["EnglishAsk", "englishAsk", "evaluator"]
+      },
+      "checks": [
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/codex-notify.ts"],
+          "pattern": "runCodexNotify[\\s\\S]*ENGLISHASK_GUARD_ENV[\\s\\S]*readStdin",
+          "message": "Check `AGENTLOG_ENGLISHASK_EVAL` at the start of the notify entry point before reading stdin or forwarding."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/__tests__/**/*.ts"],
+          "pattern": "guarded evaluator child turns|without a notify argument|AGENTLOG_ENGLISHASK_EVAL",
+          "message": "Test that guarded evaluator child notify turns create no note, no forwarded notify, and no stdin wait."
+        }
+      ]
+    },
+    {
+      "id": "englishask-raw-evaluator-input",
+      "severity": "medium",
+      "title": "EnglishAsk evaluator must receive the raw prompt, not display formatting",
+      "appliesTo": {
+        "paths": ["src/**/*.ts"],
+        "diffIncludesAny": ["EnglishAsk", "englishAsk", "evaluator", "prettyPrompt"]
+      },
+      "checks": [
+        {
+          "type": "noneContentRegex",
+          "paths": ["src/codex-notify.ts"],
+          "pattern": "const\\s+prompt\\s*=\\s*prettyPrompt\\([^)]*\\)[\\s\\S]*evaluateEnglishAsk\\(config,\\s*prompt\\s*,",
+          "message": "Pass the raw parsed prompt to EnglishAsk; reserve `prettyPrompt(...)` for Daily Note display."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/__tests__/**/*.ts"],
+          "pattern": "raw prompt to EnglishAsk|logging the display prompt|User prompt:\\\\n\\$\\{prompt\\}",
+          "message": "Add a regression test proving the evaluator receives raw multi-line prompt text while the note logs the display prompt."
+        }
+      ]
+    },
+    {
+      "id": "englishask-cwd-fallback",
+      "severity": "medium",
+      "title": "EnglishAsk evaluator must tolerate unavailable notify cwd",
+      "appliesTo": {
+        "paths": ["src/**/*.ts"],
+        "diffIncludesAny": ["EnglishAsk", "englishAsk", "evaluator", "cwd"]
+      },
+      "checks": [
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/**/*.ts"],
+          "pattern": "statSync\\(|runnableCwd\\(|process\\.cwd\\(",
+          "message": "Do not run the evaluator blindly in notify `cwd`; fall back when that path is unavailable."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/__tests__/**/*.ts"],
+          "pattern": "notify cwd is unavailable|missing cwd|missing-cwd",
+          "message": "Add a regression test for unavailable notify cwd, matching CI/other-machine payloads."
+        }
+      ]
+    },
+    {
+      "id": "englishask-prompt-list-line",
+      "severity": "medium",
+      "title": "EnglishAsk prompt metadata must stay on one Markdown list line",
+      "appliesTo": {
+        "paths": ["src/**/*.ts"],
+        "diffIncludesAny": ["EnglishAsk", "englishAsk", "feedback.prompt", "[truncated]"]
+      },
+      "checks": [
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/**/*.ts"],
+          "pattern": "listItemValue\\(|replace\\(/\\\\s\\+/",
+          "message": "Flatten stored prompt metadata before writing it as a Markdown list item."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/__tests__/**/*.ts"],
+          "pattern": "one Markdown list line|\\[truncated\\]",
+          "message": "Add a regression test for truncated multi-line prompt metadata in `- prompt:`."
+        }
+      ]
+    },
+    {
+      "id": "englishask-section-insertion",
+      "severity": "medium",
+      "title": "EnglishAsk feedback must be inserted inside the existing section",
+      "appliesTo": {
+        "paths": ["src/**/*.ts"],
+        "diffIncludesAny": ["## EnglishAsk", "appendEnglishAskFeedback", "EnglishAsk"]
+      },
+      "checks": [
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/**/*.ts"],
+          "pattern": "insertFeedbackBlock\\(|nextHeading",
+          "message": "Insert new feedback before the next top-level heading after `## EnglishAsk`, not blindly at EOF."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/__tests__/**/*.ts"],
+          "pattern": "existing EnglishAsk section|immediately following top-level section|## Other",
+          "message": "Add regression tests proving new feedback lands inside `## EnglishAsk`, including when the next `##` heading follows immediately."
+        }
+      ]
+    },
+    {
+      "id": "englishask-feedback-fence-safety",
+      "severity": "medium",
+      "title": "EnglishAsk feedback must not escape its Markdown code fence",
+      "appliesTo": {
+        "paths": ["src/**/*.ts"],
+        "diffIncludesAny": ["EnglishAsk", "englishAsk", "feedback", "```"]
+      },
+      "checks": [
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/**/*.ts"],
+          "pattern": "codeFenceFor\\(|longestBacktickRun",
+          "message": "Use a dynamic fence longer than any backtick run in evaluator feedback."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/__tests__/**/*.ts"],
+          "pattern": "longer Markdown fence|## Injected",
+          "message": "Add a regression test with evaluator feedback containing ``` and a heading-like line."
+        }
+      ]
+    },
+    {
+      "id": "englishask-fail-soft",
+      "severity": "high",
+      "title": "EnglishAsk evaluator failures must not break AgentLog writes",
+      "appliesTo": {
+        "paths": ["src/**/*.ts"],
+        "diffIncludesAny": ["EnglishAsk", "englishAsk", "evaluator"]
+      },
+      "checks": [
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/__tests__/**/*.ts"],
+          "pattern": "EnglishAsk evaluator fails",
+          "message": "Add a regression test proving AgentLog still writes when EnglishAsk fails."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/__tests__/**/*.ts"],
+          "pattern": "times out",
+          "message": "Add a regression test for evaluator timeout handling."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/__tests__/**/*.ts"],
+          "pattern": "append failures silent",
+          "message": "Add a regression test proving EnglishAsk feedback append failures stay fail-soft."
+        }
+      ]
+    },
+    {
       "id": "plan-path-resolution-doc-contract",
       "severity": "medium",
       "title": "Plan docs must not describe unsafe config.vault string concatenation",

--- a/docs/review/review-list.json
+++ b/docs/review/review-list.json
@@ -152,6 +152,29 @@
       ]
     },
     {
+      "id": "cli-command-edge-thin",
+      "severity": "medium",
+      "title": "CLI command edge should not re-accumulate shared helpers",
+      "appliesTo": {
+        "paths": ["src/cli.ts", "src/cli-shared.ts", "docs/architecture/**/*.md"],
+        "diffIncludesAny": ["validateVault", "detectBinary", "printObsidianCliStatus", "cli-shared", "Command edge"]
+      },
+      "checks": [
+        {
+          "type": "noneContentRegex",
+          "paths": ["src/cli.ts"],
+          "pattern": "(?:function\\s+|(?:export\\s+)?const\\s+)(?:validateVault|validateVaultOrExit|saveMergedConfig|printSavedConfig|printObsidianCliStatus|detectBinary)\\b",
+          "message": "Keep reusable CLI support helpers out of `src/cli.ts`; put them in `src/cli-shared.ts` or a narrower application module."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["docs/architecture/cli-layering.md"],
+          "pattern": "Command edge[\\s\\S]*src/cli\\.ts[\\s\\S]*Application support[\\s\\S]*src/cli-shared\\.ts",
+          "message": "Document the CLI layer boundary when introducing or changing the shared CLI support module."
+        }
+      ]
+    },
+    {
       "id": "docs-session-divider-length",
       "severity": "medium",
       "title": "Documented source-prefixed session dividers must use full session ids",

--- a/docs/review/review-list.json
+++ b/docs/review/review-list.json
@@ -173,6 +173,64 @@
       ]
     },
     {
+      "id": "codex-uninstall-hook-error-handling",
+      "severity": "medium",
+      "title": "Codex hook uninstall must fail cleanly on malformed hooks.json",
+      "appliesTo": {
+        "paths": ["src/cli.ts", "src/codex-hooks.ts"],
+        "diffIncludesAny": ["unregisterCodexHook", "hooks.json", "uninstallCodex"]
+      },
+      "checks": [
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/cli.ts"],
+          "pattern": "function\\s+uninstallCodex[\\s\\S]*try\\s*\\{[\\s\\S]*unregisterCodexHook\\(",
+          "message": "Wrap `unregisterCodexHook()` during uninstall so malformed hooks.json exits cleanly instead of printing a stack trace."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/__tests__/**/*.ts"],
+          "pattern": "uninstall --codex exits cleanly when (?:Codex )?hooks\\.json is invalid",
+          "message": "Add a regression test for malformed Codex hooks.json during uninstall."
+        }
+      ]
+    },
+    {
+      "id": "codex-uninstall-legacy-notify-side-effects",
+      "severity": "medium",
+      "title": "Codex uninstall docs and output must include legacy notify cleanup",
+      "appliesTo": {
+        "paths": ["src/cli.ts", "README.md", "AGENTS.md"],
+        "diffIncludesAny": ["uninstall", "Codex hook", "legacy notify", "codexNotifyRestore"]
+      },
+      "checks": [
+        {
+          "type": "noneContentRegex",
+          "paths": ["src/cli.ts", "README.md", "AGENTS.md"],
+          "pattern": "Remove Codex hook only|Remove Codex hook from `~/.codex/hooks\\.json` only",
+          "message": "Do not imply Codex uninstall only touches hooks or always restores notify; it may remove an AgentLog-owned legacy notify entry."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/cli.ts"],
+          "pattern": "Legacy Codex notify (?:removed|\\$\\{action\\})",
+          "message": "Emit a distinct message when Codex uninstall removes an AgentLog-owned legacy notify entry instead of restoring a previous command."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["README.md", "AGENTS.md"],
+          "pattern": "legacy .*notify",
+          "message": "Document legacy Codex notify cleanup when documenting Codex uninstall."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/__tests__/**/*.ts"],
+          "pattern": "legacy notify removal|removes legacy notify",
+          "message": "Add a regression test for legacy notify removal when no restore command exists."
+        }
+      ]
+    },
+    {
       "id": "englishask-recursion-guard",
       "severity": "high",
       "title": "EnglishAsk evaluator must not recursively evaluate itself",

--- a/docs/review/review-list.json
+++ b/docs/review/review-list.json
@@ -105,6 +105,53 @@
       ]
     },
     {
+      "id": "daily-bootstrap-safe-creation",
+      "severity": "high",
+      "title": "Missing Obsidian Daily Notes must be bootstrapped through the CLI",
+      "appliesTo": {
+        "paths": ["src/note-writer.ts", "src/obsidian-cli.ts", "src/__tests__/note-writer.test.ts", "README.md", "AGENTS.md", "llms.txt", "docs/**/*.md"],
+        "diffIncludesAny": ["dailyNotePath", "cliEnsureDailyNoteExists", "daily:path", "Daily Note", "bootstrap"]
+      },
+      "checks": [
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/obsidian-cli.ts"],
+          "pattern": "function\\s+cliEnsureDailyNoteExists[\\s\\S]*\\[\"daily\"\\]",
+          "message": "Add an Obsidian CLI bootstrap helper that runs `obsidian daily`, not only `daily:path`."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/obsidian-cli.ts"],
+          "pattern": "DAILY_BOOTSTRAP_TIMEOUT_MS[\\s\\S]*CLI_PROBE_TIMEOUT_MS|CLI_PROBE_TIMEOUT_MS[\\s\\S]*DAILY_BOOTSTRAP_TIMEOUT_MS",
+          "message": "Keep a distinct longer timeout for `obsidian daily` bootstrap than for lightweight CLI probes."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/__tests__/obsidian-cli.test.ts"],
+          "pattern": "DAILY_BOOTSTRAP_TIMEOUT_MS\\)\\.toBeGreaterThan\\(CLI_PROBE_TIMEOUT_MS",
+          "message": "Test that Daily bootstrap timeout stays longer than lightweight probe timeout."
+        },
+        {
+          "type": "noneContentRegex",
+          "paths": ["src/note-writer.ts"],
+          "pattern": "return\\s+join\\(config\\.vault,\\s*\"Daily\",\\s*dailyNoteFileName\\(",
+          "message": "Do not create a guessed `{vault}/Daily/...` fallback in Obsidian mode when no safe path source is available."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/__tests__/note-writer.test.ts"],
+          "pattern": "bootstraps a missing Daily Note through Obsidian before appending",
+          "message": "Add a regression test proving missing notes are created through Obsidian before AgentLog writes."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/__tests__/note-writer.test.ts"],
+          "pattern": "does not create a guessed fallback file when no safe path resolves",
+          "message": "Add a regression test proving unsafe fallback creation is skipped."
+        }
+      ]
+    },
+    {
       "id": "docs-session-divider-length",
       "severity": "medium",
       "title": "Documented source-prefixed session dividers must use full session ids",

--- a/docs/review/review-list.json
+++ b/docs/review/review-list.json
@@ -311,7 +311,7 @@
       "severity": "high",
       "title": "Claude hook matcher must use the string format",
       "appliesTo": {
-        "paths": ["src/claude-settings.ts", "src/cli.ts", "src/__tests__/cli.test.ts", "README.md", "AGENTS.md", "docs/cc/**/*.md", "docs/review/SELF_REVIEW.md"],
+        "paths": ["src/claude-settings.ts", "src/cli.ts", "src/types.ts", "src/__tests__/cli.test.ts", "src/__tests__/cli-codex.test.ts", "README.md", "AGENTS.md", "docs/cc/**/*.md", "docs/review/SELF_REVIEW.md"],
         "diffIncludesAny": ["HOOK_ENTRY", "matcher", "Claude Code", "UserPromptSubmit", "agentlog hook"]
       },
       "checks": [
@@ -338,6 +338,18 @@
           "paths": ["src/__tests__/cli.test.ts"],
           "pattern": "stale AgentLog hook matcher object[\\s\\S]*matcher must be a string",
           "message": "Add regression coverage for stale object matcher migration and doctor failure."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/cli.ts"],
+          "pattern": "hasClaudeHookMetadata[\\s\\S]*hookState\\.kind === \"missing\"[\\s\\S]*!hasClaudeHookMetadata",
+          "message": "Do not use generic Codex relevance to downgrade missing Claude hook failures; require explicit Codex-only metadata."
+        },
+        {
+          "type": "anyContentRegex",
+          "paths": ["src/__tests__/cli-codex.test.ts"],
+          "pattern": "expects both hooks but the Claude hook is missing",
+          "message": "Add a regression test for `--all`/both-hook installs where the Claude hook is missing."
         },
         {
           "type": "anyContentRegex",

--- a/llms.txt
+++ b/llms.txt
@@ -79,9 +79,11 @@ Fields:
 - `vault` (required): absolute path to Obsidian vault or plain folder
 - `plain` (optional): if true, writes simple YYYY-MM-DD.md files
 - `codexNotifyRestore` (optional): saved previous Codex notify value, restored on uninstall
+- `englishAsk` (optional): Codex prompt evaluator config. Disabled unless `englishAsk.enabled` is true. Results append under `## EnglishAsk`.
 
 Environment variables:
 - `AGENTLOG_CONFIG_DIR`: override config directory (default: `~/.agentlog`)
+- `AGENTLOG_ENGLISHASK_EVAL`: internal guard that skips EnglishAsk evaluator child notify turns
 - `AGENTLOG_PHASE`: force channel `dev` or `prod`
 - `OBSIDIAN_BIN`: override Obsidian CLI binary path
 

--- a/llms.txt
+++ b/llms.txt
@@ -97,10 +97,10 @@ Obsidian mode appends to a `## AgentLog` section, grouped by working directory:
 
 #### 10:53 · js/agentlog
 <!-- cwd=/Users/you/work/js/agentlog -->
-- - - - [[claude_a1b2c3d4]]
+- - - - [[claude_a1b2c3d4-1111-2222-3333-444455556666]]
 - 10:53 start building agentlog
 - 11:07 open the spec document
-- - - - [[claude_e5f6a7b8]]
+- - - - [[claude_e5f6a7b8-1111-2222-3333-444455556666]]
 - 11:21 initialize git
 ```
 

--- a/llms.txt
+++ b/llms.txt
@@ -112,12 +112,14 @@ Plain mode appends to `{folder}/YYYY-MM-DD.md`:
 ```
 
 Daily Note path resolution order:
-1. `obsidian daily:path` (Obsidian CLI 1.12.4+, app must be running)
-2. Fallback: `{vault}/Daily/YYYY-MM-DD-<weekday>.md`
+1. `.obsidian/daily-notes.json` when it contains a supported in-vault folder/format
+2. `obsidian daily:path` (Obsidian CLI 1.12.4+, app must be running)
+
+In Obsidian mode, missing Daily Notes are bootstrapped with `obsidian daily` before AgentLog writes so user templates are preserved. AgentLog does not create a guessed `{vault}/Daily/...` fallback file when no safe path or bootstrap is available. Plain mode still writes directly to `{dir}/YYYY-MM-DD.md`.
 
 ## How the Hook Works
 
-Claude Code fires `UserPromptSubmit` with JSON on stdin containing `prompt`, `session_id`, and `cwd`. AgentLog sanitizes the prompt, resolves the Daily Note path, and appends the entry. Fails silently — never interrupts Claude Code. Total overhead: under 50ms per prompt.
+Claude Code fires `UserPromptSubmit` with JSON on stdin containing `prompt`, `session_id`, and `cwd`. AgentLog sanitizes the prompt, resolves the Daily Note path, and appends the entry. Fails silently — never interrupts Claude Code. Steady-state overhead is under 50ms when the Daily Note already exists; missing-note bootstrap depends on Obsidian CLI startup.
 
 Codex fires `agent-turn-complete` notify. Entries are logged when the turn completes (not at prompt submission time).
 

--- a/llms.txt
+++ b/llms.txt
@@ -23,7 +23,7 @@ agentlog init --all ~/path/to/vault    # Both
 agentlog init --plain ~/notes          # Plain folder (no Obsidian)
 ```
 
-`init` writes `~/.agentlog/config.json` and registers the hook in `~/.claude/settings.json` (Claude) or `~/.codex/config.toml` (Codex). The `agentlog` binary must remain in PATH after setup.
+`init` writes `~/.agentlog/config.json` and registers the hook in `~/.claude/settings.json` (Claude) or `~/.codex/hooks.json` (Codex). The `agentlog` binary must remain in PATH after setup.
 
 Run without arguments for interactive vault auto-detection.
 
@@ -71,6 +71,8 @@ agentlog codex-notify (internal — called by Codex, not by users)
 {
   "vault": "/Users/you/Obsidian",
   "plain": false,
+  "claudeHookInstalled": true,
+  "codexHookInstalled": true,
   "codexNotifyRestore": null
 }
 ```
@@ -78,6 +80,8 @@ agentlog codex-notify (internal — called by Codex, not by users)
 Fields:
 - `vault` (required): absolute path to Obsidian vault or plain folder
 - `plain` (optional): if true, writes simple YYYY-MM-DD.md files
+- `claudeHookInstalled` (optional): marks that AgentLog expects the Claude hook to be installed
+- `codexHookInstalled` (optional): marks that AgentLog expects the Codex hook to be installed
 - `codexNotifyRestore` (optional): saved previous Codex notify value, restored on uninstall
 - `englishAsk` (optional): Codex prompt evaluator config. Disabled unless `englishAsk.enabled` is true. Results append under `## EnglishAsk`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@albireo3754/agentlog",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "Auto-log Claude Code prompts to Obsidian Daily Notes",
   "type": "module",
   "bin": {

--- a/src/__tests__/cli-codex.test.ts
+++ b/src/__tests__/cli-codex.test.ts
@@ -91,6 +91,25 @@ function findPlainNotePath(vault: string): string {
   return join(vault, file);
 }
 
+function readCodexHooks(home: string): Record<string, unknown> {
+  return JSON.parse(readFileSync(join(home, ".codex", "hooks.json"), "utf-8"));
+}
+
+function writeAgentlogCodexHook(home: string): void {
+  mkdirSync(join(home, ".codex"), { recursive: true });
+  writeFileSync(
+    join(home, ".codex", "hooks.json"),
+    JSON.stringify({
+      hooks: {
+        UserPromptSubmit: [
+          { hooks: [{ type: "command", command: "agentlog hook --source codex" }] },
+        ],
+      },
+    }),
+    "utf-8"
+  );
+}
+
 describe("cli codex commands", () => {
   let tmpHome: string;
 
@@ -102,7 +121,7 @@ describe("cli codex commands", () => {
     rmSync(tmpHome, { recursive: true, force: true });
   });
 
-  it("init --codex creates a top-level notify when Codex config has none", async () => {
+  it("init --codex creates a UserPromptSubmit hook in Codex hooks.json", async () => {
     const vault = join(tmpHome, "Obsidian");
     const cfgDir = join(tmpHome, ".agentlog");
     const pathWithCodex = makeFakeCodexPath(tmpHome);
@@ -118,20 +137,34 @@ describe("cli codex commands", () => {
 
     expect(exitCode).toBe(0);
     expect(stderr).toBe("");
-    expect(stdout).toContain("Codex");
-    expect(readFileSync(join(tmpHome, ".codex", "config.toml"), "utf-8")).toContain(
-      'notify = ["agentlog", "codex-notify"]'
-    );
+    expect(stdout).toContain("Codex hook registered");
+    expect(readCodexHooks(tmpHome)).toEqual({
+      hooks: {
+        UserPromptSubmit: [
+          { hooks: [{ type: "command", command: "agentlog hook --source codex" }] },
+        ],
+      },
+    });
+    expect(readFileSync(join(tmpHome, ".codex", "config.toml"), "utf-8")).not.toContain("agentlog\", \"codex-notify");
     expect(existsSync(join(tmpHome, ".claude", "settings.json"))).toBe(false);
   });
 
-  it("init --codex preserves an existing notify command for forward chaining", async () => {
+  it("init --codex preserves existing Codex hooks and records hook metadata", async () => {
     const vault = join(tmpHome, "Obsidian");
     const cfgDir = join(tmpHome, ".agentlog");
     const pathWithCodex = makeFakeCodexPath(tmpHome);
     mkdirSync(join(vault, ".obsidian"), { recursive: true });
     mkdirSync(join(tmpHome, ".codex"), { recursive: true });
-    writeFileSync(join(tmpHome, ".codex", "config.toml"), fixture("codex-config-existing-notify.toml"), "utf-8");
+    writeFileSync(
+      join(tmpHome, ".codex", "hooks.json"),
+      JSON.stringify({
+        hooks: {
+          Stop: [{ hooks: [{ type: "command", command: "echo stop" }] }],
+          UserPromptSubmit: [{ hooks: [{ type: "command", command: "echo prompt" }] }],
+        },
+      }),
+      "utf-8"
+    );
 
     const { exitCode } = await runCli(["init", "--codex", vault], {
       HOME: tmpHome,
@@ -140,29 +173,29 @@ describe("cli codex commands", () => {
     });
 
     expect(exitCode).toBe(0);
-    expect(readFileSync(join(tmpHome, ".codex", "config.toml"), "utf-8")).toContain(
-      'notify = ["agentlog", "codex-notify"]'
-    );
+    const hooks = readCodexHooks(tmpHome) as { hooks: { Stop: unknown[]; UserPromptSubmit: unknown[] } };
+    expect(hooks.hooks.Stop).toHaveLength(1);
+    expect(hooks.hooks.UserPromptSubmit).toHaveLength(2);
     const config = JSON.parse(readFileSync(join(cfgDir, "config.json"), "utf-8"));
-    expect(config.codexNotifyRestore).toEqual(["node", "/tmp/existing-notify.js"]);
+    expect(config.codexHookInstalled).toBe(true);
   });
 
-  it("init --codex aborts on unsupported multi-line notify arrays", async () => {
+  it("init --codex aborts on unsupported hooks.json", async () => {
     const vault = join(tmpHome, "Obsidian");
     const cfgDir = join(tmpHome, ".agentlog");
     const pathWithCodex = makeFakeCodexPath(tmpHome);
     mkdirSync(join(vault, ".obsidian"), { recursive: true });
     mkdirSync(join(tmpHome, ".codex"), { recursive: true });
-    writeFileSync(join(tmpHome, ".codex", "config.toml"), fixture("codex-config-unsupported-notify.toml"), "utf-8");
+    writeFileSync(join(tmpHome, ".codex", "hooks.json"), "{bad", "utf-8");
 
-    const { stderr, exitCode } = await runCli(["init", "--codex", vault], {
+    const { stdout, stderr, exitCode } = await runCli(["init", "--codex", vault], {
       HOME: tmpHome,
       AGENTLOG_CONFIG_DIR: cfgDir,
       PATH: pathWithCodex,
     });
 
     expect(exitCode).not.toBe(0);
-    expect(stderr).toContain("Unsupported notify");
+    expect(stdout + stderr).toContain("hooks.json is invalid JSON");
   });
 
   it("init --codex fails when Codex CLI is not installed", async () => {
@@ -192,7 +225,7 @@ describe("cli codex commands", () => {
     expect(exitCode).toBe(0);
     expect(stdout).toContain("Hook registered");
     expect(existsSync(join(tmpHome, ".claude", "settings.json"))).toBe(true);
-    expect(existsSync(join(tmpHome, ".codex", "config.toml"))).toBe(false);
+    expect(existsSync(join(tmpHome, ".codex", "hooks.json"))).toBe(false);
   });
 
   it("legacy codex-init command is rejected", async () => {
@@ -205,13 +238,12 @@ describe("cli codex commands", () => {
     expect(stdout + stderr).toContain("Usage:");
   });
 
-  it("init --all installs both the Claude hook and Codex notify", async () => {
+  it("init --all installs both the Claude hook and Codex hook", async () => {
     const vault = join(tmpHome, "Obsidian");
     const cfgDir = join(tmpHome, ".agentlog");
     const pathWithCodex = makeFakeCodexPath(tmpHome);
     mkdirSync(join(vault, ".obsidian"), { recursive: true });
     mkdirSync(join(tmpHome, ".codex"), { recursive: true });
-    writeFileSync(join(tmpHome, ".codex", "config.toml"), fixture("codex-config-no-notify.toml"), "utf-8");
 
     const { stdout, stderr, exitCode } = await runCli(["init", "--all", vault], {
       HOME: tmpHome,
@@ -222,11 +254,15 @@ describe("cli codex commands", () => {
     expect(exitCode).toBe(0);
     expect(stderr).toBe("");
     expect(stdout).toContain("Hook registered");
-    expect(stdout).toContain("Codex notify registered");
+    expect(stdout).toContain("Codex hook registered");
     expect(existsSync(join(tmpHome, ".claude", "settings.json"))).toBe(true);
-    expect(readFileSync(join(tmpHome, ".codex", "config.toml"), "utf-8")).toContain(
-      'notify = ["agentlog", "codex-notify"]'
-    );
+    expect(readCodexHooks(tmpHome)).toEqual({
+      hooks: {
+        UserPromptSubmit: [
+          { hooks: [{ type: "command", command: "agentlog hook --source codex" }] },
+        ],
+      },
+    });
   });
 
   it("codex-notify writes a Daily Note entry and forwards the saved notify command", async () => {
@@ -509,24 +545,47 @@ describe("cli codex commands", () => {
     expect(content).not.toContain("## EnglishAsk");
   });
 
+  it("agentlog hook --source codex writes a Codex-sourced Daily Note entry", async () => {
+    const vault = join(tmpHome, "notes");
+    const cfgDir = join(tmpHome, ".agentlog");
+    mkdirSync(vault, { recursive: true });
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(
+      join(cfgDir, "config.json"),
+      JSON.stringify({ vault, plain: true, codexHookInstalled: true }),
+      "utf-8"
+    );
+
+    const raw = fixture("codex-hook-user-prompt-submit.json");
+    const proc = Bun.spawn([BUN_BIN, "run", CLI_PATH, "hook", "--source", "codex"], {
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, HOME: tmpHome, AGENTLOG_CONFIG_DIR: cfgDir },
+    });
+    proc.stdin.write(raw);
+    proc.stdin.end();
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe("");
+    expect(stderr).toBe("");
+    expect(readFileSync(findPlainNotePath(vault), "utf-8")).toContain("Reply with exactly: OK");
+  });
+
   it("legacy codex-uninstall command is rejected", async () => {
     const vault = join(tmpHome, "notes");
     const cfgDir = join(tmpHome, ".agentlog");
     mkdirSync(vault, { recursive: true });
     mkdirSync(cfgDir, { recursive: true });
-    mkdirSync(join(tmpHome, ".codex"), { recursive: true });
-    writeFileSync(
-      join(tmpHome, ".codex", "config.toml"),
-      'notify = ["agentlog", "codex-notify"]\nmodel = "gpt-5.4"\n',
-      "utf-8"
-    );
+    writeAgentlogCodexHook(tmpHome);
     writeFileSync(
       join(cfgDir, "config.json"),
-      JSON.stringify({
-        vault,
-        plain: true,
-        codexNotifyRestore: ["node", "/tmp/existing-notify.js"],
-      }),
+      JSON.stringify({ vault, plain: true, codexHookInstalled: true }),
       "utf-8"
     );
 
@@ -539,9 +598,10 @@ describe("cli codex commands", () => {
     expect(stdout + stderr).toContain("Usage:");
   });
 
-  it("uninstall --codex restores Codex notify and keeps Claude hook plus shared config", async () => {
+  it("uninstall --codex removes Codex hook and keeps Claude hook plus shared config", async () => {
     const vault = join(tmpHome, "notes");
     const cfgDir = join(tmpHome, ".agentlog");
+    const marker = join(tmpHome, "forwarded-restored.txt");
     mkdirSync(vault, { recursive: true });
     mkdirSync(cfgDir, { recursive: true });
     mkdirSync(join(tmpHome, ".claude"), { recursive: true });
@@ -557,41 +617,89 @@ describe("cli codex commands", () => {
       }),
       "utf-8"
     );
-    writeFileSync(
-      join(tmpHome, ".codex", "config.toml"),
-      'notify = ["agentlog", "codex-notify"]\nmodel = "gpt-5.4"\n',
-      "utf-8"
-    );
+    writeAgentlogCodexHook(tmpHome);
+    writeFileSync(join(tmpHome, ".codex", "config.toml"), 'notify = ["agentlog", "codex-notify"]\n', "utf-8");
     writeFileSync(
       join(cfgDir, "config.json"),
       JSON.stringify({
         vault,
         plain: true,
-        codexNotifyRestore: ["node", "/tmp/existing-notify.js"],
+        codexHookInstalled: true,
+        codexNotifyRestore: ["sh", "-lc", `printf restored > '${marker}'`],
       }),
       "utf-8"
     );
 
-    const { exitCode } = await runCli(["uninstall", "--codex", "-y"], {
+    const { stdout, exitCode } = await runCli(["uninstall", "--codex", "-y"], {
       HOME: tmpHome,
       AGENTLOG_CONFIG_DIR: cfgDir,
     });
 
     expect(exitCode).toBe(0);
+    expect(stdout).toContain(`Legacy Codex notify restored: ${join(tmpHome, ".codex", "config.toml")}`);
+    expect(existsSync(join(tmpHome, ".codex", "hooks.json"))).toBe(false);
     expect(readFileSync(join(tmpHome, ".codex", "config.toml"), "utf-8")).toContain(
-      'notify = ["node", "/tmp/existing-notify.js"]'
+      `notify = ["sh", "-lc", "printf restored > '${marker}'"]`
     );
     expect(existsSync(join(tmpHome, ".claude", "settings.json"))).toBe(true);
     expect(existsSync(join(cfgDir, "config.json"))).toBe(true);
+    const config = JSON.parse(readFileSync(join(cfgDir, "config.json"), "utf-8"));
+    expect(config.codexHookInstalled).toBeUndefined();
   });
 
-  it("uninstall --all removes Claude state and restores the previous Codex notify command", async () => {
+  it("uninstall --codex reports when it removes legacy notify without a saved restore command", async () => {
+    const vault = join(tmpHome, "notes");
+    const cfgDir = join(tmpHome, ".agentlog");
+    mkdirSync(vault, { recursive: true });
+    mkdirSync(cfgDir, { recursive: true });
+    mkdirSync(join(tmpHome, ".codex"), { recursive: true });
+    writeAgentlogCodexHook(tmpHome);
+    writeFileSync(join(tmpHome, ".codex", "config.toml"), 'notify = ["agentlog", "codex-notify"]\n', "utf-8");
+    writeFileSync(
+      join(cfgDir, "config.json"),
+      JSON.stringify({ vault, plain: true, codexHookInstalled: true }),
+      "utf-8"
+    );
+
+    const { stdout, exitCode } = await runCli(["uninstall", "--codex", "-y"], {
+      HOME: tmpHome,
+      AGENTLOG_CONFIG_DIR: cfgDir,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain(`Legacy Codex notify removed: ${join(tmpHome, ".codex", "config.toml")}`);
+    expect(readFileSync(join(tmpHome, ".codex", "config.toml"), "utf-8")).not.toContain("agentlog");
+  });
+
+  it("uninstall --codex exits cleanly when hooks.json is invalid", async () => {
+    const vault = join(tmpHome, "notes");
+    const cfgDir = join(tmpHome, ".agentlog");
+    mkdirSync(vault, { recursive: true });
+    mkdirSync(cfgDir, { recursive: true });
+    mkdirSync(join(tmpHome, ".codex"), { recursive: true });
+    writeFileSync(join(tmpHome, ".codex", "hooks.json"), "{bad", "utf-8");
+    writeFileSync(
+      join(cfgDir, "config.json"),
+      JSON.stringify({ vault, plain: true, codexHookInstalled: true }),
+      "utf-8"
+    );
+
+    const { stdout, stderr, exitCode } = await runCli(["uninstall", "--codex", "-y"], {
+      HOME: tmpHome,
+      AGENTLOG_CONFIG_DIR: cfgDir,
+    });
+
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toBe("");
+    expect(stderr).toBe("Unsupported Codex hooks configuration: hooks.json is invalid JSON\n");
+  });
+
+  it("uninstall --all removes Claude state and Codex hook", async () => {
     const vault = join(tmpHome, "notes");
     const cfgDir = join(tmpHome, ".agentlog");
     mkdirSync(vault, { recursive: true });
     mkdirSync(cfgDir, { recursive: true });
     mkdirSync(join(tmpHome, ".claude"), { recursive: true });
-    mkdirSync(join(tmpHome, ".codex"), { recursive: true });
     writeFileSync(
       join(tmpHome, ".claude", "settings.json"),
       JSON.stringify({
@@ -603,18 +711,10 @@ describe("cli codex commands", () => {
       }),
       "utf-8"
     );
-    writeFileSync(
-      join(tmpHome, ".codex", "config.toml"),
-      'notify = ["agentlog", "codex-notify"]\nmodel = "gpt-5.4"\n',
-      "utf-8"
-    );
+    writeAgentlogCodexHook(tmpHome);
     writeFileSync(
       join(cfgDir, "config.json"),
-      JSON.stringify({
-        vault,
-        plain: true,
-        codexNotifyRestore: ["node", "/tmp/existing-notify.js"],
-      }),
+      JSON.stringify({ vault, plain: true, codexHookInstalled: true }),
       "utf-8"
     );
 
@@ -624,32 +724,21 @@ describe("cli codex commands", () => {
     });
 
     expect(exitCode).toBe(0);
-    expect(readFileSync(join(tmpHome, ".codex", "config.toml"), "utf-8")).toContain(
-      'notify = ["node", "/tmp/existing-notify.js"]'
-    );
+    expect(existsSync(join(tmpHome, ".codex", "hooks.json"))).toBe(false);
     expect(existsSync(join(tmpHome, ".claude", "settings.json"))).toBe(false);
     expect(existsSync(join(cfgDir, "config.json"))).toBe(false);
   });
 
-  it("doctor succeeds when Codex notify is installed", async () => {
+  it("doctor succeeds when Codex hook is installed", async () => {
     const vault = join(tmpHome, "notes");
     const cfgDir = join(tmpHome, ".agentlog");
     const pathWithCodex = makeFakeCodexPath(tmpHome);
     mkdirSync(vault, { recursive: true });
     mkdirSync(cfgDir, { recursive: true });
-    mkdirSync(join(tmpHome, ".codex"), { recursive: true });
-    writeFileSync(
-      join(tmpHome, ".codex", "config.toml"),
-      'notify = ["agentlog", "codex-notify"]\nmodel = "gpt-5.4"\n',
-      "utf-8"
-    );
+    writeAgentlogCodexHook(tmpHome);
     writeFileSync(
       join(cfgDir, "config.json"),
-      JSON.stringify({
-        vault,
-        plain: true,
-        codexNotifyRestore: null,
-      }),
+      JSON.stringify({ vault, plain: true, codexHookInstalled: true }),
       "utf-8"
     );
 
@@ -661,24 +750,19 @@ describe("cli codex commands", () => {
 
     expect(exitCode).toBe(0);
     expect(stdout).toContain("codex");
-    expect(stdout).toContain("notify");
+    expect(stdout).toContain("hook registered");
   });
 
-  it("doctor fails for partial damage when AgentLog config exists but Codex notify is missing", async () => {
+  it("doctor fails for partial damage when AgentLog config expects Codex hook but it is missing", async () => {
     const vault = join(tmpHome, "notes");
     const cfgDir = join(tmpHome, ".agentlog");
     const pathWithCodex = makeFakeCodexPath(tmpHome);
     mkdirSync(vault, { recursive: true });
     mkdirSync(cfgDir, { recursive: true });
     mkdirSync(join(tmpHome, ".codex"), { recursive: true });
-    writeFileSync(join(tmpHome, ".codex", "config.toml"), fixture("codex-config-no-notify.toml"), "utf-8");
     writeFileSync(
       join(cfgDir, "config.json"),
-      JSON.stringify({
-        vault,
-        plain: true,
-        codexNotifyRestore: ["node", "/tmp/existing-notify.js"],
-      }),
+      JSON.stringify({ vault, plain: true, codexHookInstalled: true }),
       "utf-8"
     );
 
@@ -693,20 +777,15 @@ describe("cli codex commands", () => {
     expect(stdout).toContain("inconsistent");
   });
 
-  it("doctor fails when Codex notify is not registered", async () => {
+  it("doctor ignores Codex checks when no Codex integration is configured", async () => {
     const vault = join(tmpHome, "notes");
     const cfgDir = join(tmpHome, ".agentlog");
     const pathWithCodex = makeFakeCodexPath(tmpHome);
     mkdirSync(vault, { recursive: true });
     mkdirSync(cfgDir, { recursive: true });
-    mkdirSync(join(tmpHome, ".codex"), { recursive: true });
-    writeFileSync(join(tmpHome, ".codex", "config.toml"), fixture("codex-config-no-notify.toml"), "utf-8");
     writeFileSync(
       join(cfgDir, "config.json"),
-      JSON.stringify({
-        vault,
-        plain: true,
-      }),
+      JSON.stringify({ vault, plain: true }),
       "utf-8"
     );
 
@@ -717,25 +796,21 @@ describe("cli codex commands", () => {
     });
 
     expect(exitCode).not.toBe(0);
-    expect(stdout).toContain("not registered");
-    expect(stdout).not.toContain("inconsistent");
+    expect(stdout).toContain("hook       not registered");
+    expect(stdout).not.toContain("codex-bin");
   });
 
-  it("doctor reports unsupported top-level multiline notify config", async () => {
+  it("doctor reports unsupported Codex hooks.json", async () => {
     const vault = join(tmpHome, "notes");
     const cfgDir = join(tmpHome, ".agentlog");
     const pathWithCodex = makeFakeCodexPath(tmpHome);
     mkdirSync(vault, { recursive: true });
     mkdirSync(cfgDir, { recursive: true });
     mkdirSync(join(tmpHome, ".codex"), { recursive: true });
-    writeFileSync(join(tmpHome, ".codex", "config.toml"), fixture("codex-config-unsupported-notify.toml"), "utf-8");
+    writeFileSync(join(tmpHome, ".codex", "hooks.json"), "{bad", "utf-8");
     writeFileSync(
       join(cfgDir, "config.json"),
-      JSON.stringify({
-        vault,
-        plain: true,
-        codexNotifyRestore: ["node", "/tmp/existing-notify.js"],
-      }),
+      JSON.stringify({ vault, plain: true, codexHookInstalled: true }),
       "utf-8"
     );
 

--- a/src/__tests__/cli-codex.test.ts
+++ b/src/__tests__/cli-codex.test.ts
@@ -9,7 +9,7 @@ const CLI_PATH = fileURLToPath(new URL("../cli.ts", import.meta.url));
 
 async function runCli(
   args: string[],
-  opts: { HOME?: string; AGENTLOG_CONFIG_DIR?: string; PATH?: string } = {}
+  opts: { HOME?: string; AGENTLOG_CONFIG_DIR?: string; PATH?: string; AGENTLOG_ENGLISHASK_EVAL?: string } = {}
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   const env = { ...process.env, ...opts };
   const proc = Bun.spawn(
@@ -48,6 +48,39 @@ function makeFakeCodexPath(home: string): string {
     chmodSync(bin, 0o755);
   }
   return `${binDir}:${process.env.PATH ?? "/usr/bin:/bin"}`;
+}
+
+function makeFakeEnglishAskEvaluator(home: string): { command: string[]; inputPath: string } {
+  const script = join(home, "englishask-eval.sh");
+  const inputPath = join(home, "englishask-input.txt");
+  writeFileSync(
+    script,
+    `#!/bin/sh
+test "$AGENTLOG_ENGLISHASK_EVAL" = "1" || exit 7
+cat > "$1"
+printf 'Score: 3/5\\nNatural version: Reply with exactly OK.\\nMissing context: none\\nRewrite with: exact expected output\\n'
+`,
+    "utf-8"
+  );
+  chmodSync(script, 0o755);
+  return { command: [script, inputPath], inputPath };
+}
+
+function makeReadonlyNoteEnglishAskEvaluator(home: string, vault: string): { command: string[]; inputPath: string } {
+  const script = join(home, "englishask-readonly-note.sh");
+  const inputPath = join(home, "englishask-readonly-input.txt");
+  writeFileSync(
+    script,
+    `#!/bin/sh
+test "$AGENTLOG_ENGLISHASK_EVAL" = "1" || exit 7
+cat > "$1"
+chmod 444 "$2"/*.md || exit 8
+printf '%s\\n' 'Score: 3/5' 'Natural version: Reply with exactly OK.' 'Missing context: none' 'Rewrite with: exact expected output'
+`,
+    "utf-8"
+  );
+  chmodSync(script, 0o755);
+  return { command: [script, inputPath, vault], inputPath };
 }
 
 function findPlainNotePath(vault: string): string {
@@ -278,6 +311,202 @@ describe("cli codex commands", () => {
     expect(exitCode).toBe(0);
     expect(readdirSync(vault).some((name) => /^\d{4}-\d{2}-\d{2}\.md$/.test(name))).toBe(false);
     expect(existsSync(marker)).toBe(true);
+  });
+
+  it("codex-notify appends EnglishAsk feedback when enabled", async () => {
+    const vault = join(tmpHome, "notes");
+    const cfgDir = join(tmpHome, ".agentlog");
+    const evaluator = makeFakeEnglishAskEvaluator(tmpHome);
+    mkdirSync(vault, { recursive: true });
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(
+      join(cfgDir, "config.json"),
+      JSON.stringify({
+        vault,
+        plain: true,
+        englishAsk: {
+          enabled: true,
+          mode: "log-only",
+          evaluatorCommand: evaluator.command,
+        },
+      }),
+      "utf-8"
+    );
+
+    const raw = fixture("codex-notify-single.json");
+    const { exitCode, stderr } = await runCli(["codex-notify", raw], {
+      HOME: tmpHome,
+      AGENTLOG_CONFIG_DIR: cfgDir,
+    });
+
+    const content = readFileSync(findPlainNotePath(vault), "utf-8");
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(content).toContain("Reply with exactly: OK");
+    expect(content).toContain("## EnglishAsk");
+    expect(content).toContain("- score: 3/5");
+    expect(readFileSync(evaluator.inputPath, "utf-8")).toContain("User prompt:\nReply with exactly: OK");
+  });
+
+  it("codex-notify evaluates the raw prompt to EnglishAsk while logging a pretty prompt", async () => {
+    const vault = join(tmpHome, "notes");
+    const cfgDir = join(tmpHome, ".agentlog");
+    const evaluator = makeFakeEnglishAskEvaluator(tmpHome);
+    mkdirSync(vault, { recursive: true });
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(
+      join(cfgDir, "config.json"),
+      JSON.stringify({
+        vault,
+        plain: true,
+        englishAsk: {
+          enabled: true,
+          mode: "log-only",
+          evaluatorCommand: evaluator.command,
+        },
+      }),
+      "utf-8"
+    );
+
+    const raw = JSON.stringify({
+      type: "agent-turn-complete",
+      "thread-id": "thread-raw-prompt",
+      cwd: "/Users/pray/Obsidian",
+      "input-messages": ["Line one\nLine two\nLine three"],
+    });
+    const { exitCode, stderr } = await runCli(["codex-notify", raw], {
+      HOME: tmpHome,
+      AGENTLOG_CONFIG_DIR: cfgDir,
+    });
+
+    const content = readFileSync(findPlainNotePath(vault), "utf-8");
+    const evaluatorInput = readFileSync(evaluator.inputPath, "utf-8");
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(content).toContain("Line one (+1 lines) Line three");
+    expect(evaluatorInput).toContain("User prompt:\nLine one\nLine two\nLine three");
+  });
+
+  it("codex-notify skips guarded evaluator child turns without forwarding", async () => {
+    const vault = join(tmpHome, "notes");
+    const cfgDir = join(tmpHome, ".agentlog");
+    const marker = join(tmpHome, "forwarded-guarded.txt");
+    mkdirSync(vault, { recursive: true });
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(
+      join(cfgDir, "config.json"),
+      JSON.stringify({
+        vault,
+        plain: true,
+        codexNotifyRestore: ["sh", "-lc", `printf forwarded > '${marker}'`],
+        englishAsk: {
+          enabled: true,
+        },
+      }),
+      "utf-8"
+    );
+
+    const raw = fixture("codex-notify-single.json");
+    const { exitCode, stderr } = await runCli(["codex-notify", raw], {
+      HOME: tmpHome,
+      AGENTLOG_CONFIG_DIR: cfgDir,
+      AGENTLOG_ENGLISHASK_EVAL: "1",
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(readdirSync(vault).some((name) => /^\d{4}-\d{2}-\d{2}\.md$/.test(name))).toBe(false);
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  it("codex-notify exits immediately for guarded child turns without a notify argument", async () => {
+    const vault = join(tmpHome, "notes");
+    const cfgDir = join(tmpHome, ".agentlog");
+    mkdirSync(vault, { recursive: true });
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(
+      join(cfgDir, "config.json"),
+      JSON.stringify({
+        vault,
+        plain: true,
+        englishAsk: {
+          enabled: true,
+        },
+      }),
+      "utf-8"
+    );
+
+    const { exitCode, stderr } = await runCli(["codex-notify"], {
+      HOME: tmpHome,
+      AGENTLOG_CONFIG_DIR: cfgDir,
+      AGENTLOG_ENGLISHASK_EVAL: "1",
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(readdirSync(vault).some((name) => /^\d{4}-\d{2}-\d{2}\.md$/.test(name))).toBe(false);
+  });
+
+  it("codex-notify still writes the note when EnglishAsk evaluator fails", async () => {
+    const vault = join(tmpHome, "notes");
+    const cfgDir = join(tmpHome, ".agentlog");
+    mkdirSync(vault, { recursive: true });
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(
+      join(cfgDir, "config.json"),
+      JSON.stringify({
+        vault,
+        plain: true,
+        englishAsk: {
+          enabled: true,
+          evaluatorCommand: ["sh", "-lc", "exit 42"],
+        },
+      }),
+      "utf-8"
+    );
+
+    const raw = fixture("codex-notify-single.json");
+    const { exitCode } = await runCli(["codex-notify", raw], {
+      HOME: tmpHome,
+      AGENTLOG_CONFIG_DIR: cfgDir,
+    });
+
+    const content = readFileSync(findPlainNotePath(vault), "utf-8");
+    expect(exitCode).toBe(0);
+    expect(content).toContain("Reply with exactly: OK");
+    expect(content).not.toContain("## EnglishAsk");
+  });
+
+  it("codex-notify keeps EnglishAsk append failures silent", async () => {
+    const vault = join(tmpHome, "notes");
+    const cfgDir = join(tmpHome, ".agentlog");
+    const evaluator = makeReadonlyNoteEnglishAskEvaluator(tmpHome, vault);
+    mkdirSync(vault, { recursive: true });
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(
+      join(cfgDir, "config.json"),
+      JSON.stringify({
+        vault,
+        plain: true,
+        englishAsk: {
+          enabled: true,
+          evaluatorCommand: evaluator.command,
+        },
+      }),
+      "utf-8"
+    );
+
+    const raw = fixture("codex-notify-single.json");
+    const { exitCode, stderr } = await runCli(["codex-notify", raw], {
+      HOME: tmpHome,
+      AGENTLOG_CONFIG_DIR: cfgDir,
+    });
+
+    const content = readFileSync(findPlainNotePath(vault), "utf-8");
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(content).toContain("Reply with exactly: OK");
+    expect(content).not.toContain("## EnglishAsk");
   });
 
   it("legacy codex-uninstall command is rejected", async () => {

--- a/src/__tests__/cli-codex.test.ts
+++ b/src/__tests__/cli-codex.test.ts
@@ -147,6 +147,9 @@ describe("cli codex commands", () => {
     });
     expect(readFileSync(join(tmpHome, ".codex", "config.toml"), "utf-8")).not.toContain("agentlog\", \"codex-notify");
     expect(existsSync(join(tmpHome, ".claude", "settings.json"))).toBe(false);
+    const config = JSON.parse(readFileSync(join(cfgDir, "config.json"), "utf-8"));
+    expect(config.codexHookInstalled).toBe(true);
+    expect(config.claudeHookInstalled).toBeUndefined();
   });
 
   it("init --codex preserves existing Codex hooks and records hook metadata", async () => {
@@ -178,6 +181,7 @@ describe("cli codex commands", () => {
     expect(hooks.hooks.UserPromptSubmit).toHaveLength(2);
     const config = JSON.parse(readFileSync(join(cfgDir, "config.json"), "utf-8"));
     expect(config.codexHookInstalled).toBe(true);
+    expect(config.claudeHookInstalled).toBeUndefined();
   });
 
   it("init --codex aborts on unsupported hooks.json", async () => {
@@ -226,6 +230,8 @@ describe("cli codex commands", () => {
     expect(stdout).toContain("Hook registered");
     expect(existsSync(join(tmpHome, ".claude", "settings.json"))).toBe(true);
     expect(existsSync(join(tmpHome, ".codex", "hooks.json"))).toBe(false);
+    const config = JSON.parse(readFileSync(join(tmpHome, ".agentlog", "config.json"), "utf-8"));
+    expect(config.claudeHookInstalled).toBe(true);
   });
 
   it("legacy codex-init command is rejected", async () => {
@@ -263,6 +269,9 @@ describe("cli codex commands", () => {
         ],
       },
     });
+    const config = JSON.parse(readFileSync(join(cfgDir, "config.json"), "utf-8"));
+    expect(config.codexHookInstalled).toBe(true);
+    expect(config.claudeHookInstalled).toBe(true);
   });
 
   it("codex-notify writes a Daily Note entry and forwards the saved notify command", async () => {
@@ -751,6 +760,35 @@ describe("cli codex commands", () => {
     expect(exitCode).toBe(0);
     expect(stdout).toContain("codex");
     expect(stdout).toContain("hook registered");
+  });
+
+  it("doctor fails when config expects both hooks but the Claude hook is missing", async () => {
+    const vault = join(tmpHome, "notes");
+    const cfgDir = join(tmpHome, ".agentlog");
+    const pathWithCodex = makeFakeCodexPath(tmpHome);
+    mkdirSync(vault, { recursive: true });
+    mkdirSync(cfgDir, { recursive: true });
+    writeAgentlogCodexHook(tmpHome);
+    writeFileSync(
+      join(cfgDir, "config.json"),
+      JSON.stringify({
+        vault,
+        plain: true,
+        codexHookInstalled: true,
+        claudeHookInstalled: true,
+      }),
+      "utf-8"
+    );
+
+    const { stdout, exitCode } = await runCli(["doctor"], {
+      HOME: tmpHome,
+      AGENTLOG_CONFIG_DIR: cfgDir,
+      PATH: pathWithCodex,
+    });
+
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toContain("❌ hook");
+    expect(stdout).toContain("not registered");
   });
 
   it("doctor fails for partial damage when AgentLog config expects Codex hook but it is missing", async () => {

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -361,6 +361,25 @@ printf '%s\n' "$@" > "${argsFile}"
     expect(exitCode).toBe(1);
     expect(stderr).toContain("prompt is required");
   });
+
+  it("exits cleanly when Codex hook registration cannot parse hooks.json", async () => {
+    const binDir = join(tmpHome, "bin");
+    mkdirSync(binDir, { recursive: true });
+    writeFileSync(join(binDir, "codex"), "#!/bin/sh\nexit 0\n", "utf-8");
+    Bun.spawnSync(["chmod", "+x", join(binDir, "codex")]);
+    mkdirSync(join(tmpHome, ".codex"), { recursive: true });
+    writeFileSync(join(tmpHome, ".codex", "hooks.json"), "{bad", "utf-8");
+
+    const { stdout, stderr, exitCode } = await runCli(["codex-debug", "hello"], {
+      HOME: tmpHome,
+      PATH: `${binDir}:${process.env.PATH ?? ""}`,
+    });
+
+    expect(exitCode).toBe(1);
+    expect(stdout + stderr).toContain("hooks.json is invalid JSON");
+    expect(stdout + stderr).not.toContain("error: script");
+    expect(stdout + stderr).not.toContain("at ");
+  });
 });
 
 describe("cli init --dry-run", () => {

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -136,7 +136,8 @@ describe("cli init command", () => {
     expect(Array.isArray(settings.hooks.UserPromptSubmit)).toBe(true);
 
     const hasHook = settings.hooks.UserPromptSubmit.some(
-      (entry: { hooks?: Array<{ command?: string }> }) =>
+      (entry: { matcher?: unknown; hooks?: Array<{ command?: string }> }) =>
+        entry.matcher === "" &&
         Array.isArray(entry.hooks) &&
         entry.hooks.some((h) => h.command === "agentlog hook")
     );
@@ -164,6 +165,45 @@ describe("cli init command", () => {
     expect(settings.theme).toBe("dark");
     expect(settings.model).toBe("sonnet");
     expect(settings.hooks).toBeDefined();
+  });
+
+  it("migrates a stale AgentLog hook matcher object to the Claude string matcher format", async () => {
+    const vault = join(tmpHome, "Obsidian");
+    mkdirSync(join(vault, ".obsidian"), { recursive: true });
+    mkdirSync(join(tmpHome, ".claude"), { recursive: true });
+    writeFileSync(
+      join(tmpHome, ".claude", "settings.json"),
+      JSON.stringify({
+        hooks: {
+          UserPromptSubmit: [
+            {
+              matcher: { tools: ["UserPromptSubmit"] },
+              hooks: [{ type: "command", command: "agentlog hook" }],
+            },
+            {
+              matcher: "keep",
+              hooks: [{ type: "command", command: "echo keep" }],
+            },
+          ],
+        },
+      }),
+      "utf-8"
+    );
+
+    const { exitCode } = await runCli(["init", vault], { HOME: tmpHome });
+
+    expect(exitCode).toBe(0);
+    const settings = JSON.parse(readFileSync(join(tmpHome, ".claude", "settings.json"), "utf-8"));
+    expect(settings.hooks.UserPromptSubmit).toEqual([
+      {
+        matcher: "keep",
+        hooks: [{ type: "command", command: "echo keep" }],
+      },
+      {
+        matcher: "",
+        hooks: [{ type: "command", command: "agentlog hook" }],
+      },
+    ]);
   });
 
   // CL8: init expands ~/
@@ -295,6 +335,39 @@ describe("cli doctor command", () => {
     expect(stdout).toContain("plain mode");
     // obsidian line should not appear when plain mode
     expect(stdout).not.toContain("obsidian");
+  });
+
+  it("exits 1 when the registered AgentLog hook uses a stale object matcher", async () => {
+    const notes = join(tmpHome, "notes");
+    mkdirSync(notes, { recursive: true });
+    mkdirSync(join(tmpHome, ".agentlog"), { recursive: true });
+    writeFileSync(
+      join(tmpHome, ".agentlog", "config.json"),
+      JSON.stringify({ vault: notes, plain: true }),
+      "utf-8"
+    );
+    mkdirSync(join(tmpHome, ".claude"), { recursive: true });
+    writeFileSync(
+      join(tmpHome, ".claude", "settings.json"),
+      JSON.stringify({
+        hooks: {
+          UserPromptSubmit: [
+            {
+              matcher: { tools: ["UserPromptSubmit"] },
+              hooks: [{ type: "command", command: "agentlog hook" }],
+            },
+          ],
+        },
+      }),
+      "utf-8"
+    );
+
+    const { stdout, exitCode } = await runCli(["doctor"], { HOME: tmpHome });
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("hook");
+    expect(stdout).toContain("matcher must be a string");
+    expect(stdout).toContain("agentlog init");
   });
 });
 
@@ -544,6 +617,38 @@ describe("cli validate", () => {
 
     expect(exitCode).toBe(1);
     expect(stdout).toContain("hook: fail");
+  });
+
+  it("exits 1 with hook: fail when the registered hook matcher is unsupported", async () => {
+    const vault = join(tmpHome, "Obsidian");
+    mkdirSync(join(vault, ".obsidian"), { recursive: true });
+    mkdirSync(join(tmpHome, ".agentlog"), { recursive: true });
+    writeFileSync(
+      join(tmpHome, ".agentlog", "config.json"),
+      JSON.stringify({ vault }),
+      "utf-8"
+    );
+    mkdirSync(join(tmpHome, ".claude"), { recursive: true });
+    writeFileSync(
+      join(tmpHome, ".claude", "settings.json"),
+      JSON.stringify({
+        hooks: {
+          UserPromptSubmit: [
+            {
+              matcher: { tools: ["UserPromptSubmit"] },
+              hooks: [{ type: "command", command: "agentlog hook" }],
+            },
+          ],
+        },
+      }),
+      "utf-8"
+    );
+
+    const { stdout, exitCode } = await runCli(["validate"], { HOME: tmpHome });
+
+    expect(exitCode).toBe(1);
+    expect(stdout).toContain("hook: fail");
+    expect(stdout).toContain("matcher must be a string");
   });
 });
 

--- a/src/__tests__/codex-hooks.test.ts
+++ b/src/__tests__/codex-hooks.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "bun:test";
+import {
+  AGENTLOG_CODEX_HOOK_COMMAND,
+  hasAgentlogCodexHook,
+  installCodexHook,
+  inspectCodexHookState,
+  uninstallCodexHook,
+} from "../codex-hooks.js";
+
+describe("codex hook config", () => {
+  it("creates a UserPromptSubmit command hook in an empty hooks.json", () => {
+    const result = installCodexHook("");
+
+    expect(result.changed).toBe(true);
+    expect(hasAgentlogCodexHook(result.json)).toBe(true);
+    expect(JSON.parse(result.json)).toEqual({
+      hooks: {
+        UserPromptSubmit: [
+          {
+            hooks: [
+              {
+                type: "command",
+                command: AGENTLOG_CODEX_HOOK_COMMAND,
+              },
+            ],
+          },
+        ],
+      },
+    });
+  });
+
+  it("preserves unrelated hooks and appends AgentLog idempotently", () => {
+    const existing = JSON.stringify({
+      hooks: {
+        Stop: [{ hooks: [{ type: "command", command: "echo stop" }] }],
+        UserPromptSubmit: [{ hooks: [{ type: "command", command: "echo prompt" }] }],
+      },
+    });
+
+    const first = installCodexHook(existing);
+    const second = installCodexHook(first.json);
+    const parsed = JSON.parse(second.json);
+
+    expect(first.changed).toBe(true);
+    expect(second.changed).toBe(false);
+    expect(parsed.hooks.Stop).toHaveLength(1);
+    expect(parsed.hooks.UserPromptSubmit).toHaveLength(2);
+    expect(hasAgentlogCodexHook(second.json)).toBe(true);
+  });
+
+  it("removes only the AgentLog Codex hook", () => {
+    const installed = installCodexHook(JSON.stringify({
+      hooks: {
+        UserPromptSubmit: [{ hooks: [{ type: "command", command: "echo prompt" }] }],
+      },
+    }));
+
+    const removed = uninstallCodexHook(installed.json);
+    const parsed = JSON.parse(removed.json);
+
+    expect(removed.changed).toBe(true);
+    expect(hasAgentlogCodexHook(removed.json)).toBe(false);
+    expect(parsed.hooks.UserPromptSubmit).toEqual([
+      { hooks: [{ type: "command", command: "echo prompt" }] },
+    ]);
+  });
+
+  it("removes only the AgentLog handler when a hook group has multiple handlers", () => {
+    const installed = JSON.stringify({
+      hooks: {
+        UserPromptSubmit: [
+          {
+            hooks: [
+              { type: "command", command: "agentlog hook --source codex" },
+              { type: "command", command: "echo keep-me" },
+            ],
+          },
+        ],
+      },
+    });
+
+    const removed = uninstallCodexHook(installed);
+    const parsed = JSON.parse(removed.json);
+
+    expect(removed.changed).toBe(true);
+    expect(hasAgentlogCodexHook(removed.json)).toBe(false);
+    expect(parsed.hooks.UserPromptSubmit).toEqual([
+      { hooks: [{ type: "command", command: "echo keep-me" }] },
+    ]);
+  });
+
+  it("removes hooks.json when AgentLog was the only hook", () => {
+    const installed = installCodexHook("");
+    const removed = uninstallCodexHook(installed.json);
+
+    expect(removed.changed).toBe(true);
+    expect(removed.json).toBe("");
+  });
+
+  it("reports unsupported hook shapes without throwing from inspection", () => {
+    expect(inspectCodexHookState("{bad")).toEqual({
+      kind: "unsupported",
+      reason: "Unsupported Codex hooks configuration: hooks.json is invalid JSON",
+    });
+    expect(inspectCodexHookState(JSON.stringify({ hooks: [] })).kind).toBe("unsupported");
+    expect(inspectCodexHookState(JSON.stringify({ hooks: { UserPromptSubmit: {} } })).kind).toBe("unsupported");
+  });
+});

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -84,13 +84,24 @@ describe("config", () => {
 
   // C6: save then load round-trip
   it("saveConfig and loadConfig round-trip preserves all fields", () => {
-    const cfg = { vault: "/abs/vault", plain: true };
+    const cfg = {
+      vault: "/abs/vault",
+      plain: true,
+      englishAsk: {
+        enabled: true,
+        mode: "log-only" as const,
+        threshold: 3,
+        timeoutMs: 8000,
+      },
+    };
     saveConfig(cfg);
 
     const loaded = loadConfig();
     expect(loaded).not.toBeNull();
     expect(loaded!.vault).toBe("/abs/vault");
     expect(loaded!.plain).toBe(true);
+    expect(loaded!.englishAsk?.enabled).toBe(true);
+    expect(loaded!.englishAsk?.threshold).toBe(3);
   });
 
   // C7: expandHome with ~/

--- a/src/__tests__/daily-note.test.ts
+++ b/src/__tests__/daily-note.test.ts
@@ -70,15 +70,21 @@ describe("buildAgentLogEntry", () => {
 
 describe("buildSessionDivider", () => {
   it("returns divider with claude prefix by default", () => {
-    expect(buildSessionDivider("abc12345-def6-7890-abcd-ef1234567890")).toBe("- - - - [[claude_abc12345]]");
+    expect(buildSessionDivider("abc12345-def6-7890-abcd-ef1234567890")).toBe(
+      "- - - - [[claude_abc12345-def6-7890-abcd-ef1234567890]]"
+    );
   });
 
   it("returns divider with claude prefix when source is claude", () => {
-    expect(buildSessionDivider("abc12345-def6-7890-abcd-ef1234567890", "claude")).toBe("- - - - [[claude_abc12345]]");
+    expect(buildSessionDivider("abc12345-def6-7890-abcd-ef1234567890", "claude")).toBe(
+      "- - - - [[claude_abc12345-def6-7890-abcd-ef1234567890]]"
+    );
   });
 
   it("returns divider with codex prefix when source is codex", () => {
-    expect(buildSessionDivider("abc12345-def6-7890-abcd-ef1234567890", "codex")).toBe("- - - - [[codex_abc12345]]");
+    expect(buildSessionDivider("abc12345-def6-7890-abcd-ef1234567890", "codex")).toBe(
+      "- - - - [[codex_abc12345-def6-7890-abcd-ef1234567890]]"
+    );
   });
 
   it("uses full sessionId when shorter than 8 chars", () => {

--- a/src/__tests__/english-ask.test.ts
+++ b/src/__tests__/english-ask.test.ts
@@ -168,7 +168,7 @@ describe("EnglishAsk", () => {
     const content = readFileSync(filePath, "utf-8");
     expect(content).toContain("## EnglishAsk");
     expect(content).toContain("### 10:53 · js/agentlog");
-    expect(content).toContain("- session: [[codex_abcdef12]]");
+    expect(content).toContain("- session: [[codex_abcdef12-3456]]");
     expect(content).toContain("- score: 3/5");
     expect(content).toContain("What should I do next?");
   });

--- a/src/__tests__/english-ask.test.ts
+++ b/src/__tests__/english-ask.test.ts
@@ -1,0 +1,287 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { chmodSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  ENGLISHASK_GUARD_ENV,
+  appendEnglishAskFeedback,
+  englishAskSuggestion,
+  evaluateEnglishAsk,
+  shouldEvaluateEnglishAsk,
+} from "../english-ask.js";
+import type { AgentLogConfig, EnglishAskFeedback } from "../types.js";
+
+let tmp: string;
+
+function makeTmp(): string {
+  const dir = join(tmpdir(), `agentlog-englishask-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function fakeEvaluator(output: string): { command: string[]; inputPath: string } {
+  const script = join(tmp, "fake-englishask.sh");
+  const inputPath = join(tmp, "evaluator-input.txt");
+  writeFileSync(
+    script,
+    `#!/bin/sh
+test "$${ENGLISHASK_GUARD_ENV}" = "1" || exit 7
+cat > "$1"
+printf '%s' '${output.replace(/'/g, "'\\''")}'
+`,
+    "utf-8"
+  );
+  chmodSync(script, 0o755);
+  return { command: [script, inputPath], inputPath };
+}
+
+describe("EnglishAsk", () => {
+  beforeEach(() => {
+    tmp = makeTmp();
+  });
+
+  afterEach(() => {
+    delete process.env[ENGLISHASK_GUARD_ENV];
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("is off by default", () => {
+    expect(shouldEvaluateEnglishAsk({ vault: tmp }, "What should I do next?")).toBe(false);
+  });
+
+  it("skips recursive evaluator notify calls", () => {
+    process.env[ENGLISHASK_GUARD_ENV] = "1";
+    expect(
+      shouldEvaluateEnglishAsk({ vault: tmp, englishAsk: { enabled: true } }, "What should I do next?")
+    ).toBe(false);
+  });
+
+  it("skips non-English prompts", () => {
+    expect(
+      shouldEvaluateEnglishAsk({ vault: tmp, englishAsk: { enabled: true } }, "다음에 뭐 할까?")
+    ).toBe(false);
+  });
+
+  it("runs evaluator with recursion guard and parses score", () => {
+    const { command, inputPath } = fakeEvaluator(
+      "Score: 3/5\nNatural version: What should I do next?\nMissing context: target\nRewrite with: target/result"
+    );
+    const config: AgentLogConfig = {
+      vault: tmp,
+      englishAsk: {
+        enabled: true,
+        evaluatorCommand: command,
+      },
+    };
+
+    const result = evaluateEnglishAsk(config, "What should I do next?", tmp);
+
+    expect(result?.score).toBe(3);
+    expect(result?.feedback).toContain("Score: 3/5");
+    expect(readFileSync(inputPath, "utf-8")).toContain("User prompt:\nWhat should I do next?");
+  });
+
+  it("returns null when evaluator fails", () => {
+    const script = join(tmp, "fail-englishask.sh");
+    writeFileSync(script, "#!/bin/sh\nexit 42\n", "utf-8");
+    chmodSync(script, 0o755);
+
+    const result = evaluateEnglishAsk(
+      { vault: tmp, englishAsk: { enabled: true, evaluatorCommand: [script] } },
+      "What should I do next?",
+      tmp
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("falls back to the current process cwd when the notify cwd is unavailable", () => {
+    const { command, inputPath } = fakeEvaluator(
+      "Score: 4/5\nNatural version: ok\nMissing context: none\nRewrite with: none"
+    );
+
+    const result = evaluateEnglishAsk(
+      { vault: tmp, englishAsk: { enabled: true, evaluatorCommand: command } },
+      "What should I do next?",
+      join(tmp, "missing-cwd")
+    );
+
+    expect(result?.score).toBe(4);
+    expect(readFileSync(inputPath, "utf-8")).toContain("User prompt:\nWhat should I do next?");
+  });
+
+  it("returns null when evaluator times out", () => {
+    const script = join(tmp, "slow-englishask.sh");
+    writeFileSync(script, "#!/bin/sh\nsleep 1\n", "utf-8");
+    chmodSync(script, 0o755);
+
+    const result = evaluateEnglishAsk(
+      { vault: tmp, englishAsk: { enabled: true, evaluatorCommand: [script], timeoutMs: 20 } },
+      "What should I do next?",
+      tmp
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("redacts and truncates prompt before evaluator", () => {
+    const { command, inputPath } = fakeEvaluator(
+      "Score: 4/5\nNatural version: ok\nMissing context: none\nRewrite with: none"
+    );
+    const config: AgentLogConfig = {
+      vault: tmp,
+      englishAsk: {
+        enabled: true,
+        evaluatorCommand: command,
+        maxPromptChars: 40,
+      },
+    };
+
+    const result = evaluateEnglishAsk(config, "Use sk-abcdefghijklmnopqrstuvwxyz and explain the next action", tmp);
+
+    expect(result?.prompt).toContain("[redacted-api-key]");
+    expect(result?.prompt).toContain("[truncated]");
+    expect(readFileSync(inputPath, "utf-8")).not.toContain("sk-abcdefghijklmnopqrstuvwxyz");
+  });
+
+  it("appends feedback to an EnglishAsk Daily Note section", () => {
+    const filePath = join(tmp, "2026-03-02.md");
+    writeFileSync(filePath, "## AgentLog\n- existing\n", "utf-8");
+    const feedback: EnglishAskFeedback = {
+      score: 3,
+      prompt: "What should I do next?",
+      feedback: "Score: 3/5\nNatural version: What should I do next?",
+    };
+
+    appendEnglishAskFeedback(
+      filePath,
+      feedback,
+      {
+        time: "10:53",
+        project: "js/agentlog",
+        cwd: "/Users/pray/work/js/agentlog",
+        sessionId: "abcdef12-3456",
+      },
+      { vault: tmp, englishAsk: { enabled: true, mode: "log-only" } }
+    );
+
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toContain("## EnglishAsk");
+    expect(content).toContain("### 10:53 · js/agentlog");
+    expect(content).toContain("- session: [[codex_abcdef12]]");
+    expect(content).toContain("- score: 3/5");
+    expect(content).toContain("What should I do next?");
+  });
+
+  it("keeps stored prompt metadata on one Markdown list line", () => {
+    const filePath = join(tmp, "2026-03-02.md");
+    const feedback: EnglishAskFeedback = {
+      score: 3,
+      prompt: "What should I do next?\n[truncated]",
+      feedback: "Score: 3/5",
+    };
+
+    appendEnglishAskFeedback(
+      filePath,
+      feedback,
+      {
+        time: "10:53",
+        project: "js/agentlog",
+        cwd: "/Users/pray/work/js/agentlog",
+        sessionId: "abcdef12-3456",
+      },
+      { vault: tmp, englishAsk: { enabled: true } }
+    );
+
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toContain("- prompt: What should I do next? [truncated]");
+    expect(content).not.toContain("- prompt: What should I do next?\n[truncated]");
+  });
+
+  it("inserts new feedback inside an existing EnglishAsk section", () => {
+    const filePath = join(tmp, "2026-03-02.md");
+    writeFileSync(filePath, "## AgentLog\n- existing\n\n## EnglishAsk\n\n### old\n- score: 5/5\n\n## Other\n- keep\n", "utf-8");
+    const feedback: EnglishAskFeedback = {
+      score: 2,
+      prompt: "Needs section placement",
+      feedback: "Score: 2/5",
+    };
+
+    appendEnglishAskFeedback(
+      filePath,
+      feedback,
+      {
+        time: "10:54",
+        project: "js/agentlog",
+        cwd: "/Users/pray/work/js/agentlog",
+        sessionId: "abcdef12-3456",
+      },
+      { vault: tmp, englishAsk: { enabled: true } }
+    );
+
+    const content = readFileSync(filePath, "utf-8");
+    expect(content.indexOf("## EnglishAsk")).toBeLessThan(content.indexOf("Needs section placement"));
+    expect(content.indexOf("Needs section placement")).toBeLessThan(content.indexOf("## Other"));
+  });
+
+  it("inserts feedback before an immediately following top-level section", () => {
+    const filePath = join(tmp, "2026-03-02.md");
+    writeFileSync(filePath, "## AgentLog\n- existing\n\n## EnglishAsk\n## Other\n- keep\n", "utf-8");
+    const feedback: EnglishAskFeedback = {
+      score: 2,
+      prompt: "Needs immediate section placement",
+      feedback: "Score: 2/5",
+    };
+
+    appendEnglishAskFeedback(
+      filePath,
+      feedback,
+      {
+        time: "10:54",
+        project: "js/agentlog",
+        cwd: "/Users/pray/work/js/agentlog",
+        sessionId: "abcdef12-3456",
+      },
+      { vault: tmp, englishAsk: { enabled: true } }
+    );
+
+    const content = readFileSync(filePath, "utf-8");
+    expect(content.indexOf("## EnglishAsk")).toBeLessThan(content.indexOf("Needs immediate section placement"));
+    expect(content.indexOf("Needs immediate section placement")).toBeLessThan(content.indexOf("## Other"));
+  });
+
+  it("uses a longer Markdown fence when feedback contains backtick fences", () => {
+    const filePath = join(tmp, "2026-03-02.md");
+    const feedback: EnglishAskFeedback = {
+      score: 2,
+      prompt: "Needs fence safety",
+      feedback: "Score: 2/5\n```\n## Injected\n```",
+    };
+
+    appendEnglishAskFeedback(
+      filePath,
+      feedback,
+      {
+        time: "10:54",
+        project: "js/agentlog",
+        cwd: "/Users/pray/work/js/agentlog",
+        sessionId: "abcdef12-3456",
+      },
+      { vault: tmp, englishAsk: { enabled: true } }
+    );
+
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toContain("````text");
+    expect(content).toContain("  ```\n  ## Injected\n  ```");
+    expect(content.trimEnd().endsWith("````")).toBe(true);
+  });
+
+  it("emits optional rewrite guidance in suggest mode", () => {
+    const suggestion = englishAskSuggestion(
+      { vault: tmp, englishAsk: { enabled: true, mode: "suggest", threshold: 3 } },
+      { score: 3, prompt: "What next?", feedback: "Score: 3/5" }
+    );
+
+    expect(suggestion).toContain("EnglishAsk score 3/5");
+  });
+});

--- a/src/__tests__/fixtures/codex-hook-user-prompt-submit.json
+++ b/src/__tests__/fixtures/codex-hook-user-prompt-submit.json
@@ -1,0 +1,10 @@
+{
+  "session_id": "019cb123-ac48-7d22-b5bf-195ee34699af",
+  "transcript_path": "/Users/pray/.codex/sessions/example.jsonl",
+  "cwd": "/Users/pray/opensource/agentlog",
+  "hook_event_name": "UserPromptSubmit",
+  "model": "gpt-5.5",
+  "turn_id": "019cb123-ac4f-7800-a1f9-a953dc2ce3f5",
+  "permission_mode": "default",
+  "prompt": "Reply with exactly: OK"
+}

--- a/src/__tests__/hook-input.test.ts
+++ b/src/__tests__/hook-input.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
 import { parseHookInput } from "../schema/hook-input.js";
+
+function fixture(name: string): string {
+  return readFileSync(join(import.meta.dir, "fixtures", name), "utf-8");
+}
 
 describe("parseHookInput", () => {
   // H1: valid input with prompt field
@@ -16,8 +22,8 @@ describe("parseHookInput", () => {
     expect(result.prompt).toBe("hello world");
   });
 
-  // H2: fallback to message.content
-  it("falls back to message.content when prompt is absent", () => {
+  // H2: Claude/backward-compatibility fallback to message.content
+  it("falls back to message.content for non-Codex hook payloads when prompt is absent", () => {
     const input = JSON.stringify({
       hook_event_name: "UserPromptSubmit",
       session_id: "abc123",
@@ -28,8 +34,8 @@ describe("parseHookInput", () => {
     expect(result.prompt).toBe("from message content");
   });
 
-  // H3: fallback to parts[].text
-  it("falls back to parts[0].text when prompt and message absent", () => {
+  // H3: Claude/backward-compatibility fallback to parts[].text
+  it("falls back to parts[0].text for non-Codex hook payloads when prompt and message absent", () => {
     const input = JSON.stringify({
       hook_event_name: "UserPromptSubmit",
       session_id: "abc123",
@@ -103,5 +109,39 @@ describe("parseHookInput", () => {
     });
     const result = parseHookInput(input);
     expect(result.prompt).toBe("agentlog 개발을 위해서 작업 진행");
+  });
+
+  it("parses the documented Codex UserPromptSubmit hook payload", () => {
+    const result = parseHookInput(fixture("codex-hook-user-prompt-submit.json"), { source: "codex" });
+
+    expect(result).toEqual({
+      sessionId: "019cb123-ac48-7d22-b5bf-195ee34699af",
+      cwd: "/Users/pray/opensource/agentlog",
+      prompt: "Reply with exactly: OK",
+    });
+  });
+
+  it("requires prompt for Codex UserPromptSubmit hook payloads", () => {
+    const input = JSON.stringify({
+      hook_event_name: "UserPromptSubmit",
+      session_id: "abc123",
+      cwd: "/some/dir",
+      model: "gpt-5.5",
+      turn_id: "turn-123",
+      message: { content: "Claude fallback must not satisfy Codex" },
+    });
+
+    expect(() => parseHookInput(input, { source: "codex" })).toThrow("prompt");
+  });
+
+  it("throws when hook_event_name is not UserPromptSubmit", () => {
+    const input = JSON.stringify({
+      hook_event_name: "Stop",
+      session_id: "abc123",
+      cwd: "/some/dir",
+      prompt: "hello",
+    });
+
+    expect(() => parseHookInput(input)).toThrow("UserPromptSubmit");
   });
 });

--- a/src/__tests__/note-writer.test.ts
+++ b/src/__tests__/note-writer.test.ts
@@ -54,11 +54,11 @@ describe("dailyNotePath", () => {
     }
   });
 
-  it("returns Obsidian Daily path with Korean day name (CLI unavailable)", () => {
+  it("returns null when no non-plain path source is available", () => {
     process.env.OBSIDIAN_BIN = "/nonexistent/obsidian";
     const config: AgentLogConfig = { vault: "/vault" };
     const path = dailyNotePath(config, TEST_DATE);
-    expect(path).toBe("/vault/Daily/2026-03-01-일.md");
+    expect(path).toBeNull();
   });
 
   it("returns plain path without Daily subdir", () => {
@@ -219,7 +219,7 @@ describe("dailyNotePath", () => {
     );
 
     const path = dailyNotePath({ vault }, TEST_DATE);
-    expect(path).toBe(join(vault, "Daily/2026-03-01-일.md"));
+    expect(path).toBeNull();
 
     rmSync(vault, { recursive: true, force: true });
   });
@@ -232,18 +232,18 @@ describe("dailyNotePath", () => {
     process.env.OBSIDIAN_BIN = mockBin;
 
     const path = dailyNotePath({ vault }, TEST_DATE);
-    expect(path).toBe(join(vault, "Daily/2026-03-01-일.md"));
+    expect(path).toBeNull();
 
     rmSync(mockBin, { force: true });
     rmSync(vault, { recursive: true, force: true });
   });
 
-  it("falls back to hardcoded path when CLI fails", () => {
+  it("returns null when CLI fails and config is unavailable", () => {
     process.env.OBSIDIAN_BIN = "/nonexistent/obsidian";
 
     const config: AgentLogConfig = { vault: "/vault" };
     const path = dailyNotePath(config, TEST_DATE);
-    expect(path).toBe("/vault/Daily/2026-03-01-일.md");
+    expect(path).toBeNull();
   });
 
 });
@@ -256,8 +256,14 @@ describe("appendEntry — session-grouped AgentLog section", () => {
   beforeEach(() => {
     tmpDir = makeTmpDir();
     config = { vault: tmpDir };
-    // Disable CLI so tests use hardcoded Daily/ path with the test date
+    // Disable CLI; most tests resolve the Daily path through vault settings.
     process.env.OBSIDIAN_BIN = "/nonexistent/obsidian";
+    mkdirSync(join(tmpDir, ".obsidian"), { recursive: true });
+    writeFileSync(
+      join(tmpDir, ".obsidian", "daily-notes.json"),
+      JSON.stringify({ folder: "Daily", format: "YYYY-MM-DD-ddd" }),
+      "utf-8"
+    );
     mkdirSync(join(tmpDir, "Daily"), { recursive: true });
   });
 
@@ -270,8 +276,45 @@ describe("appendEntry — session-grouped AgentLog section", () => {
     }
   });
 
+  function dailyFilePath(): string {
+    return join(tmpDir, "Daily", "2026-03-01-일.md");
+  }
+
+  function writeDailyFile(content = FIXTURE_NO_TIMEBLOCKS): string {
+    const filePath = dailyFilePath();
+    writeFileSync(filePath, content, "utf-8");
+    return filePath;
+  }
+
+  function installDailyBootstrapCli(template: string): string {
+    const mockBin = join(tmpDir, "mock-obsidian");
+    const filePath = dailyFilePath();
+    writeFileSync(
+      mockBin,
+      [
+        "#!/bin/bash",
+        "if [ \"$1\" = \"daily:path\" ]; then",
+        "  echo \"Daily/2026-03-01-일.md\"",
+        "  exit 0",
+        "fi",
+        "if [ \"$1\" = \"daily\" ]; then",
+        `  mkdir -p ${JSON.stringify(join(tmpDir, "Daily"))}`,
+        `  printf '%s' ${JSON.stringify(template)} > ${JSON.stringify(filePath)}`,
+        "  exit 0",
+        "fi",
+        "exit 1",
+      ].join("\n"),
+      "utf-8"
+    );
+    chmodSync(mockBin, 0o755);
+    process.env.OBSIDIAN_BIN = mockBin;
+    return filePath;
+  }
+
   // N1: new file — creates ## AgentLog + > 🕐 + #### section
-  it("creates ## AgentLog with latest line and project section on new file", () => {
+  it("bootstraps a missing Daily Note through Obsidian before appending", () => {
+    installDailyBootstrapCli("# 2026-03-01\n\n## Template\n- keep me\n");
+
     const entry = makeEntry();
     const result = appendEntry(config, entry, TEST_DATE);
 
@@ -280,6 +323,8 @@ describe("appendEntry — session-grouped AgentLog section", () => {
     expect(existsSync(result.filePath)).toBe(true);
 
     const content = readFileSync(result.filePath, "utf-8");
+    expect(content).toContain("## Template");
+    expect(content).toContain("- keep me");
     expect(content).toContain("## AgentLog");
     expect(content).toContain("> 🕐 10:53 — js/agentlog › 테스트 작업");
     expect(content).toContain("#### 10:53 · js/agentlog");
@@ -288,10 +333,38 @@ describe("appendEntry — session-grouped AgentLog section", () => {
     expect(content).toContain("- 10:53 테스트 작업");
   });
 
+  it("does not create a guessed fallback file when no safe path resolves", () => {
+    process.env.OBSIDIAN_BIN = "/nonexistent/obsidian";
+    rmSync(join(tmpDir, ".obsidian", "daily-notes.json"), { force: true });
+
+    expect(() => appendEntry(config, makeEntry(), TEST_DATE)).toThrow("Daily Note path could not be resolved");
+    expect(existsSync(dailyFilePath())).toBe(false);
+  });
+
+  it("aborts missing-note writes when Obsidian bootstrap fails", () => {
+    const mockBin = join(tmpDir, "mock-obsidian-fail");
+    writeFileSync(
+      mockBin,
+      [
+        "#!/bin/bash",
+        "if [ \"$1\" = \"daily:path\" ]; then",
+        "  echo \"Daily/2026-03-01-일.md\"",
+        "  exit 0",
+        "fi",
+        "exit 1",
+      ].join("\n"),
+      "utf-8"
+    );
+    chmodSync(mockBin, 0o755);
+    process.env.OBSIDIAN_BIN = mockBin;
+
+    expect(() => appendEntry(config, makeEntry(), TEST_DATE)).toThrow("Daily Note is missing");
+    expect(existsSync(dailyFilePath())).toBe(false);
+  });
+
   // N2: file with existing content — appends ## AgentLog at end
   it("appends ## AgentLog section to existing file without modifying existing content", () => {
-    const filePath = join(tmpDir, "Daily", "2026-03-01-일.md");
-    writeFileSync(filePath, FIXTURE_NO_TIMEBLOCKS, "utf-8");
+    const filePath = writeDailyFile();
 
     const entry = makeEntry();
     appendEntry(config, entry, TEST_DATE);
@@ -304,8 +377,7 @@ describe("appendEntry — session-grouped AgentLog section", () => {
 
   // N3: file with timeblocks — entries go to ## AgentLog, NOT into timeblocks
   it("writes to ## AgentLog section even when timeblocks exist (no timeblock insertion)", () => {
-    const filePath = join(tmpDir, "Daily", "2026-03-01-일.md");
-    writeFileSync(filePath, FIXTURE_WITH_TIMEBLOCKS, "utf-8");
+    const filePath = writeDailyFile(FIXTURE_WITH_TIMEBLOCKS);
 
     const entry = makeEntry();
     const result = appendEntry(config, entry, TEST_DATE);
@@ -323,8 +395,7 @@ describe("appendEntry — session-grouped AgentLog section", () => {
 
   // N4: same project, same session → append to existing section
   it("appends to existing project section when project and session match", () => {
-    const filePath = join(tmpDir, "Daily", "2026-03-01-일.md");
-    writeFileSync(filePath, FIXTURE_NO_TIMEBLOCKS, "utf-8");
+    const filePath = writeDailyFile();
 
     const entry1 = makeEntry({ time: "10:53", prompt: "첫 번째 작업" });
     const entry2 = makeEntry({ time: "11:07", prompt: "두 번째 작업" });
@@ -343,7 +414,7 @@ describe("appendEntry — session-grouped AgentLog section", () => {
   });
 
   it("treats legacy short session divider as the same current session", () => {
-    const filePath = join(tmpDir, "Daily", "2026-03-01-일.md");
+    const filePath = dailyFilePath();
     writeFileSync(
       filePath,
       [
@@ -369,8 +440,7 @@ describe("appendEntry — session-grouped AgentLog section", () => {
 
   // N5: same project, different session → insert divider
   it("inserts session divider when session changes within same project", () => {
-    const filePath = join(tmpDir, "Daily", "2026-03-01-일.md");
-    writeFileSync(filePath, FIXTURE_NO_TIMEBLOCKS, "utf-8");
+    const filePath = writeDailyFile();
 
     const entry1 = makeEntry({ time: "10:53", sessionId: "session1-aaaa-bbbb-cccc-dddddddddddd" });
     const entry2 = makeEntry({ time: "15:00", sessionId: "session2-xxxx-yyyy-zzzz-111111111111" });
@@ -386,8 +456,7 @@ describe("appendEntry — session-grouped AgentLog section", () => {
 
   // N5b: codex source emits [[codex_...]] dividers
   it("emits codex-prefixed divider when source is codex", () => {
-    const filePath = join(tmpDir, "Daily", "2026-03-01-일.md");
-    writeFileSync(filePath, FIXTURE_NO_TIMEBLOCKS, "utf-8");
+    const filePath = writeDailyFile();
 
     const entry1 = makeEntry({ time: "10:53", source: "codex", sessionId: "codex111-aaaa-bbbb-cccc-dddddddddddd" });
     const entry2 = makeEntry({ time: "15:00", source: "codex", sessionId: "codex222-xxxx-yyyy-zzzz-111111111111" });
@@ -402,8 +471,7 @@ describe("appendEntry — session-grouped AgentLog section", () => {
 
   // N6: different projects → separate #### sections
   it("creates separate sections for different projects", () => {
-    const filePath = join(tmpDir, "Daily", "2026-03-01-일.md");
-    writeFileSync(filePath, FIXTURE_NO_TIMEBLOCKS, "utf-8");
+    const filePath = writeDailyFile();
 
     const entry1 = makeEntry({
       time: "10:53",
@@ -425,8 +493,7 @@ describe("appendEntry — session-grouped AgentLog section", () => {
 
   // N7: > 🕐 latest line always reflects the most recent entry
   it("updates > 🕐 latest line to the most recent entry on each write", () => {
-    const filePath = join(tmpDir, "Daily", "2026-03-01-일.md");
-    writeFileSync(filePath, FIXTURE_NO_TIMEBLOCKS, "utf-8");
+    const filePath = writeDailyFile();
 
     appendEntry(config, makeEntry({ time: "10:53", prompt: "첫 번째" }), TEST_DATE);
     appendEntry(config, makeEntry({ time: "11:07", prompt: "두 번째" }), TEST_DATE);
@@ -439,8 +506,7 @@ describe("appendEntry — session-grouped AgentLog section", () => {
 
   // N8: project header preserves original start time when session updates
   it("preserves original project start time in header when session changes", () => {
-    const filePath = join(tmpDir, "Daily", "2026-03-01-일.md");
-    writeFileSync(filePath, FIXTURE_NO_TIMEBLOCKS, "utf-8");
+    const filePath = writeDailyFile();
 
     appendEntry(config, makeEntry({ time: "10:53", sessionId: "session1-aaaa-bbbb-cccc-dddddddddddd" }), TEST_DATE);
     appendEntry(config, makeEntry({ time: "15:00", sessionId: "session2-xxxx-yyyy-zzzz-111111111111" }), TEST_DATE);
@@ -453,7 +519,7 @@ describe("appendEntry — session-grouped AgentLog section", () => {
 
   // N9: ## AgentLog already exists → append project section inside it
   it("appends to existing ## AgentLog section", () => {
-    const filePath = join(tmpDir, "Daily", "2026-03-01-일.md");
+    const filePath = dailyFilePath();
     writeFileSync(
       filePath,
       "# 2026-03-01\n\n## AgentLog\n> 🕐 09:00 — js/old › old entry\n\n#### 09:00 · js/old\n<!-- cwd=/old/path ses=abc00000 -->\n- 09:00 old entry\n",
@@ -472,7 +538,7 @@ describe("appendEntry — session-grouped AgentLog section", () => {
 
   // N10: empty file
   it("handles empty file without crashing", () => {
-    const filePath = join(tmpDir, "Daily", "2026-03-01-일.md");
+    const filePath = dailyFilePath();
     writeFileSync(filePath, "", "utf-8");
 
     const entry = makeEntry();
@@ -484,6 +550,7 @@ describe("appendEntry — session-grouped AgentLog section", () => {
 
   // N11: WriteResult fields
   it("returns section=agentlog and correct filePath", () => {
+    writeDailyFile();
     const entry = makeEntry();
     const result = appendEntry(config, entry, TEST_DATE);
     expect(result.section).toBe("agentlog");
@@ -492,10 +559,11 @@ describe("appendEntry — session-grouped AgentLog section", () => {
 
   // N12: section header contains cwd (no ses in metadata)
   it("embeds full cwd in section header comment (ses tracked via dividers)", () => {
+    writeDailyFile();
     const entry = makeEntry();
     appendEntry(config, entry, TEST_DATE);
 
-    const filePath = join(tmpDir, "Daily", "2026-03-01-일.md");
+    const filePath = dailyFilePath();
     const content = readFileSync(filePath, "utf-8");
     expect(content).toContain("<!-- cwd=/Users/pray/work/js/agentlog -->");
     expect(content).not.toContain("ses=");
@@ -503,6 +571,7 @@ describe("appendEntry — session-grouped AgentLog section", () => {
 
   // N13: cwd with spaces — section matching must not break
   it("handles cwd with spaces in path correctly", () => {
+    writeDailyFile();
     const entry = makeEntry({
       cwd: "/Users/John Doe/work/js/agentlog",
       project: "js/agentlog",
@@ -518,7 +587,7 @@ describe("appendEntry — session-grouped AgentLog section", () => {
     });
     appendEntry(config, entry2, TEST_DATE);
 
-    const filePath = join(tmpDir, "Daily", "2026-03-01-일.md");
+    const filePath = dailyFilePath();
     const content = readFileSync(filePath, "utf-8");
     // Should have only one #### section (not two)
     const sections = content.split("#### ");
@@ -530,8 +599,7 @@ describe("appendEntry — session-grouped AgentLog section", () => {
 
   // N14: 3 entries in same session — all appended in order within the section
   it("appends three entries in same session in insertion order", () => {
-    const filePath = join(tmpDir, "Daily", "2026-03-01-일.md");
-    writeFileSync(filePath, FIXTURE_NO_TIMEBLOCKS, "utf-8");
+    const filePath = writeDailyFile();
 
     appendEntry(config, makeEntry({ time: "10:00", prompt: "첫 번째" }), TEST_DATE);
     appendEntry(config, makeEntry({ time: "10:30", prompt: "두 번째" }), TEST_DATE);

--- a/src/__tests__/note-writer.test.ts
+++ b/src/__tests__/note-writer.test.ts
@@ -284,7 +284,7 @@ describe("appendEntry — session-grouped AgentLog section", () => {
     expect(content).toContain("> 🕐 10:53 — js/agentlog › 테스트 작업");
     expect(content).toContain("#### 10:53 · js/agentlog");
     expect(content).toContain("<!-- cwd=/Users/pray/work/js/agentlog -->");
-    expect(content).toContain("- - - - [[claude_abc12345]]");
+    expect(content).toContain("- - - - [[claude_abc12345-def6-7890-abcd-ef1234567890]]");
     expect(content).toContain("- 10:53 테스트 작업");
   });
 
@@ -342,6 +342,31 @@ describe("appendEntry — session-grouped AgentLog section", () => {
     expect(dividerCount).toBe(1);
   });
 
+  it("treats legacy short session divider as the same current session", () => {
+    const filePath = join(tmpDir, "Daily", "2026-03-01-일.md");
+    writeFileSync(
+      filePath,
+      [
+        "## AgentLog",
+        "> 🕐 10:53 — js/agentlog › 첫 번째 작업",
+        "",
+        "#### 10:53 · js/agentlog",
+        "<!-- cwd=/Users/pray/work/js/agentlog -->",
+        "- - - - [[claude_abc12345]]",
+        "- 10:53 첫 번째 작업",
+        "",
+      ].join("\n"),
+      "utf-8"
+    );
+
+    appendEntry(config, makeEntry({ time: "11:07", prompt: "두 번째 작업" }), TEST_DATE);
+
+    const content = readFileSync(filePath, "utf-8");
+    const dividerCount = (content.match(/- - - -/g) ?? []).length;
+    expect(dividerCount).toBe(1);
+    expect(content).toContain("- 11:07 두 번째 작업");
+  });
+
   // N5: same project, different session → insert divider
   it("inserts session divider when session changes within same project", () => {
     const filePath = join(tmpDir, "Daily", "2026-03-01-일.md");
@@ -353,8 +378,8 @@ describe("appendEntry — session-grouped AgentLog section", () => {
     appendEntry(config, entry2, TEST_DATE);
 
     const content = readFileSync(filePath, "utf-8");
-    expect(content).toContain("- - - - [[claude_session1]]");
-    expect(content).toContain("- - - - [[claude_session2]]");
+    expect(content).toContain("- - - - [[claude_session1-aaaa-bbbb-cccc-dddddddddddd]]");
+    expect(content).toContain("- - - - [[claude_session2-xxxx-yyyy-zzzz-111111111111]]");
     expect(content).toContain("- 10:53 테스트 작업");
     expect(content).toContain("- 15:00 테스트 작업");
   });
@@ -370,8 +395,8 @@ describe("appendEntry — session-grouped AgentLog section", () => {
     appendEntry(config, entry2, TEST_DATE);
 
     const content = readFileSync(filePath, "utf-8");
-    expect(content).toContain("- - - - [[codex_codex111]]");
-    expect(content).toContain("- - - - [[codex_codex222]]");
+    expect(content).toContain("- - - - [[codex_codex111-aaaa-bbbb-cccc-dddddddddddd]]");
+    expect(content).toContain("- - - - [[codex_codex222-xxxx-yyyy-zzzz-111111111111]]");
     expect(content).not.toContain("claude_");
   });
 

--- a/src/__tests__/note-writer.test.ts
+++ b/src/__tests__/note-writer.test.ts
@@ -362,6 +362,19 @@ describe("appendEntry — session-grouped AgentLog section", () => {
     expect(existsSync(dailyFilePath())).toBe(false);
   });
 
+  it("does not write a raw ## AgentLog note when the Obsidian CLI is disabled (exit 0 warning)", () => {
+    const mockBin = join(tmpDir, "mock-obsidian-disabled");
+    const warning =
+      "Command line interface is not enabled. Please turn it on in Settings > General > Advanced.";
+    // Disabled CLI: every subcommand prints the warning and exits 0 without doing anything.
+    writeFileSync(mockBin, `#!/bin/bash\necho ${JSON.stringify(warning)}\nexit 0`, "utf-8");
+    chmodSync(mockBin, 0o755);
+    process.env.OBSIDIAN_BIN = mockBin;
+
+    expect(() => appendEntry(config, makeEntry(), TEST_DATE)).toThrow("Daily Note is missing");
+    expect(existsSync(dailyFilePath())).toBe(false);
+  });
+
   // N2: file with existing content — appends ## AgentLog at end
   it("appends ## AgentLog section to existing file without modifying existing content", () => {
     const filePath = writeDailyFile();

--- a/src/__tests__/note-writer.test.ts
+++ b/src/__tests__/note-writer.test.ts
@@ -482,6 +482,52 @@ describe("appendEntry — session-grouped AgentLog section", () => {
     expect(content).not.toContain("claude_");
   });
 
+  // N5c: source differs but session id collides → insert a source-specific divider
+  // (Codex IDs can look UUID-like and collide with an existing claude_ id; must not be mislabeled.)
+  it("inserts a codex divider when source differs from an existing claude divider with the same id", () => {
+    const filePath = writeDailyFile();
+
+    const sharedId = "019abcde-1111-2222-3333-444455556666";
+    appendEntry(config, makeEntry({ time: "10:53", source: "claude", sessionId: sharedId }), TEST_DATE);
+    appendEntry(config, makeEntry({ time: "11:07", source: "codex", sessionId: sharedId }), TEST_DATE);
+
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toContain(`- - - - [[claude_${sharedId}]]`);
+    expect(content).toContain(`- - - - [[codex_${sharedId}]]`);
+    const dividerCount = (content.match(/- - - -/g) ?? []).length;
+    expect(dividerCount).toBe(2);
+  });
+
+  // N5d: legacy short claude divider must not absorb a codex entry whose id shares the 8-char prefix
+  it("does not file a codex entry under a legacy claude_ divider sharing the 8-char prefix", () => {
+    const filePath = dailyFilePath();
+    writeFileSync(
+      filePath,
+      [
+        "## AgentLog",
+        "> 🕐 10:53 — js/agentlog › 첫 번째 작업",
+        "",
+        "#### 10:53 · js/agentlog",
+        "<!-- cwd=/Users/pray/work/js/agentlog -->",
+        "- - - - [[claude_abc12345]]",
+        "- 10:53 첫 번째 작업",
+        "",
+      ].join("\n"),
+      "utf-8"
+    );
+
+    appendEntry(
+      config,
+      makeEntry({ time: "11:07", source: "codex", sessionId: "abc12345-def6-7890-abcd-ef1234567890", prompt: "codex 작업" }),
+      TEST_DATE
+    );
+
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toContain("- - - - [[codex_abc12345-def6-7890-abcd-ef1234567890]]");
+    const dividerCount = (content.match(/- - - -/g) ?? []).length;
+    expect(dividerCount).toBe(2);
+  });
+
   // N6: different projects → separate #### sections
   it("creates separate sections for different projects", () => {
     const filePath = writeDailyFile();

--- a/src/__tests__/obsidian-cli.test.ts
+++ b/src/__tests__/obsidian-cli.test.ts
@@ -1,7 +1,15 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 
-import { isVersionAtLeast, MIN_CLI_VERSION, resolveCliBin, cliDailyPath } from "../obsidian-cli.js";
-import { writeFileSync, mkdirSync, chmodSync, rmSync } from "fs";
+import {
+  CLI_PROBE_TIMEOUT_MS,
+  DAILY_BOOTSTRAP_TIMEOUT_MS,
+  isVersionAtLeast,
+  MIN_CLI_VERSION,
+  resolveCliBin,
+  cliDailyPath,
+  cliEnsureDailyNoteExists,
+} from "../obsidian-cli.js";
+import { writeFileSync, readFileSync, mkdirSync, chmodSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 
@@ -48,6 +56,12 @@ describe("isVersionAtLeast", () => {
 describe("MIN_CLI_VERSION", () => {
   it("is set to 1.12.4", () => {
     expect(MIN_CLI_VERSION).toBe("1.12.4");
+  });
+});
+
+describe("Obsidian CLI timeouts", () => {
+  it("gives Daily bootstrap more time than lightweight probes", () => {
+    expect(DAILY_BOOTSTRAP_TIMEOUT_MS).toBeGreaterThan(CLI_PROBE_TIMEOUT_MS);
   });
 });
 
@@ -151,5 +165,49 @@ describe("cliDailyPath", () => {
 
     process.env.OBSIDIAN_BIN = mockBin;
     expect(cliDailyPath()).toBeNull();
+  });
+});
+
+describe("cliEnsureDailyNoteExists", () => {
+  const originalBin = process.env.OBSIDIAN_BIN;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = join(tmpdir(), `agentlog-cli-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (originalBin === undefined) {
+      delete process.env.OBSIDIAN_BIN;
+    } else {
+      process.env.OBSIDIAN_BIN = originalBin;
+    }
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns true when obsidian daily exits 0", () => {
+    const mockBin = join(tmpDir, "mock-obsidian-daily");
+    const called = join(tmpDir, "called");
+    writeFileSync(mockBin, `#!/bin/bash\necho "$1" > ${JSON.stringify(called)}\nexit 0`, "utf-8");
+    chmodSync(mockBin, 0o755);
+
+    process.env.OBSIDIAN_BIN = mockBin;
+    expect(cliEnsureDailyNoteExists()).toBe(true);
+    expect(readFileSync(called, "utf-8")).toBe("daily\n");
+  });
+
+  it("returns false when obsidian daily exits non-zero", () => {
+    const mockBin = join(tmpDir, "mock-obsidian-daily-fail");
+    writeFileSync(mockBin, "#!/bin/bash\nexit 1", "utf-8");
+    chmodSync(mockBin, 0o755);
+
+    process.env.OBSIDIAN_BIN = mockBin;
+    expect(cliEnsureDailyNoteExists()).toBe(false);
+  });
+
+  it("returns false when CLI binary is not found", () => {
+    process.env.OBSIDIAN_BIN = "/nonexistent/obsidian";
+    expect(cliEnsureDailyNoteExists()).toBe(false);
   });
 });

--- a/src/__tests__/obsidian-cli.test.ts
+++ b/src/__tests__/obsidian-cli.test.ts
@@ -4,6 +4,7 @@ import {
   CLI_PROBE_TIMEOUT_MS,
   DAILY_BOOTSTRAP_TIMEOUT_MS,
   isVersionAtLeast,
+  isCliDisabledOutput,
   MIN_CLI_VERSION,
   resolveCliBin,
   cliDailyPath,
@@ -50,6 +51,31 @@ describe("isVersionAtLeast", () => {
   it("handles single-segment versions", () => {
     expect(isVersionAtLeast("2", "1")).toBe(true);
     expect(isVersionAtLeast("1", "2")).toBe(false);
+  });
+});
+
+describe("isCliDisabledOutput", () => {
+  it("detects the disabled-CLI warning in stdout", () => {
+    expect(
+      isCliDisabledOutput(
+        "Command line interface is not enabled. Please turn it on in Settings > General > Advanced."
+      )
+    ).toBe(true);
+  });
+
+  it("detects the warning regardless of surrounding noise/case", () => {
+    expect(
+      isCliDisabledOutput("Loading updated app package\nCOMMAND LINE INTERFACE IS NOT ENABLED.")
+    ).toBe(true);
+  });
+
+  it("returns false for a normal daily path", () => {
+    expect(isCliDisabledOutput("Daily/2026-06-16-화.md")).toBe(false);
+  });
+
+  it("returns false for empty/undefined output", () => {
+    expect(isCliDisabledOutput("")).toBe(false);
+    expect(isCliDisabledOutput(undefined)).toBe(false);
   });
 });
 
@@ -166,6 +192,19 @@ describe("cliDailyPath", () => {
     process.env.OBSIDIAN_BIN = mockBin;
     expect(cliDailyPath()).toBeNull();
   });
+
+  it("returns null when disabled CLI prints warning but exits 0", () => {
+    const mockBin = join(tmpDir, "mock-obsidian-path-disabled");
+    writeFileSync(
+      mockBin,
+      '#!/bin/bash\necho "Command line interface is not enabled. Please turn it on in Settings > General > Advanced."\nexit 0',
+      "utf-8"
+    );
+    chmodSync(mockBin, 0o755);
+
+    process.env.OBSIDIAN_BIN = mockBin;
+    expect(cliDailyPath()).toBeNull();
+  });
 });
 
 describe("cliEnsureDailyNoteExists", () => {
@@ -208,6 +247,32 @@ describe("cliEnsureDailyNoteExists", () => {
 
   it("returns false when CLI binary is not found", () => {
     process.env.OBSIDIAN_BIN = "/nonexistent/obsidian";
+    expect(cliEnsureDailyNoteExists()).toBe(false);
+  });
+
+  it("returns false when disabled CLI prints warning but exits 0 (stdout)", () => {
+    const mockBin = join(tmpDir, "mock-obsidian-daily-disabled");
+    writeFileSync(
+      mockBin,
+      '#!/bin/bash\necho "Command line interface is not enabled. Please turn it on in Settings > General > Advanced."\nexit 0',
+      "utf-8"
+    );
+    chmodSync(mockBin, 0o755);
+
+    process.env.OBSIDIAN_BIN = mockBin;
+    expect(cliEnsureDailyNoteExists()).toBe(false);
+  });
+
+  it("returns false when disabled CLI prints warning to stderr but exits 0", () => {
+    const mockBin = join(tmpDir, "mock-obsidian-daily-disabled-stderr");
+    writeFileSync(
+      mockBin,
+      '#!/bin/bash\necho "Command line interface is not enabled. Please turn it on in Settings > General > Advanced." >&2\nexit 0',
+      "utf-8"
+    );
+    chmodSync(mockBin, 0o755);
+
+    process.env.OBSIDIAN_BIN = mockBin;
     expect(cliEnsureDailyNoteExists()).toBe(false);
   });
 });

--- a/src/claude-settings.ts
+++ b/src/claude-settings.ts
@@ -20,16 +20,23 @@ export const HOOK_ENTRY = {
   ],
 };
 
+export type ClaudeHookState =
+  | { kind: "registered" }
+  | { kind: "missing" }
+  | { kind: "unsupported"; reason: string };
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 /** Returns true if the given hook entry contains an "agentlog hook" command. */
 function isAgentlogHookEntry(entry: unknown): boolean {
   return (
-    typeof entry === "object" &&
-    entry !== null &&
+    isPlainObject(entry) &&
     Array.isArray((entry as Record<string, unknown>)["hooks"]) &&
     ((entry as Record<string, unknown>)["hooks"] as unknown[]).some(
       (h) =>
-        typeof h === "object" &&
-        h !== null &&
+        isPlainObject(h) &&
         (h as Record<string, unknown>)["command"] === "agentlog hook"
     )
   );
@@ -38,14 +45,54 @@ function isAgentlogHookEntry(entry: unknown): boolean {
 function readClaudeSettings(): Record<string, unknown> | null {
   if (!existsSync(CLAUDE_SETTINGS_PATH)) return null;
   try {
-    return JSON.parse(readFileSync(CLAUDE_SETTINGS_PATH, "utf-8"));
+    const parsed = JSON.parse(readFileSync(CLAUDE_SETTINGS_PATH, "utf-8"));
+    return isPlainObject(parsed) ? parsed : null;
   } catch {
     return null;
   }
 }
 
+function readClaudeSettingsState():
+  | { kind: "missing" }
+  | { kind: "ok"; settings: Record<string, unknown> }
+  | { kind: "unsupported"; reason: string } {
+  if (!existsSync(CLAUDE_SETTINGS_PATH)) return { kind: "missing" };
+  try {
+    const parsed = JSON.parse(readFileSync(CLAUDE_SETTINGS_PATH, "utf-8"));
+    if (!isPlainObject(parsed)) {
+      return { kind: "unsupported", reason: "settings.json must be an object" };
+    }
+    return { kind: "ok", settings: parsed };
+  } catch {
+    return { kind: "unsupported", reason: "settings.json is invalid JSON" };
+  }
+}
+
 function writeClaudeSettings(settings: Record<string, unknown>): void {
   writeFileSync(CLAUDE_SETTINGS_PATH, JSON.stringify(settings, null, 2), "utf-8");
+}
+
+export function validateClaudeHookSettings(settings: Record<string, unknown>): string | null {
+  const hooks = settings["hooks"];
+  if (hooks === undefined) return null;
+  if (!isPlainObject(hooks)) return "hooks must be an object";
+
+  for (const [eventName, entries] of Object.entries(hooks)) {
+    if (!Array.isArray(entries)) return `hooks.${eventName} must be an array`;
+
+    for (let index = 0; index < entries.length; index++) {
+      const entry = entries[index];
+      if (!isPlainObject(entry)) return `hooks.${eventName}.${index} must be an object`;
+      if ("matcher" in entry && typeof entry["matcher"] !== "string") {
+        return `hooks.${eventName}.${index}.matcher must be a string`;
+      }
+      if (!Array.isArray(entry["hooks"])) {
+        return `hooks.${eventName}.${index}.hooks must be an array`;
+      }
+    }
+  }
+
+  return null;
 }
 
 export function unregisterHook(): boolean {
@@ -96,21 +143,32 @@ export function registerHook(): void {
   }
   const upsArr = hooks["UserPromptSubmit"] as unknown[];
 
-  // Idempotent: only add if not already registered
-  if (!upsArr.some(isAgentlogHookEntry)) {
-    upsArr.push(HOOK_ENTRY);
-  }
+  // Replace any AgentLog-owned stale hook entry with the canonical matcher string format.
+  hooks["UserPromptSubmit"] = [
+    ...upsArr.filter((entry) => !isAgentlogHookEntry(entry)),
+    HOOK_ENTRY,
+  ];
 
   writeClaudeSettings(settings);
 }
 
+export function inspectClaudeHookState(): ClaudeHookState {
+  const state = readClaudeSettingsState();
+  if (state.kind === "missing") return { kind: "missing" };
+  if (state.kind === "unsupported") return { kind: "unsupported", reason: state.reason };
+
+  const validationError = validateClaudeHookSettings(state.settings);
+  if (validationError) return { kind: "unsupported", reason: validationError };
+
+  const hooks = state.settings["hooks"] as Record<string, unknown> | undefined;
+  if (!hooks || !Array.isArray(hooks["UserPromptSubmit"])) return { kind: "missing" };
+
+  return (hooks["UserPromptSubmit"] as unknown[]).some(isAgentlogHookEntry)
+    ? { kind: "registered" }
+    : { kind: "missing" };
+}
+
 /** Returns true if the agentlog hook is registered in ~/.claude/settings.json */
 export function isHookRegistered(): boolean {
-  const settings = readClaudeSettings();
-  if (!settings) return false;
-
-  const hooks = settings["hooks"] as Record<string, unknown> | undefined;
-  if (!hooks || !Array.isArray(hooks["UserPromptSubmit"])) return false;
-
-  return (hooks["UserPromptSubmit"] as unknown[]).some(isAgentlogHookEntry);
+  return inspectClaudeHookState().kind === "registered";
 }

--- a/src/cli-shared.ts
+++ b/src/cli-shared.ts
@@ -1,0 +1,93 @@
+import { spawnSync } from "child_process";
+import { existsSync } from "fs";
+import { resolve, join } from "path";
+import * as readline from "readline";
+import { detectCli } from "./detect.js";
+import { configPath, expandHome, loadConfig, saveConfig } from "./config.js";
+import { Errors, formatError } from "./errors.js";
+import { MIN_CLI_VERSION } from "./obsidian-cli.js";
+import type { AgentLogConfig } from "./types.js";
+
+export function ask(prompt: string): Promise<string> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolveAnswer) => {
+    rl.question(prompt, (answer) => {
+      rl.close();
+      resolveAnswer(answer.trim());
+    });
+  });
+}
+
+export function validateVault(vaultArg: string, plain: boolean): { vault: string; error?: string } {
+  const vault = resolve(expandHome(vaultArg));
+
+  if (!existsSync(vault)) {
+    return { vault, error: formatError(Errors.VAULT_NOT_FOUND(vault)) };
+  }
+
+  if (!plain) {
+    const obsidianDir = join(vault, ".obsidian");
+    if (!existsSync(obsidianDir)) {
+      return { vault, error: formatError(Errors.VAULT_NOT_OBSIDIAN(vault)) };
+    }
+  }
+
+  return { vault };
+}
+
+export function validateVaultOrExit(vaultArg: string, plain: boolean): string {
+  const { vault, error } = validateVault(vaultArg, plain);
+  if (error) {
+    console.error(error);
+    process.exit(1);
+  }
+  return vault;
+}
+
+export function saveMergedConfig(
+  vault: string,
+  plain: boolean,
+  extra: Partial<AgentLogConfig> = {}
+): AgentLogConfig {
+  const existing = loadConfig() ?? { vault };
+  const next: AgentLogConfig = {
+    ...existing,
+    ...extra,
+    vault,
+  };
+
+  if (plain) {
+    next.plain = true;
+  } else {
+    delete next.plain;
+  }
+
+  saveConfig(next);
+  return next;
+}
+
+export function printSavedConfig(vault: string, plain: boolean): void {
+  console.log(`Config saved: ${configPath()}`);
+  console.log(`  vault: ${vault}${plain ? " (plain mode)" : ""}`);
+}
+
+export function printObsidianCliStatus(plain: boolean): void {
+  if (plain) return;
+
+  const cli = detectCli();
+  if (cli.installed) {
+    console.log(`  Obsidian CLI: detected (${cli.version ?? "unknown version"})`);
+    console.log(`  Daily notes will be written via CLI when Obsidian is running.`);
+  } else {
+    console.log(`  Obsidian CLI: not detected (using direct file write)`);
+    console.log(`  For better integration, enable CLI in Obsidian ${MIN_CLI_VERSION}+ Settings.`);
+  }
+}
+
+export function detectBinary(bin: "agentlog" | "codex"): string {
+  const result = spawnSync("/bin/sh", ["-lc", `command -v ${bin}`], {
+    encoding: "utf-8",
+  });
+  if (result.status !== 0) return "";
+  return (result.stdout ?? "").trim().split("\n").filter(Boolean).pop() ?? "";
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,7 @@ import { spawnSync } from "child_process";
 import { saveConfig, loadConfig, expandHome, configPath, configDir } from "./config.js";
 import type { AgentLogConfig } from "./types.js";
 import { detectVaults, detectCli } from "./detect.js";
-import { isVersionAtLeast, MIN_CLI_VERSION, resolveCliBin, parseCliVersion } from "./obsidian-cli.js";
+import { isVersionAtLeast, isCliDisabledOutput, MIN_CLI_VERSION, resolveCliBin, parseCliVersion } from "./obsidian-cli.js";
 import { registerHook, unregisterHook, inspectClaudeHookState, CLAUDE_SETTINGS_PATH } from "./claude-settings.js";
 import {
   ask,
@@ -427,9 +427,13 @@ async function cmdDoctor(): Promise<void> {
     if (cliBinPath) {
       // 5a. CLI version + minimum version check
       const cliVer = spawnSync(cliBinPath, ["version"], { encoding: "utf-8", timeout: 3000 });
-      // stdout may contain warning lines before the version; take the last non-empty line
-      const version = cliVer.status === 0 ? (parseCliVersion(cliVer.stdout ?? "") ?? "") : "";
-      if (version) {
+      const cliVerDisabled = isCliDisabledOutput(cliVer.stdout) || isCliDisabledOutput(cliVer.stderr);
+      // stdout may contain warning lines before the version; take the last non-empty line.
+      // A disabled CLI emits only the warning, which must not be parsed as a version string.
+      const version = cliVer.status === 0 && !cliVerDisabled ? (parseCliVersion(cliVer.stdout ?? "") ?? "") : "";
+      if (cliVerDisabled) {
+        check("cli-ver", false, "CLI disabled in Obsidian settings", `Enable CLI in Obsidian ${MIN_CLI_VERSION}+ Settings > General > Command line interface`, true);
+      } else if (version) {
         const meetsMin = isVersionAtLeast(version, MIN_CLI_VERSION);
         check(
           "cli-ver",
@@ -442,20 +446,27 @@ async function cmdDoctor(): Promise<void> {
         check("cli-ver", false, "could not determine version", "Ensure Obsidian app is running", true);
       }
 
-      // 5b. CLI responsive (app running + can communicate)
+      // 5b. CLI responsive (app running + CLI enabled + can communicate).
+      // A disabled CLI exits 0 while only printing a warning, so status alone is not enough.
       const cliProbe = spawnSync(cliBinPath, ["daily:path"], { encoding: "utf-8", timeout: 3000 });
+      const cliDisabled = isCliDisabledOutput(cliProbe.stdout) || isCliDisabledOutput(cliProbe.stderr);
+      const cliResponsive = cliProbe.status === 0 && !cliDisabled;
       check(
         "cli-app",
-        cliProbe.status === 0,
-        cliProbe.status === 0 ? "responsive" : "app not responding",
-        "Start Obsidian app, or check CLI settings",
+        cliResponsive,
+        cliResponsive ? "responsive" : cliDisabled ? "CLI disabled in Obsidian settings" : "app not responding",
+        cliDisabled
+          ? `Enable CLI in Obsidian ${MIN_CLI_VERSION}+ Settings > General > Command line interface`
+          : "Start Obsidian app, or check CLI settings",
         true
       );
 
       // 5c. Daily note status (only when CLI is responsive)
-      if (cliProbe.status === 0) {
+      if (cliResponsive) {
         const dailyRead = spawnSync(cliBinPath, ["daily:read"], { encoding: "utf-8", timeout: 3000 });
-        const noteExists = dailyRead.status === 0 && (dailyRead.stdout ?? "").trim().length > 0;
+        const dailyDisabled = isCliDisabledOutput(dailyRead.stdout) || isCliDisabledOutput(dailyRead.stderr);
+        const noteExists =
+          dailyRead.status === 0 && !dailyDisabled && (dailyRead.stdout ?? "").trim().length > 0;
         check(
           "daily",
           noteExists,
@@ -542,11 +553,22 @@ async function cmdDoctor(): Promise<void> {
 }
 
 async function cmdOpen(): Promise<void> {
-  const proc = spawnSync("obsidian", ["daily"], {
+  // Resolve via the shared lookup so OBSIDIAN_BIN and the macOS app-bundle
+  // fallback work here too, instead of relying on `obsidian` being on PATH.
+  const cliBin = resolveCliBin();
+  if (!cliBin) {
+    console.error("Failed to open. Obsidian CLI not found.");
+    console.error(`  Enable CLI in Obsidian ${MIN_CLI_VERSION}+ Settings > General > Command line interface`);
+    process.exit(1);
+    return;
+  }
+  const proc = spawnSync(cliBin, ["daily"], {
     encoding: "utf-8",
     timeout: 5000,
   });
-  if (proc.status === 0) {
+  // A disabled CLI exits 0 while only printing a warning, so status alone is not success.
+  const disabled = isCliDisabledOutput(proc.stdout) || isCliDisabledOutput(proc.stderr);
+  if (proc.status === 0 && !disabled) {
     console.log("Opened today's Daily Note in Obsidian.");
   } else {
     console.error("Failed to open. Is Obsidian running with CLI enabled?");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -51,7 +51,7 @@ type UninstallTarget = "claude" | "codex" | "all";
 async function runInit(vaultArg: string, plain: boolean): Promise<void> {
   const vault = validateVaultOrExit(vaultArg, plain);
 
-  saveMergedConfig(vault, plain);
+  saveMergedConfig(vault, plain, { claudeHookInstalled: true });
   printSavedConfig(vault, plain);
   printObsidianCliStatus(plain);
 
@@ -105,7 +105,7 @@ async function runAllInit(vaultArg: string, plain: boolean): Promise<void> {
     process.exit(1);
   }
 
-  saveMergedConfig(vault, plain, { codexHookInstalled: true });
+  saveMergedConfig(vault, plain, { codexHookInstalled: true, claudeHookInstalled: true });
   printSavedConfig(vault, plain);
   printObsidianCliStatus(plain);
 
@@ -468,6 +468,7 @@ async function cmdDoctor(): Promise<void> {
   }
 
   const hasCodexHookMetadata = config?.codexHookInstalled === true;
+  const hasClaudeHookMetadata = config?.claudeHookInstalled === true;
   const hasRestoreMetadata = !!config && Object.prototype.hasOwnProperty.call(config, "codexNotifyRestore");
   const codexHookState = readCodexHookState();
   const legacyNotifyState = readCodexNotifyState();
@@ -492,7 +493,7 @@ async function cmdDoctor(): Promise<void> {
     hookState.kind === "unsupported"
       ? "run: agentlog init to migrate AgentLog hook, or fix Claude settings"
       : "run: agentlog init to re-register",
-    codexRelevant && hookState.kind === "missing"
+    codexRelevant && hookState.kind === "missing" && !hasClaudeHookMetadata
   );
 
   // 7. Codex hook checks (only when configured or explicitly requested)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,7 +20,7 @@ import { saveConfig, loadConfig, expandHome, configPath, configDir } from "./con
 import type { AgentLogConfig } from "./types.js";
 import { detectVaults, detectCli } from "./detect.js";
 import { isVersionAtLeast, MIN_CLI_VERSION, resolveCliBin, parseCliVersion } from "./obsidian-cli.js";
-import { registerHook, unregisterHook, isHookRegistered, CLAUDE_SETTINGS_PATH } from "./claude-settings.js";
+import { registerHook, unregisterHook, inspectClaudeHookState, CLAUDE_SETTINGS_PATH } from "./claude-settings.js";
 import {
   ask,
   detectBinary,
@@ -477,14 +477,22 @@ async function cmdDoctor(): Promise<void> {
     codexHookState.kind !== "missing" ||
     legacyNotifyState.kind !== "missing";
 
-  // 6. Hook registered
-  const hookOk = isHookRegistered();
+  // 6. Claude hook registered and compatible with Claude Code matcher validation.
+  const hookState = inspectClaudeHookState();
+  const hookOk = hookState.kind === "registered";
+  const hookDetail = hookState.kind === "registered"
+    ? CLAUDE_SETTINGS_PATH
+    : hookState.kind === "unsupported"
+      ? `${CLAUDE_SETTINGS_PATH} — ${hookState.reason}`
+      : "not registered";
   check(
     "hook",
     hookOk,
-    hookOk ? CLAUDE_SETTINGS_PATH : "not registered",
-    "run: agentlog init  to re-register",
-    codexRelevant
+    hookDetail,
+    hookState.kind === "unsupported"
+      ? "run: agentlog init to migrate AgentLog hook, or fix Claude settings"
+      : "run: agentlog init to re-register",
+    codexRelevant && hookState.kind === "missing"
   );
 
   // 7. Codex hook checks (only when configured or explicitly requested)
@@ -671,11 +679,12 @@ async function cmdValidate(): Promise<void> {
   }
 
   // 2. Hook check
-  const hookOk = isHookRegistered();
-  if (hookOk) {
+  const hookState = inspectClaudeHookState();
+  if (hookState.kind === "registered") {
     console.log(`hook: ok — ${CLAUDE_SETTINGS_PATH}`);
   } else {
-    console.log("hook: fail — not registered");
+    const detail = hookState.kind === "unsupported" ? hookState.reason : "not registered";
+    console.log(`hook: fail — ${detail}`);
     allOk = false;
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,12 +4,12 @@
  *
  * Commands:
  *   agentlog init [vault] [--plain] [--claude | --codex | --all]
- *                                   — configure Claude hook, Codex notify, or both
+ *                                   — configure Claude hook, Codex hook, or both
  *   agentlog uninstall [-y] [--codex | --all]
- *                                   — remove Claude hook, Codex notify, or both
+ *                                   — remove Claude hook, Codex hook, or both
  *   agentlog detect                   — list detected Obsidian vaults
  *   agentlog hook                     — invoked by Claude Code UserPromptSubmit hook
- *   agentlog codex-notify             — invoked by Codex notify on agent-turn-complete
+ *   agentlog codex-notify             — legacy Codex notify handler
  */
 
 import { existsSync, readFileSync, rmSync } from "fs";
@@ -23,9 +23,15 @@ import { isVersionAtLeast, MIN_CLI_VERSION, resolveCliBin, parseCliVersion } fro
 import { registerHook, unregisterHook, isHookRegistered, CLAUDE_SETTINGS_PATH } from "./claude-settings.js";
 import { Errors, formatError } from "./errors.js";
 import {
+  CODEX_HOOKS_PATH,
+  type CodexHookMutationResult,
+  readCodexHookState,
+  registerCodexHook,
+  unregisterCodexHook,
+} from "./codex-hooks.js";
+import {
   CODEX_CONFIG_PATH,
   readCodexNotifyState,
-  registerCodexNotify,
   unregisterCodexNotify,
 } from "./codex-settings.js";
 import { formatVersionHeadline, formatVersionOutput, getRuntimeInfo, readVersion, resolvePackageRoot } from "./version-info.js";
@@ -141,17 +147,21 @@ async function runCodexInit(vaultArg: string, plain: boolean): Promise<void> {
   }
 
   const vault = validateVaultOrExit(vaultArg, plain);
-  const existing = loadConfig();
-  const result = registerCodexNotify(existing?.codexNotifyRestore ?? null);
+  let result: CodexHookMutationResult;
+  try {
+    result = registerCodexHook();
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
 
-  saveMergedConfig(vault, plain, { codexNotifyRestore: result.restoreNotify });
+  saveMergedConfig(vault, plain, { codexHookInstalled: true });
   printSavedConfig(vault, plain);
   printObsidianCliStatus(plain);
   console.log(`  Codex CLI: ${codexBin}`);
-  console.log(`Codex notify registered: ${CODEX_CONFIG_PATH}`);
-  if (result.restoreNotify) {
-    console.log(`  Previous notify preserved for forwarding (${result.restoreNotify[0]})`);
-  }
+  console.log(`Codex hook registered: ${CODEX_HOOKS_PATH}`);
+  if (!result.changed) console.log(`  Existing AgentLog Codex hook left unchanged`);
+  console.log(`  Review/trust the hook in Codex with /hooks if prompted.`);
   console.log(`
 AgentLog is ready. Codex turns will be logged to your Daily Note.`);
 }
@@ -164,20 +174,24 @@ async function runAllInit(vaultArg: string, plain: boolean): Promise<void> {
   }
 
   const vault = validateVaultOrExit(vaultArg, plain);
-  const existing = loadConfig();
-  const result = registerCodexNotify(existing?.codexNotifyRestore ?? null);
+  let result: CodexHookMutationResult;
+  try {
+    result = registerCodexHook();
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
 
-  saveMergedConfig(vault, plain, { codexNotifyRestore: result.restoreNotify });
+  saveMergedConfig(vault, plain, { codexHookInstalled: true });
   printSavedConfig(vault, plain);
   printObsidianCliStatus(plain);
 
   registerHook();
   console.log(`Hook registered: ${CLAUDE_SETTINGS_PATH}`);
   console.log(`  Codex CLI: ${codexBin}`);
-  console.log(`Codex notify registered: ${CODEX_CONFIG_PATH}`);
-  if (result.restoreNotify) {
-    console.log(`  Previous notify preserved for forwarding (${result.restoreNotify[0]})`);
-  }
+  console.log(`Codex hook registered: ${CODEX_HOOKS_PATH}`);
+  if (!result.changed) console.log(`  Existing AgentLog Codex hook left unchanged`);
+  console.log(`  Review/trust the hook in Codex with /hooks if prompted.`);
   console.log(`
 AgentLog is ready. Claude Code prompts and Codex turns will be logged to your Daily Note.`);
 }
@@ -279,15 +293,28 @@ function uninstallClaude(configDirPath: string): void {
 
 function uninstallCodex(clearRestoreMetadata: boolean): void {
   const config = loadConfig();
-  const result = unregisterCodexNotify(config?.codexNotifyRestore ?? null);
+  let result: CodexHookMutationResult;
+  try {
+    result = unregisterCodexHook();
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
   if (result.changed) {
-    console.log(`Codex notify restored: ${CODEX_CONFIG_PATH}`);
+    console.log(`Codex hook removed: ${CODEX_HOOKS_PATH}`);
   } else {
-    console.log("Codex notify not found (already removed or never registered)");
+    console.log("Codex hook not found (already removed or never registered)");
+  }
+
+  const legacyNotify = unregisterCodexNotify(config?.codexNotifyRestore ?? null);
+  if (legacyNotify.changed) {
+    const action = legacyNotify.restoreNotify && legacyNotify.restoreNotify.length > 0 ? "restored" : "removed";
+    console.log(`Legacy Codex notify ${action}: ${CODEX_CONFIG_PATH}`);
   }
 
   if (clearRestoreMetadata && config) {
     const next: AgentLogConfig = { ...config };
+    delete next.codexHookInstalled;
     delete next.codexNotifyRestore;
     saveConfig(next);
   }
@@ -321,7 +348,7 @@ async function cmdInitDryRun(vaultArg: string, plain: boolean, target: string): 
     console.log(`  Would register hook in: ${claudeSettingsPath}`);
   }
   if (target === "codex" || target === "all") {
-    console.log(`  Would register codex notify integration`);
+    console.log(`  Would register codex hook integration in: ${CODEX_HOOKS_PATH}`);
   }
 }
 
@@ -517,9 +544,15 @@ async function cmdDoctor(): Promise<void> {
     }
   }
 
+  const hasCodexHookMetadata = config?.codexHookInstalled === true;
   const hasRestoreMetadata = !!config && Object.prototype.hasOwnProperty.call(config, "codexNotifyRestore");
-  const codexState = readCodexNotifyState();
-  const codexRelevant = hasRestoreMetadata || codexState.kind !== "missing";
+  const codexHookState = readCodexHookState();
+  const legacyNotifyState = readCodexNotifyState();
+  const codexRelevant =
+    hasCodexHookMetadata ||
+    hasRestoreMetadata ||
+    codexHookState.kind !== "missing" ||
+    legacyNotifyState.kind !== "missing";
 
   // 6. Hook registered
   const hookOk = isHookRegistered();
@@ -531,7 +564,7 @@ async function cmdDoctor(): Promise<void> {
     codexRelevant
   );
 
-  // 7. Codex notify checks (only when configured or explicitly requested)
+  // 7. Codex hook checks (only when configured or explicitly requested)
   if (codexRelevant) {
     const codexBinPath = detectBinary("codex");
     check(
@@ -541,22 +574,28 @@ async function cmdDoctor(): Promise<void> {
       "install Codex CLI, then re-run: agentlog init --codex ~/path/to/vault"
     );
 
-    const detail = codexState.kind === "unsupported"
-      ? `${CODEX_CONFIG_PATH} — unsupported notify config (${codexState.reason})`
-      : codexState.kind === "registered"
-        ? `${CODEX_CONFIG_PATH} — notify registered`
-        : hasRestoreMetadata
-          ? `${CODEX_CONFIG_PATH} — not registered (inconsistent state)`
-          : `${CODEX_CONFIG_PATH} — not registered`;
+    const detail = codexHookState.kind === "unsupported"
+      ? `${CODEX_HOOKS_PATH} — unsupported hook config (${codexHookState.reason})`
+      : codexHookState.kind === "registered"
+        ? `${CODEX_HOOKS_PATH} — hook registered`
+        : hasCodexHookMetadata
+          ? `${CODEX_HOOKS_PATH} — not registered (inconsistent state)`
+          : legacyNotifyState.kind === "registered"
+            ? `${CODEX_CONFIG_PATH} — legacy notify registered; migrate to hooks`
+            : legacyNotifyState.kind === "unsupported"
+              ? `${CODEX_CONFIG_PATH} — unsupported legacy notify config (${legacyNotifyState.reason})`
+              : `${CODEX_HOOKS_PATH} — not registered`;
 
     check(
       "codex",
-      codexState.kind === "registered",
+      codexHookState.kind === "registered",
       detail,
-      codexState.kind === "unsupported"
-        ? "use a top-level single-line notify array or run: agentlog init --codex after simplifying config"
-        : hasRestoreMetadata
-          ? "run: agentlog init --codex to repair inconsistent state"
+      codexHookState.kind === "unsupported"
+        ? "fix hooks.json or move it aside, then run: agentlog init --codex"
+        : legacyNotifyState.kind === "unsupported"
+          ? "simplify legacy notify config or move config.toml aside, then run: agentlog init --codex"
+          : hasCodexHookMetadata || hasRestoreMetadata || legacyNotifyState.kind === "registered"
+            ? "run: agentlog init --codex to repair or migrate to hooks"
           : "run: agentlog init --codex ~/path/to/vault"
     );
   }
@@ -584,7 +623,7 @@ async function cmdOpen(): Promise<void> {
   }
 }
 
-async function cmdHook(): Promise<void> {
+async function cmdHook(_source: "claude" | "codex" = "claude"): Promise<void> {
   // Dynamically import hook to avoid loading it unless needed
   await import("./hook.js");
 }
@@ -601,13 +640,19 @@ async function cmdCodexDebug(prompt: string[]): Promise<void> {
     process.exit(1);
   }
 
-  // Ensure codex notify is registered so logging works
+  // Ensure Codex hook is registered so logging works
   const config = loadConfig();
-  const result = registerCodexNotify(config?.codexNotifyRestore ?? null);
+  let result: CodexHookMutationResult;
+  try {
+    result = registerCodexHook();
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
   if (result.changed) {
-    console.log("[agentlog] codex notify registered");
+    console.log("[agentlog] codex hook registered");
     if (config) {
-      saveConfig({ ...config, codexNotifyRestore: result.restoreNotify });
+      saveConfig({ ...config, codexHookInstalled: true });
     }
   }
 
@@ -643,16 +688,17 @@ async function cmdUninstall(opts: { y: boolean; codex: boolean; all: boolean; dr
       console.log(`  Would remove config dir: ${cfgDir}`);
     }
     if (target === "codex" || target === "all") {
-      console.log(`  Would restore codex notify: ${CODEX_CONFIG_PATH}`);
+      console.log(`  Would remove codex hook from: ${CODEX_HOOKS_PATH}`);
+      console.log(`  Would restore/remove legacy codex notify in: ${CODEX_CONFIG_PATH}`);
     }
     return;
   }
 
   if (!opts.y && process.stdin.isTTY) {
     const prompt = target === "all"
-      ? "Remove AgentLog Claude hook, Codex notify, and config? [y/N]: "
+      ? "Remove AgentLog Claude hook, Codex hook, and config? [y/N]: "
       : target === "codex"
-        ? "Remove AgentLog Codex notify integration? [y/N]: "
+        ? "Remove AgentLog Codex hook and legacy notify integration? [y/N]: "
         : "Remove AgentLog hook and config? [y/N]: ";
     const answer = await ask(prompt);
     if (answer.toLowerCase() !== "y") {
@@ -669,11 +715,11 @@ async function cmdUninstall(opts: { y: boolean; codex: boolean; all: boolean; dr
   if (target === "all") {
     uninstallCodex(false);
   } else {
-    // Check if Codex notify is still registered
-    const config = loadConfig();
-    if (config?.codexNotifyRestore) {
+    // Check if Codex hook is still registered
+    const codexHookState = readCodexHookState();
+    if (codexHookState.kind === "registered") {
       console.warn(
-        "⚠️  Codex notify is still registered. Run `agentlog uninstall --all` to also remove it."
+        "⚠️  Codex hook is still registered. Run `agentlog uninstall --all` to also remove it."
       );
     }
   }
@@ -721,13 +767,13 @@ const SCHEMA_DATA = {
   commands: [
     {
       name: "init",
-      description: "Configure Claude hook, Codex notify, or both",
+      description: "Configure Claude hook, Codex hook, or both",
       arguments: [{ name: "vault", description: "Path to Obsidian vault or plain folder", required: false }],
       options: [
         { flags: "--plain", description: "Write to plain folder without Obsidian timeblock parsing" },
         { flags: "--claude", description: "Register Claude Code hook only (default)" },
-        { flags: "--codex", description: "Register Codex notify only" },
-        { flags: "--all", description: "Register both Claude hook and Codex notify" },
+        { flags: "--codex", description: "Register Codex hook only" },
+        { flags: "--all", description: "Register both Claude hook and Codex hook" },
         { flags: "--dry-run", description: "Show what would happen without making changes" },
         { flags: "--format <format>", description: "Output format: text or json" },
       ],
@@ -759,12 +805,12 @@ const SCHEMA_DATA = {
     },
     {
       name: "uninstall",
-      description: "Remove Claude hook, Codex notify, or both",
+      description: "Remove Claude hook, Codex hook, or both",
       arguments: [],
       options: [
         { flags: "-y", description: "Skip confirmation prompt" },
-        { flags: "--codex", description: "Remove Codex notify only" },
-        { flags: "--all", description: "Remove both Claude hook and Codex notify" },
+        { flags: "--codex", description: "Remove Codex hook and legacy notify integration" },
+        { flags: "--all", description: "Remove Claude hook, Codex hook, legacy notify, and config" },
         { flags: "--dry-run", description: "Show what would happen without making changes" },
         { flags: "--format <format>", description: "Output format: text or json" },
       ],
@@ -791,13 +837,13 @@ const SCHEMA_DATA = {
     },
     {
       name: "hook",
-      description: "Run hook (called by Claude Code UserPromptSubmit)",
+      description: "Run hook (called by Claude Code or Codex UserPromptSubmit)",
       arguments: [],
       options: [],
     },
     {
       name: "codex-notify",
-      description: "Run notify handler (called by Codex on agent-turn-complete)",
+      description: "Run legacy notify handler (called by old Codex notify on agent-turn-complete)",
       arguments: [{ name: "output-file", description: "Output file path", required: false }],
       options: [],
     },
@@ -848,11 +894,11 @@ Options:
 
 program
   .command("init [vault]")
-  .description("Configure Claude hook, Codex notify, or both")
+  .description("Configure Claude hook, Codex hook, or both")
   .option("--plain", "Write to plain folder without Obsidian timeblock parsing", false)
   .option("--claude", "Register Claude Code hook only (default)", false)
-  .option("--codex", "Register Codex notify only", false)
-  .option("--all", "Register both Claude hook and Codex notify", false)
+  .option("--codex", "Register Codex hook only", false)
+  .option("--all", "Register both Claude hook and Codex hook", false)
   .option("--dry-run", "Show what would happen without making changes", false)
   .option("--format <format>", "Output format: text or json", "text")
   .action(async (vault: string | undefined, opts: { plain: boolean; claude: boolean; codex: boolean; all: boolean; dryRun: boolean; format: string }) => {
@@ -893,10 +939,10 @@ program
 
 program
   .command("uninstall")
-  .description("Remove Claude hook, Codex notify, or both")
+  .description("Remove Claude hook, Codex hook, or both")
   .option("-y", "Skip confirmation prompt", false)
-  .option("--codex", "Remove Codex notify only", false)
-  .option("--all", "Remove both Claude hook and Codex notify", false)
+  .option("--codex", "Remove Codex hook and legacy notify integration", false)
+  .option("--all", "Remove Claude hook, Codex hook, legacy notify, and config", false)
   .option("--dry-run", "Show what would happen without making changes", false)
   .option("--format <format>", "Output format: text or json", "text")
   .action(async (opts: { y: boolean; codex: boolean; all: boolean; dryRun: boolean; format: string }) => {
@@ -923,14 +969,15 @@ program
 
 program
   .command("hook")
-  .description("Run hook (called by Claude Code UserPromptSubmit)")
-  .action(async () => {
-    await cmdHook();
+  .description("Run hook (called by Claude Code or Codex UserPromptSubmit)")
+  .option("--source <source>", "Source to record: claude or codex", "claude")
+  .action(async (opts: { source: "claude" | "codex" }) => {
+    await cmdHook(opts.source);
   });
 
 program
   .command("codex-notify [output-file]")
-  .description("Run notify handler (called by Codex on agent-turn-complete)")
+  .description("Run legacy notify handler (called by old Codex notify on agent-turn-complete)")
   .action(async (outputFile: string | undefined) => {
     await cmdCodexNotify(outputFile);
   });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,7 +12,7 @@
  *   agentlog codex-notify             — legacy Codex notify handler
  */
 
-import { existsSync, readFileSync, rmSync } from "fs";
+import { existsSync, rmSync } from "fs";
 import { join, resolve } from "path";
 import { homedir } from "os";
 import { spawnSync } from "child_process";
@@ -21,7 +21,15 @@ import type { AgentLogConfig } from "./types.js";
 import { detectVaults, detectCli } from "./detect.js";
 import { isVersionAtLeast, MIN_CLI_VERSION, resolveCliBin, parseCliVersion } from "./obsidian-cli.js";
 import { registerHook, unregisterHook, isHookRegistered, CLAUDE_SETTINGS_PATH } from "./claude-settings.js";
-import { Errors, formatError } from "./errors.js";
+import {
+  ask,
+  detectBinary,
+  printObsidianCliStatus,
+  printSavedConfig,
+  saveMergedConfig,
+  validateVault,
+  validateVaultOrExit,
+} from "./cli-shared.js";
 import {
   CODEX_HOOKS_PATH,
   type CodexHookMutationResult,
@@ -35,92 +43,7 @@ import {
   unregisterCodexNotify,
 } from "./codex-settings.js";
 import { formatVersionHeadline, formatVersionOutput, getRuntimeInfo, readVersion, resolvePackageRoot } from "./version-info.js";
-import * as readline from "readline";
 import { Command } from "commander";
-
-function ask(prompt: string): Promise<string> {
-  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-  return new Promise((resolve) => {
-    rl.question(prompt, (answer) => {
-      rl.close();
-      resolve(answer.trim());
-    });
-  });
-}
-
-function validateVault(vaultArg: string, plain: boolean): { vault: string; error?: string } {
-  const vault = resolve(expandHome(vaultArg));
-
-  if (!existsSync(vault)) {
-    return { vault, error: formatError(Errors.VAULT_NOT_FOUND(vault)) };
-  }
-
-  if (!plain) {
-    const obsidianDir = join(vault, ".obsidian");
-    if (!existsSync(obsidianDir)) {
-      return { vault, error: formatError(Errors.VAULT_NOT_OBSIDIAN(vault)) };
-    }
-  }
-
-  return { vault };
-}
-
-function validateVaultOrExit(vaultArg: string, plain: boolean): string {
-  const { vault, error } = validateVault(vaultArg, plain);
-  if (error) {
-    console.error(error);
-    process.exit(1);
-  }
-  return vault;
-}
-
-function saveMergedConfig(
-  vault: string,
-  plain: boolean,
-  extra: Partial<AgentLogConfig> = {}
-): AgentLogConfig {
-  const existing = loadConfig() ?? { vault };
-  const next: AgentLogConfig = {
-    ...existing,
-    ...extra,
-    vault,
-  };
-
-  if (plain) {
-    next.plain = true;
-  } else {
-    delete next.plain;
-  }
-
-  saveConfig(next);
-  return next;
-}
-
-function printSavedConfig(vault: string, plain: boolean): void {
-  console.log(`Config saved: ${configPath()}`);
-  console.log(`  vault: ${vault}${plain ? " (plain mode)" : ""}`);
-}
-
-function printObsidianCliStatus(plain: boolean): void {
-  if (plain) return;
-
-  const cli = detectCli();
-  if (cli.installed) {
-    console.log(`  Obsidian CLI: detected (${cli.version ?? "unknown version"})`);
-    console.log(`  Daily notes will be written via CLI when Obsidian is running.`);
-  } else {
-    console.log(`  Obsidian CLI: not detected (using direct file write)`);
-    console.log(`  For better integration, enable CLI in Obsidian ${MIN_CLI_VERSION}+ Settings.`);
-  }
-}
-
-function detectBinary(bin: "agentlog" | "codex"): string {
-  const result = spawnSync("/bin/sh", ["-lc", `command -v ${bin}`], {
-    encoding: "utf-8",
-  });
-  if (result.status !== 0) return "";
-  return (result.stdout ?? "").trim().split("\n").filter(Boolean).pop() ?? "";
-}
 
 type InitTarget = "claude" | "codex" | "all";
 type UninstallTarget = "claude" | "codex" | "all";

--- a/src/codex-hooks.ts
+++ b/src/codex-hooks.ts
@@ -1,0 +1,219 @@
+import { copyFileSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+export const CODEX_HOOKS_PATH = join(homedir(), ".codex", "hooks.json");
+export const CODEX_HOOKS_BACKUP_PATH = join(homedir(), ".codex", "hooks.json.bak");
+export const AGENTLOG_CODEX_HOOK_COMMAND = "agentlog hook --source codex";
+
+export const CODEX_HOOK_ENTRY = {
+  hooks: [
+    {
+      type: "command",
+      command: AGENTLOG_CODEX_HOOK_COMMAND,
+    },
+  ],
+};
+
+export interface CodexHookMutationResult {
+  json: string;
+  changed: boolean;
+}
+
+export type CodexHookState =
+  | { kind: "missing" }
+  | { kind: "registered" }
+  | { kind: "unsupported"; reason: string };
+
+function parseHooksJson(json: string): Record<string, unknown> {
+  if (json.trim() === "") return {};
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    throw new Error("Unsupported Codex hooks configuration: hooks.json is invalid JSON");
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("Unsupported Codex hooks configuration: hooks.json must be an object");
+  }
+
+  return parsed as Record<string, unknown>;
+}
+
+function isAgentlogCodexHookEntry(entry: unknown): boolean {
+  return (
+    typeof entry === "object" &&
+    entry !== null &&
+    Array.isArray((entry as Record<string, unknown>)["hooks"]) &&
+    ((entry as Record<string, unknown>)["hooks"] as unknown[]).some(isAgentlogCodexHookHandler)
+  );
+}
+
+function isAgentlogCodexHookHandler(hook: unknown): boolean {
+  return (
+    typeof hook === "object" &&
+    hook !== null &&
+    (hook as Record<string, unknown>)["type"] === "command" &&
+    (hook as Record<string, unknown>)["command"] === AGENTLOG_CODEX_HOOK_COMMAND
+  );
+}
+
+function ensureHookArray(root: Record<string, unknown>): unknown[] {
+  if (root["hooks"] === undefined) {
+    root["hooks"] = {};
+  }
+  if (typeof root["hooks"] !== "object" || root["hooks"] === null || Array.isArray(root["hooks"])) {
+    throw new Error("Unsupported Codex hooks configuration: hooks must be an object");
+  }
+
+  const hooks = root["hooks"] as Record<string, unknown>;
+  if (hooks["UserPromptSubmit"] === undefined) {
+    hooks["UserPromptSubmit"] = [];
+  }
+  if (!Array.isArray(hooks["UserPromptSubmit"])) {
+    throw new Error("Unsupported Codex hooks configuration: hooks.UserPromptSubmit must be an array");
+  }
+
+  return hooks["UserPromptSubmit"] as unknown[];
+}
+
+function formatHooksJson(root: Record<string, unknown>): string {
+  return `${JSON.stringify(root, null, 2)}\n`;
+}
+
+export function installCodexHook(json: string): CodexHookMutationResult {
+  const root = parseHooksJson(json);
+  const userPromptSubmit = ensureHookArray(root);
+
+  if (userPromptSubmit.some(isAgentlogCodexHookEntry)) {
+    return { json, changed: false };
+  }
+
+  userPromptSubmit.push(CODEX_HOOK_ENTRY);
+  return { json: formatHooksJson(root), changed: true };
+}
+
+export function uninstallCodexHook(json: string): CodexHookMutationResult {
+  const root = parseHooksJson(json);
+  if (root["hooks"] === undefined) return { json, changed: false };
+  if (typeof root["hooks"] !== "object" || root["hooks"] === null || Array.isArray(root["hooks"])) {
+    throw new Error("Unsupported Codex hooks configuration: hooks must be an object");
+  }
+
+  const hooks = root["hooks"] as Record<string, unknown>;
+  if (hooks["UserPromptSubmit"] === undefined) return { json, changed: false };
+  if (!Array.isArray(hooks["UserPromptSubmit"])) {
+    throw new Error("Unsupported Codex hooks configuration: hooks.UserPromptSubmit must be an array");
+  }
+
+  let removedAgentlogHandler = false;
+  const before = hooks["UserPromptSubmit"] as unknown[];
+  const after = before.flatMap((entry) => {
+    if (
+      typeof entry !== "object" ||
+      entry === null ||
+      !Array.isArray((entry as Record<string, unknown>)["hooks"])
+    ) {
+      return [entry];
+    }
+
+    const hookGroup = entry as Record<string, unknown>;
+    const handlers = hookGroup["hooks"] as unknown[];
+    const nextHandlers = handlers.filter((handler) => !isAgentlogCodexHookHandler(handler));
+    if (nextHandlers.length === handlers.length) return [entry];
+    removedAgentlogHandler = true;
+    if (nextHandlers.length === 0) return [];
+    return [{ ...hookGroup, hooks: nextHandlers }];
+  });
+  if (!removedAgentlogHandler) return { json, changed: false };
+
+  if (after.length === 0) {
+    delete hooks["UserPromptSubmit"];
+  } else {
+    hooks["UserPromptSubmit"] = after;
+  }
+
+  if (Object.keys(hooks).length === 0) {
+    delete root["hooks"];
+  }
+
+  if (Object.keys(root).length === 0) {
+    return { json: "", changed: true };
+  }
+
+  return { json: formatHooksJson(root), changed: true };
+}
+
+export function inspectCodexHookState(json: string): CodexHookState {
+  let root: Record<string, unknown>;
+  try {
+    root = parseHooksJson(json);
+  } catch (err) {
+    return { kind: "unsupported", reason: err instanceof Error ? err.message : String(err) };
+  }
+
+  if (root["hooks"] === undefined) return { kind: "missing" };
+  if (typeof root["hooks"] !== "object" || root["hooks"] === null || Array.isArray(root["hooks"])) {
+    return { kind: "unsupported", reason: "Unsupported Codex hooks configuration: hooks must be an object" };
+  }
+
+  const userPromptSubmit = (root["hooks"] as Record<string, unknown>)["UserPromptSubmit"];
+  if (userPromptSubmit === undefined) return { kind: "missing" };
+  if (!Array.isArray(userPromptSubmit)) {
+    return {
+      kind: "unsupported",
+      reason: "Unsupported Codex hooks configuration: hooks.UserPromptSubmit must be an array",
+    };
+  }
+
+  return userPromptSubmit.some(isAgentlogCodexHookEntry) ? { kind: "registered" } : { kind: "missing" };
+}
+
+export function hasAgentlogCodexHook(json: string): boolean {
+  return inspectCodexHookState(json).kind === "registered";
+}
+
+function readCodexHooksJson(): string {
+  if (!existsSync(CODEX_HOOKS_PATH)) return "";
+  return readFileSync(CODEX_HOOKS_PATH, "utf-8");
+}
+
+function writeCodexHooksJson(json: string, backup: boolean): void {
+  mkdirSync(join(homedir(), ".codex"), { recursive: true });
+  if (backup && existsSync(CODEX_HOOKS_PATH)) {
+    copyFileSync(CODEX_HOOKS_PATH, CODEX_HOOKS_BACKUP_PATH);
+  }
+  if (json === "") {
+    rmSync(CODEX_HOOKS_PATH, { force: true });
+    return;
+  }
+  writeFileSync(CODEX_HOOKS_PATH, json, "utf-8");
+}
+
+export function registerCodexHook(): CodexHookMutationResult {
+  const current = readCodexHooksJson();
+  const result = installCodexHook(current);
+  if (result.changed) {
+    writeCodexHooksJson(result.json, true);
+  }
+  return result;
+}
+
+export function unregisterCodexHook(): CodexHookMutationResult {
+  const current = readCodexHooksJson();
+  const result = uninstallCodexHook(current);
+  if (result.changed) {
+    writeCodexHooksJson(result.json, true);
+  }
+  return result;
+}
+
+export function isCodexHookRegistered(): boolean {
+  return hasAgentlogCodexHook(readCodexHooksJson());
+}
+
+export function readCodexHookState(): CodexHookState {
+  return inspectCodexHookState(readCodexHooksJson());
+}

--- a/src/codex-notify.ts
+++ b/src/codex-notify.ts
@@ -4,6 +4,12 @@ import { appendEntry } from "./note-writer.js";
 import { cwdToProject } from "./schema/daily-note.js";
 import { parseCodexNotifyInput } from "./schema/codex-notify-input.js";
 import { prettyPrompt } from "./schema/pretty-prompt.js";
+import {
+  ENGLISHASK_GUARD_ENV,
+  appendEnglishAskFeedback,
+  englishAskSuggestion,
+  evaluateEnglishAsk,
+} from "./english-ask.js";
 
 function readStdin(): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -29,8 +35,10 @@ function forwardNotify(raw: string, restore: string[] | null | undefined): void 
 }
 
 export async function runCodexNotify(rawArg?: string): Promise<void> {
-  const config = loadConfig();
+  if (process.env[ENGLISHASK_GUARD_ENV] === "1") return;
+
   const raw = rawArg ?? await readStdin();
+  const config = loadConfig();
 
   try {
     if (!config) {
@@ -48,18 +56,31 @@ export async function runCodexNotify(rawArg?: string): Promise<void> {
     const hh = String(now.getHours()).padStart(2, "0");
     const mm = String(now.getMinutes()).padStart(2, "0");
 
-    appendEntry(
+    const entry = {
+      time: `${hh}:${mm}`,
+      prompt,
+      sessionId: parsed.sessionId,
+      project: cwdToProject(parsed.cwd),
+      cwd: parsed.cwd,
+      source: "codex" as const,
+    };
+
+    const result = appendEntry(
       config,
-      {
-        time: `${hh}:${mm}`,
-        prompt,
-        sessionId: parsed.sessionId,
-        project: cwdToProject(parsed.cwd),
-        cwd: parsed.cwd,
-        source: "codex",
-      },
+      entry,
       now
     );
+
+    const feedback = evaluateEnglishAsk(config, parsed.prompt, parsed.cwd);
+    if (feedback) {
+      try {
+        appendEnglishAskFeedback(result.filePath, feedback, entry, config);
+        const suggestion = englishAskSuggestion(config, feedback);
+        if (suggestion) process.stderr.write(suggestion);
+      } catch {
+        // EnglishAsk is best-effort; the normal AgentLog entry is already written.
+      }
+    }
   } catch (err) {
     process.stderr.write(`[agentlog] codex notify error: ${err}\n`);
   } finally {

--- a/src/english-ask.ts
+++ b/src/english-ask.ts
@@ -1,0 +1,187 @@
+import { existsSync, readFileSync, statSync, writeFileSync } from "fs";
+import { spawnSync } from "child_process";
+import type { AgentLogConfig, EnglishAskFeedback } from "./types.js";
+
+export const ENGLISHASK_GUARD_ENV = "AGENTLOG_ENGLISHASK_EVAL";
+
+const DEFAULT_TIMEOUT_MS = 8_000;
+const DEFAULT_THRESHOLD = 3;
+const DEFAULT_MAX_PROMPT_CHARS = 2_000;
+const DEFAULT_MAX_OUTPUT_CHARS = 4_000;
+
+function configured(config: AgentLogConfig): boolean {
+  return config.englishAsk?.enabled === true;
+}
+
+function looksLikeEnglish(prompt: string): boolean {
+  const letters = prompt.match(/[A-Za-z]/g)?.length ?? 0;
+  const hangul = /[가-힣]/.test(prompt);
+  return letters >= 3 && !hangul;
+}
+
+function truncate(value: string, max: number): string {
+  if (value.length <= max) return value;
+  return `${value.slice(0, max)}\n[truncated]`;
+}
+
+function redact(value: string): string {
+  return value
+    .replace(/(sk-[A-Za-z0-9_-]{12,})/g, "[redacted-api-key]")
+    .replace(/(gh[pousr]_[A-Za-z0-9_]{12,})/g, "[redacted-github-token]")
+    .replace(/(npm_[A-Za-z0-9]{12,})/g, "[redacted-npm-token]")
+    .replace(/(Bearer\s+)[A-Za-z0-9._-]{12,}/gi, "$1[redacted-token]");
+}
+
+function buildEvaluatorPrompt(prompt: string): string {
+  return `Evaluate this Codex user prompt for answerability from prior context, not grammar.
+
+Score rubric:
+5: directly answerable
+4: answerable with small assumptions
+3: missing key target, intent, or constraints
+2: unclear requested action
+1: impossible without context
+
+Output exactly:
+Score: N/5
+Natural version: ...
+Missing context: ...
+Rewrite with: ...
+
+User prompt:
+${prompt}`;
+}
+
+function scoreFrom(output: string): number | null {
+  const match = output.match(/Score:\s*([1-5])\s*\/\s*5/i);
+  return match ? Number(match[1]) : null;
+}
+
+function runnableCwd(cwd: string): string {
+  try {
+    return statSync(cwd).isDirectory() ? cwd : process.cwd();
+  } catch {
+    return process.cwd();
+  }
+}
+
+export function shouldEvaluateEnglishAsk(config: AgentLogConfig, prompt: string): boolean {
+  if (!configured(config)) return false;
+  if (process.env[ENGLISHASK_GUARD_ENV] === "1") return false;
+  return looksLikeEnglish(prompt);
+}
+
+export function evaluateEnglishAsk(config: AgentLogConfig, prompt: string, cwd: string): EnglishAskFeedback | null {
+  if (!shouldEvaluateEnglishAsk(config, prompt)) return null;
+
+  const englishAsk = config.englishAsk ?? {};
+  const timeoutMs = englishAsk.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxPromptChars = englishAsk.maxPromptChars ?? DEFAULT_MAX_PROMPT_CHARS;
+  const maxOutputChars = englishAsk.maxOutputChars ?? DEFAULT_MAX_OUTPUT_CHARS;
+  const command = englishAsk.evaluatorCommand ?? ["codex", "exec", "-"];
+  const [bin, ...args] = command;
+  if (!bin) return null;
+
+  const sanitizedPrompt = truncate(redact(prompt), maxPromptChars);
+  const input = buildEvaluatorPrompt(sanitizedPrompt);
+
+  try {
+    const result = spawnSync(bin, args, {
+      cwd: runnableCwd(cwd),
+      input,
+      encoding: "utf-8",
+      timeout: timeoutMs,
+      env: {
+        ...process.env,
+        [ENGLISHASK_GUARD_ENV]: "1",
+      },
+    });
+
+    if (result.error || result.status !== 0 || result.signal !== null) {
+      return null;
+    }
+
+    const raw = result.stdout ?? "";
+    const feedback = truncate(redact(raw.trim()), maxOutputChars);
+    if (!feedback) return null;
+
+    return {
+      score: scoreFrom(feedback),
+      feedback,
+      prompt: sanitizedPrompt,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function englishAskSuggestion(config: AgentLogConfig, feedback: EnglishAskFeedback): string | null {
+  const mode = config.englishAsk?.mode ?? "log-only";
+  const threshold = config.englishAsk?.threshold ?? DEFAULT_THRESHOLD;
+  if (mode !== "suggest") return null;
+  if (feedback.score === null || feedback.score > threshold) return null;
+  return `[agentlog] EnglishAsk score ${feedback.score}/5. Rewrite with target/result, relevant context, constraints, and expected output.\n`;
+}
+
+function indentFeedback(feedback: string): string {
+  return feedback
+    .split("\n")
+    .map((line) => `  ${line}`)
+    .join("\n");
+}
+
+function codeFenceFor(feedback: string): string {
+  const longestBacktickRun = Math.max(2, ...(feedback.match(/`+/g) ?? []).map((run) => run.length));
+  return "`".repeat(Math.max(3, longestBacktickRun + 1));
+}
+
+function listItemValue(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function insertFeedbackBlock(content: string, block: string): string {
+  const sectionMatch = /(^|\n)## EnglishAsk[ \t]*(?:\n|$)/.exec(content);
+  if (!sectionMatch) {
+    const prefix = content.length === 0 ? "" : content.endsWith("\n") ? "\n" : "\n\n";
+    return `${content}${prefix}## EnglishAsk\n\n${block}\n`;
+  }
+
+  const bodyStart = sectionMatch.index + sectionMatch[0].length;
+  const nextHeading = /(^|\n)## /.exec(content.slice(bodyStart));
+  const insertAt = nextHeading ? bodyStart + nextHeading.index : content.length;
+  const before = content.slice(0, insertAt);
+  const after = content.slice(insertAt);
+  const prefix = before.endsWith("\n") ? "\n" : "\n\n";
+
+  return `${before}${prefix}${block}\n${after}`;
+}
+
+export function appendEnglishAskFeedback(
+  filePath: string,
+  feedback: EnglishAskFeedback,
+  entry: { time: string; project: string; cwd: string; sessionId: string },
+  config: AgentLogConfig
+): void {
+  const mode = config.englishAsk?.mode ?? "log-only";
+  const threshold = config.englishAsk?.threshold ?? DEFAULT_THRESHOLD;
+  const scoreText = feedback.score === null ? "unknown" : `${feedback.score}/5`;
+  const rewriteHint = mode === "suggest" && feedback.score !== null && feedback.score <= threshold
+    ? "- action: rewrite suggested before next question"
+    : "";
+  const fence = codeFenceFor(feedback.feedback);
+  const block = [
+    `### ${entry.time} · ${entry.project}`,
+    `<!-- cwd=${entry.cwd} -->`,
+    `- session: [[codex_${entry.sessionId.slice(0, 8)}]]`,
+    `- score: ${scoreText}`,
+    `- prompt: ${listItemValue(feedback.prompt)}`,
+    `${rewriteHint}`,
+    `${fence}text`,
+    indentFeedback(feedback.feedback),
+    fence,
+  ].filter(Boolean).join("\n");
+
+  const content = existsSync(filePath) ? readFileSync(filePath, "utf-8") : "";
+  const next = insertFeedbackBlock(content, block);
+  writeFileSync(filePath, next, "utf-8");
+}

--- a/src/english-ask.ts
+++ b/src/english-ask.ts
@@ -172,7 +172,7 @@ export function appendEnglishAskFeedback(
   const block = [
     `### ${entry.time} · ${entry.project}`,
     `<!-- cwd=${entry.cwd} -->`,
-    `- session: [[codex_${entry.sessionId.slice(0, 8)}]]`,
+    `- session: [[codex_${entry.sessionId}]]`,
     `- score: ${scoreText}`,
     `- prompt: ${listItemValue(feedback.prompt)}`,
     `${rewriteHint}`,

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -1,10 +1,10 @@
 /**
  * AgentLog hook entry point.
  *
- * Invoked by Claude Code UserPromptSubmit hook via stdin JSON.
+ * Invoked by Claude Code or Codex UserPromptSubmit hook via stdin JSON.
  * Reads prompt, determines Daily Note path, delegates to note-writer.
  *
- * Design: fail silently — never interrupt Claude Code.
+ * Design: fail silently — never interrupt the host agent (Claude Code or Codex).
  */
 
 import { loadConfig } from "./config.js";
@@ -12,6 +12,13 @@ import { parseHookInput } from "./schema/hook-input.js";
 import { cwdToProject } from "./schema/daily-note.js";
 import { prettyPrompt } from "./schema/pretty-prompt.js";
 import { appendEntry } from "./note-writer.js";
+import type { SourceType } from "./types.js";
+
+function resolveSource(): SourceType {
+  const sourceIndex = process.argv.indexOf("--source");
+  const source = sourceIndex >= 0 ? process.argv[sourceIndex + 1] : "claude";
+  return source === "codex" ? "codex" : "claude";
+}
 
 /** Read all stdin as a string. Works with both Bun and Node.js. */
 function readStdin(): Promise<string> {
@@ -24,10 +31,15 @@ function readStdin(): Promise<string> {
 }
 
 async function main(): Promise<void> {
+  const source = resolveSource();
+
   // 1. Load config — if absent, hint and exit (not initialized)
   const config = loadConfig();
   if (!config) {
-    process.stderr.write("[agentlog] not initialized. Run: agentlog init ~/path/to/vault\n");
+    const initHint = source === "codex"
+      ? "agentlog init --codex ~/path/to/vault"
+      : "agentlog init ~/path/to/vault";
+    process.stderr.write(`[agentlog] not initialized. Run: ${initHint}\n`);
     return;
   }
 
@@ -37,7 +49,7 @@ async function main(): Promise<void> {
   // 3. Parse hook input
   let parsed;
   try {
-    parsed = parseHookInput(raw);
+    parsed = parseHookInput(raw, { source });
   } catch (err) {
     process.stderr.write(`[agentlog] parse error: ${err}\n`);
     return;
@@ -60,7 +72,7 @@ async function main(): Promise<void> {
     sessionId: parsed.sessionId,
     project: cwdToProject(parsed.cwd),
     cwd: parsed.cwd,
-    source: "claude" as const,
+    source,
   };
 
   try {

--- a/src/note-writer.ts
+++ b/src/note-writer.ts
@@ -201,8 +201,10 @@ function insertIntoAgentLogSection(content: string, entry: LogEntry): string {
   const metaRe = /^<!-- cwd=(.+?) -->$/;
   const legacyMetaRe = /^<!-- cwd=(.+?) ses=([\w-]+) -->$/;
   const legacyHeaderRe = /^#### .+ <!-- cwd=(.+?) ses=([\w-]+) -->$/;
-  // Match current [[claude_...]]/[[codex_...]] and legacy [[ses_...]]/(ses_...) dividers
-  const dividerRe = /^- - - - (?:\[\[(?:claude|codex|ses)_([\w-]+)\]\]|\(ses_([\w-]+)\))$/;
+  // Match current [[claude_...]]/[[codex_...]] and legacy [[ses_...]]/(ses_...) dividers.
+  // Captures the source prefix so session matching stays source-aware: a codex entry
+  // must never be filed under a claude_ divider (or vice versa) even when the ids collide.
+  const dividerRe = /^- - - - (?:\[\[(claude|codex|ses)_([\w-]+)\]\]|\((ses)_([\w-]+)\))$/;
 
   let projectIdx = -1;
   let projectMetaIdx = -1; // -1 means legacy inline format (no separate metadata line)
@@ -280,16 +282,24 @@ function insertIntoAgentLogSection(content: string, entry: LogEntry): string {
       insertAt--;
     }
 
-    // Determine current session from the last divider in this subsection.
+    // Determine current session + source from the last divider in this subsection.
     // Falls back to legacySes (from old metadata format) if no dividers found.
     let currentSes = "";
+    let currentSource = ""; // "claude" | "codex" | "ses" (legacy, source-agnostic) | ""
     for (let i = firstContentIdx; i < subsectionEnd; i++) {
       const m = lines[i].match(dividerRe);
-      if (m) currentSes = m[1] ?? m[2];
+      if (m) {
+        currentSource = m[1] ?? m[3];
+        currentSes = m[2] ?? m[4];
+      }
     }
     if (!currentSes) currentSes = legacySes;
 
-    const sameSession = currentSes === entry.sessionId || currentSes === entry.sessionId.slice(0, 8);
+    const idMatches = currentSes === entry.sessionId || currentSes === entry.sessionId.slice(0, 8);
+    // Legacy dividers ("ses") and metadata-only fallbacks ("") carry no source, so treat them
+    // as matching any source to preserve backward-compatible grouping.
+    const sourceMatches = currentSource === "" || currentSource === "ses" || currentSource === entry.source;
+    const sameSession = idMatches && sourceMatches;
 
     if (!sameSession) {
       // Session changed: insert divider + entry.

--- a/src/note-writer.ts
+++ b/src/note-writer.ts
@@ -10,7 +10,7 @@ import {
   buildProjectHeader,
   buildProjectMetadata,
 } from "./schema/daily-note.js";
-import { cliDailyPath } from "./obsidian-cli.js";
+import { cliDailyPath, cliEnsureDailyNoteExists } from "./obsidian-cli.js";
 
 type DailyNotesConfig = {
   folder?: string;
@@ -87,8 +87,8 @@ function pad2(n: number): string {
   return String(n).padStart(2, "0");
 }
 
-/** Returns daily note file path for a given date. */
-export function dailyNotePath(config: AgentLogConfig, date: Date): string {
+/** Returns daily note file path for a given date, or null when non-plain mode has no safe path source. */
+export function dailyNotePath(config: AgentLogConfig, date: Date): string | null {
   if (config.plain) {
     const yyyy = date.getFullYear();
     const mm = pad2(date.getMonth() + 1);
@@ -105,8 +105,7 @@ export function dailyNotePath(config: AgentLogConfig, date: Date): string {
   const cliPath = relativePath ? safeVaultJoin(config.vault, relativePath) : null;
   if (cliPath) return cliPath;
 
-  // Fallback: hardcoded {vault}/Daily/
-  return join(config.vault, "Daily", dailyNoteFileName(date));
+  return null;
 }
 
 /**
@@ -124,6 +123,9 @@ export function appendEntry(
   date: Date = new Date()
 ): WriteResult {
   const filePath = dailyNotePath(config, date);
+  if (!filePath) {
+    throw new Error("Daily Note path could not be resolved. Enable the Obsidian CLI or configure Daily Notes settings.");
+  }
 
   if (config.plain) {
     return appendPlain(filePath, entry, date);
@@ -131,10 +133,15 @@ export function appendEntry(
 
   const created = !existsSync(filePath);
   if (created) {
-    mkdirSync(dirname(filePath), { recursive: true });
+    if (!cliEnsureDailyNoteExists()) {
+      throw new Error("Daily Note is missing and Obsidian CLI could not create it.");
+    }
+    if (!existsSync(filePath)) {
+      throw new Error("Daily Note is missing after Obsidian CLI bootstrap.");
+    }
   }
 
-  const content = created ? "" : readFileSync(filePath, "utf-8");
+  const content = readFileSync(filePath, "utf-8");
   const newContent = insertIntoAgentLogSection(content, entry);
   writeFileSync(filePath, newContent, "utf-8");
   return { filePath, created, section: "agentlog" };

--- a/src/note-writer.ts
+++ b/src/note-writer.ts
@@ -147,13 +147,12 @@ export function appendEntry(
  *   ## AgentLog
  *   > 🕐 HH:MM — project › prompt        ← latest entry (always updated)
  *
- *   #### project · HH:MM                  ← one section per cwd
+ *   #### HH:MM · project                  ← one section per cwd
  *   - HH:MM entry
- *   - - - - [[claude_XXXXXXXX]]          ← divider when session changes
+ *   - - - - [[claude_<session_id>]]      ← divider when session changes
  *   - HH:MM entry
  */
 function insertIntoAgentLogSection(content: string, entry: LogEntry): string {
-  const sessionShort = entry.sessionId.slice(0, 8);
   const entryLine = buildAgentLogEntry(entry.time, entry.prompt);
   const latestLine = buildLatestLine(entry.time, entry.project, entry.prompt);
 
@@ -283,7 +282,9 @@ function insertIntoAgentLogSection(content: string, entry: LogEntry): string {
     }
     if (!currentSes) currentSes = legacySes;
 
-    if (currentSes !== sessionShort) {
+    const sameSession = currentSes === entry.sessionId || currentSes === entry.sessionId.slice(0, 8);
+
+    if (!sameSession) {
       // Session changed: insert divider + entry.
       lines.splice(insertAt, 0, buildSessionDivider(entry.sessionId, entry.source), entryLine);
       // Migrate legacy metadata format to new format (remove ses=).

--- a/src/obsidian-cli.ts
+++ b/src/obsidian-cli.ts
@@ -26,6 +26,21 @@ type CliBinCacheState =
 /** Cached CLI resolution state for PATH/macos fallback lookup. */
 let _cachedBinState: CliBinCacheState = { status: "unresolved" };
 
+/**
+ * Detect the Obsidian "CLI disabled" warning. When the command line interface
+ * is turned off in Obsidian settings, commands like `daily`, `daily:path`, and
+ * `daily:read` print this warning to stdout/stderr while still exiting with
+ * status 0 — so exit status alone is not a reliable success signal.
+ *
+ * Matches Obsidian's English warning text only; a localized CLI message would
+ * not be detected. The CLI currently emits this string in English regardless of
+ * the app's display language.
+ */
+export function isCliDisabledOutput(output: string | undefined | null): boolean {
+  if (!output) return false;
+  return /command line interface is not enabled/i.test(output);
+}
+
 function envOverrideBin(): string | null {
   const raw = process.env.OBSIDIAN_BIN?.trim();
   return raw ? raw : null;
@@ -74,6 +89,7 @@ export function cliDailyPath(): string | null {
   if (!bin) return null;
   const result = spawnSync(bin, ["daily:path"], { encoding: "utf-8", timeout: CLI_PROBE_TIMEOUT_MS });
   if (result.status !== 0) return null;
+  if (isCliDisabledOutput(result.stdout) || isCliDisabledOutput(result.stderr)) return null;
   // stdout may contain Electron noise lines (e.g. "Loading updated app package",
   // version warnings). The actual path is always the last non-empty line.
   const lines = result.stdout.trim().split("\n").filter(Boolean);
@@ -92,7 +108,10 @@ export function cliEnsureDailyNoteExists(): boolean {
   const bin = resolveCliBin();
   if (!bin) return false;
   const result = spawnSync(bin, ["daily"], { encoding: "utf-8", timeout: DAILY_BOOTSTRAP_TIMEOUT_MS });
-  return result.status === 0;
+  if (result.status !== 0) return false;
+  // A disabled CLI exits 0 while only printing a warning — never bootstraps the note.
+  if (isCliDisabledOutput(result.stdout) || isCliDisabledOutput(result.stderr)) return false;
+  return true;
 }
 
 /** Minimum Obsidian version that supports CLI */

--- a/src/obsidian-cli.ts
+++ b/src/obsidian-cli.ts
@@ -12,6 +12,12 @@ const MACOS_CLI_PATHS = [
   "/Applications/Obsidian.app/Contents/MacOS/obsidian",
 ];
 
+/** Timeout for lightweight CLI probes such as `which`, `version`, and `daily:path`. */
+export const CLI_PROBE_TIMEOUT_MS = 3000;
+
+/** Missing-note bootstrap can start or wake Obsidian, so it gets a longer timeout. */
+export const DAILY_BOOTSTRAP_TIMEOUT_MS = 10000;
+
 type CliBinCacheState =
   | { status: "unresolved" }
   | { status: "resolved"; bin: string }
@@ -39,7 +45,7 @@ export function resolveCliBin(): string | null {
   if (_cachedBinState.status === "resolved") return _cachedBinState.bin;
   if (_cachedBinState.status === "not-found") return null;
 
-  const which = spawnSync("which", ["obsidian"], { encoding: "utf-8", timeout: 3000 });
+  const which = spawnSync("which", ["obsidian"], { encoding: "utf-8", timeout: CLI_PROBE_TIMEOUT_MS });
   if (which.status === 0 && which.stdout.trim()) {
     _cachedBinState = { status: "resolved", bin: which.stdout.trim() };
     return _cachedBinState.bin;
@@ -66,7 +72,7 @@ export function resolveCliBin(): string | null {
 export function cliDailyPath(): string | null {
   const bin = resolveCliBin();
   if (!bin) return null;
-  const result = spawnSync(bin, ["daily:path"], { encoding: "utf-8", timeout: 3000 });
+  const result = spawnSync(bin, ["daily:path"], { encoding: "utf-8", timeout: CLI_PROBE_TIMEOUT_MS });
   if (result.status !== 0) return null;
   // stdout may contain Electron noise lines (e.g. "Loading updated app package",
   // version warnings). The actual path is always the last non-empty line.
@@ -76,6 +82,17 @@ export function cliDailyPath(): string | null {
   // "2026-03-24 04:27:38 App is up to date." being used as a filename.
   if (!path.endsWith(".md")) return null;
   return path || null;
+}
+
+/**
+ * Ask Obsidian to create/open today's Daily Note through its official flow.
+ * This lets Obsidian apply the user's Daily Notes template before AgentLog writes.
+ */
+export function cliEnsureDailyNoteExists(): boolean {
+  const bin = resolveCliBin();
+  if (!bin) return false;
+  const result = spawnSync(bin, ["daily"], { encoding: "utf-8", timeout: DAILY_BOOTSTRAP_TIMEOUT_MS });
+  return result.status === 0;
 }
 
 /** Minimum Obsidian version that supports CLI */

--- a/src/schema/daily-note.ts
+++ b/src/schema/daily-note.ts
@@ -47,10 +47,10 @@ export function buildAgentLogEntry(time: string, prompt: string): string {
 /**
  * Session divider line inserted when session_id changes within a project section.
  * Uses Obsidian wiki-link format so the session ID becomes a navigable link.
- * Format: "- - - - [[claude_XXXXXXXX]]" or "- - - - [[codex_XXXXXXXX]]"
+ * Format: "- - - - [[claude_<session_id>]]" or "- - - - [[codex_<session_id>]]"
  */
 export function buildSessionDivider(sessionId: string, source: SourceType = "claude"): string {
-  return `- - - - [[${source}_${sessionId.slice(0, 8)}]]`;
+  return `- - - - [[${source}_${sessionId}]]`;
 }
 
 /**

--- a/src/schema/hook-input.ts
+++ b/src/schema/hook-input.ts
@@ -1,7 +1,8 @@
 /**
  * Hook Input Schema — Source of Truth
  *
- * Claude Code sends this JSON payload via stdin when a UserPromptSubmit hook fires.
+ * Claude Code and Codex send this JSON payload via stdin when a
+ * UserPromptSubmit hook fires.
  * All fields are validated at runtime by parseHookInput().
  */
 
@@ -17,24 +18,28 @@ export interface HookInputMessage {
 }
 
 /**
- * Full UserPromptSubmit hook payload from Claude Code.
+ * Full UserPromptSubmit hook payload.
  *
  * Required fields: hook_event_name, session_id, cwd
- * Prompt is sourced from `prompt` (preferred) or `message.content` fallback.
+ * Codex requires `prompt`. Claude compatibility keeps older fallback shapes.
  */
 export interface HookInput {
   hook_event_name: "UserPromptSubmit";
   session_id: string;
   cwd: string;
   /** Path to the session transcript JSONL file */
-  transcript_path?: string;
-  /** Claude Code permission mode (e.g. "default", "acceptEdits") */
+  transcript_path?: string | null;
+  /** Codex/Claude permission mode (e.g. "default", "acceptEdits") */
   permission_mode?: string;
-  /** Direct prompt text — preferred source */
+  /** Codex-specific active model slug */
+  model?: string;
+  /** Codex-specific active turn id */
+  turn_id?: string;
+  /** Direct prompt text — required for Codex, preferred for Claude */
   prompt?: string;
-  /** Nested message object — fallback if prompt is absent */
+  /** Claude/backward-compatibility fallback if prompt is absent */
   message?: HookInputMessage;
-  /** Structured content parts — secondary fallback */
+  /** Claude/backward-compatibility fallback if prompt and message are absent */
   parts?: HookInputPart[];
 }
 
@@ -45,17 +50,24 @@ export interface ParsedHookInput {
   prompt: string;
 }
 
+export interface ParseHookInputOptions {
+  source?: "claude" | "codex";
+}
+
 /**
  * Parse and validate raw hook stdin JSON.
  *
- * Prompt extraction priority:
+ * Codex extraction:
+ *   1. input.prompt (required by Codex UserPromptSubmit)
+ *
+ * Claude/backward-compatibility extraction priority:
  *   1. input.prompt
  *   2. input.message.content
  *   3. input.parts[0].text (first text part)
  *
  * @throws {Error} if JSON is invalid or required fields are missing
  */
-export function parseHookInput(raw: string): ParsedHookInput {
+export function parseHookInput(raw: string, options: ParseHookInputOptions = {}): ParsedHookInput {
   let input: unknown;
   try {
     input = JSON.parse(raw);
@@ -69,6 +81,9 @@ export function parseHookInput(raw: string): ParsedHookInput {
 
   const obj = input as Record<string, unknown>;
 
+  if (obj["hook_event_name"] !== "UserPromptSubmit") {
+    throw new Error("Missing or unsupported hook_event_name: UserPromptSubmit");
+  }
   if (typeof obj["session_id"] !== "string" || !obj["session_id"]) {
     throw new Error("Missing required field: session_id");
   }
@@ -81,6 +96,8 @@ export function parseHookInput(raw: string): ParsedHookInput {
 
   if (typeof obj["prompt"] === "string" && obj["prompt"]) {
     prompt = obj["prompt"];
+  } else if (options.source === "codex") {
+    throw new Error("Missing required field for Codex UserPromptSubmit: prompt");
   } else if (
     typeof obj["message"] === "object" &&
     obj["message"] !== null &&

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,23 @@ export interface AgentLogConfig {
   vault: string;
   plain?: boolean;
   codexNotifyRestore?: string[] | null;
+  englishAsk?: EnglishAskConfig;
+}
+
+export interface EnglishAskConfig {
+  enabled?: boolean;
+  mode?: "log-only" | "suggest";
+  threshold?: number;
+  timeoutMs?: number;
+  maxPromptChars?: number;
+  maxOutputChars?: number;
+  evaluatorCommand?: string[];
+}
+
+export interface EnglishAskFeedback {
+  score: number | null;
+  prompt: string;
+  feedback: string;
 }
 
 /** Source of the log entry — which AI tool produced it */

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,8 @@
 export interface AgentLogConfig {
   vault: string;
   plain?: boolean;
+  codexHookInstalled?: boolean;
+  /** Legacy metadata for pre-hook Codex notify installs. */
   codexNotifyRestore?: string[] | null;
   englishAsk?: EnglishAskConfig;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,7 @@
 export interface AgentLogConfig {
   vault: string;
   plain?: boolean;
+  claudeHookInstalled?: boolean;
   codexHookInstalled?: boolean;
   /** Legacy metadata for pre-hook Codex notify installs. */
   codexNotifyRestore?: string[] | null;


### PR DESCRIPTION
## 릴리즈 v0.2.0

develop → main. main push 시 release.yml이 v0.2.0 태그·GitHub Release·npm publish 트리거.

### 주요 변경 (v0.1.3 → v0.2.0)
- feat: EnglishAsk codex evaluator
- feat: Codex 통합을 hooks로 마이그레이션
- feat: note 링크에 full session id 저장
- fix: Codex 세션 codex_ 라벨링, CLI 비활성 status 처리, claude hook matcher 검증
- refactor: 공유 CLI support 레이어 추출
- docs: WORKFLOW 규약 정비