### PR TITLE
chore: 릴리즈 0.3.0 버전 준비

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@albireo3754/agentlog",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Auto-log Claude Code prompts to Obsidian Daily Notes",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- bump package version to 0.3.0 for the Hermes hook and EnglishAsk context release

## Verification
- bun test (311 pass)
- bun run typecheck
- bun run build
- npm pack --dry-run