### PR TITLE
release: v0.3.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,7 +218,8 @@ Legacy handler for older Codex `notify` installs on `agent-turn-complete`. Do no
   "codexNotifyRestore": null,
   "englishAsk": {
     "enabled": false,
-    "mode": "log-only"
+    "mode": "log-only",
+    "maxContextChars": 4000
   }
 }
 ```
@@ -230,9 +231,9 @@ Legacy handler for older Codex `notify` installs on `agent-turn-complete`. Do no
 | `claudeHookInstalled` | no | Marks that AgentLog expects the Claude hook to be installed for doctor/repair checks |
 | `codexHookInstalled` | no | Marks that AgentLog expects the Codex hook to be installed for doctor/repair checks |
 | `codexNotifyRestore` | no | Legacy metadata for older Codex `notify` installs |
-| `englishAsk` | no | Optional Codex prompt evaluator config. Disabled unless `englishAsk.enabled` is true |
+| `englishAsk` | no | Optional hook prompt evaluator config. Disabled unless `englishAsk.enabled` is true |
 
-EnglishAsk evaluates English Codex user prompts with `codex exec` after the normal Daily Note append. Results are written under `## EnglishAsk`; evaluator failures and timeouts are fail-soft. `AGENTLOG_ENGLISHASK_EVAL=1` skips evaluator child notify turns.
+EnglishAsk evaluates English hook prompts with `codex exec` after the normal Daily Note append. The evaluator receives the current raw prompt plus bounded prior user/model context from the hook transcript when available. If no transcript is available, AgentLog falls back to same-session prompt context from the Daily Note. Results are written under `## EnglishAsk`; evaluator failures and timeouts are fail-soft. `AGENTLOG_ENGLISHASK_EVAL=1` skips evaluator child turns.
 
 ## Daily Note Output Format
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,17 @@ Example:
 agentlog open
 ```
 
+### `agentlog backfill [date] [--source all|claude|codex] [--dry-run]`
+
+Scans local Claude Code and Codex session JSONL files for missed user prompts and appends entries that are not already present in the target Daily Note. Defaults to today and both sources.
+
+Example:
+```
+agentlog backfill
+agentlog backfill 2026-06-19 --source codex
+agentlog backfill --dry-run
+```
+
 ### `agentlog uninstall [-y] [--codex | --all]`
 
 Removes AgentLog integration(s).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,7 @@ Example:
 agentlog open
 ```
 
-### `agentlog backfill [date] [--source all|claude|codex] [--dry-run]`
+### `agentlog backfill [date] [--source all|claude|codex] [--dry-run] [--format text|json]`
 
 Scans local Claude Code and Codex session JSONL files for missed user prompts and appends entries that are not already present in the target Daily Note. Defaults to today and both sources.
 
@@ -121,7 +121,7 @@ Example:
 ```
 agentlog backfill
 agentlog backfill 2026-06-19 --source codex
-agentlog backfill --dry-run
+agentlog backfill --dry-run --format json
 ```
 
 ### `agentlog uninstall [-y] [--codex | --all]`

--- a/README.md
+++ b/README.md
@@ -113,6 +113,18 @@ The `default = --all` variant is intentionally not supported. `agentlog init` st
 
 Use Claude Code or Codex normally. Claude and Codex prompts are logged from their `UserPromptSubmit` hook payloads.
 
+### Backfill Missed Prompts
+
+If hooks were disabled, untrusted, or misconfigured for part of the day, rebuild the Daily Note from local session JSONL files:
+
+```bash
+agentlog backfill              # today, Claude + Codex
+agentlog backfill 2026-06-19   # specific day
+agentlog backfill --source codex --dry-run
+```
+
+Backfill scans `~/.codex/sessions/YYYY/MM/DD/*.jsonl` and top-level `~/.claude/projects/**/*.jsonl`, extracts user prompts only, skips subagent/tool-result noise, and appends entries that are not already present in the target Daily Note.
+
 ### How It Works
 
 1. Claude Code or Codex fires the `UserPromptSubmit` hook
@@ -168,6 +180,7 @@ Current CLI:
 |---------|-------------|
 | `agentlog init [vault] [--plain] [--claude\|--codex\|--all]` | Configure vault and install integrations. `--claude` (default): Claude hook, `--codex`: Codex hook, `--all`: both |
 | `agentlog detect` | List detected Obsidian vaults and CLI status |
+| `agentlog backfill [date] [--source all\|claude\|codex] [--dry-run]` | Scan local Claude/Codex session JSONL files and append missing prompts to the Daily Note |
 | `agentlog codex-debug <prompt>` | Run `codex exec "<prompt>"` with Codex hook auto-registered |
 | `agentlog doctor` | Run health checks for the binary, vault, Claude hook registration/format, and Obsidian CLI. Also checks Codex hook status if configured |
 | `agentlog open` | Open today's Daily Note in Obsidian (requires CLI 1.12.4+) |

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ If hooks were disabled, untrusted, or misconfigured for part of the day, rebuild
 ```bash
 agentlog backfill              # today, Claude + Codex
 agentlog backfill 2026-06-19   # specific day
-agentlog backfill --source codex --dry-run
+agentlog backfill --source codex --dry-run --format json
 ```
 
 Backfill scans `~/.codex/sessions/YYYY/MM/DD/*.jsonl` and top-level `~/.claude/projects/**/*.jsonl`, extracts user prompts only, skips subagent/tool-result noise, and appends entries that are not already present in the target Daily Note.
@@ -180,7 +180,7 @@ Current CLI:
 |---------|-------------|
 | `agentlog init [vault] [--plain] [--claude\|--codex\|--all]` | Configure vault and install integrations. `--claude` (default): Claude hook, `--codex`: Codex hook, `--all`: both |
 | `agentlog detect` | List detected Obsidian vaults and CLI status |
-| `agentlog backfill [date] [--source all\|claude\|codex] [--dry-run]` | Scan local Claude/Codex session JSONL files and append missing prompts to the Daily Note |
+| `agentlog backfill [date] [--source all\|claude\|codex] [--dry-run] [--format text\|json]` | Scan local Claude/Codex session JSONL files and append missing prompts to the Daily Note |
 | `agentlog codex-debug <prompt>` | Run `codex exec "<prompt>"` with Codex hook auto-registered |
 | `agentlog doctor` | Run health checks for the binary, vault, Claude hook registration/format, and Obsidian CLI. Also checks Codex hook status if configured |
 | `agentlog open` | Open today's Daily Note in Obsidian (requires CLI 1.12.4+) |

--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ agentlog init --codex ~/Obsidian
 # Claude + Codex
 agentlog init --all ~/Obsidian
 
+# Hermes Agent
+agentlog init --hermes ~/Obsidian
+agentlog init --hermes --hermes-profile work ~/Obsidian
+agentlog init --hermes --hermes-all-profiles ~/Obsidian
+
 # Plain folder
 agentlog init --plain ~/notes
 ```
@@ -109,9 +114,19 @@ Run `agentlog init` without arguments to auto-detect installed vaults.
 
 The `default = --all` variant is intentionally not supported. `agentlog init` stays Claude-first for backward compatibility and to avoid failing on machines without Codex CLI.
 
+`agentlog init --hermes` records Hermes metadata and writes this shell hook under `hooks.pre_llm_call` in the selected Hermes config:
+
+```yaml
+hooks:
+  pre_llm_call:
+    - command: "agentlog hook --source hermes"
+```
+
+By default it edits `~/.hermes/config.yaml`. Use `--hermes-profile <name>` for `~/.hermes/profiles/<name>/config.yaml`, repeat the flag for multiple profiles, or use `--hermes-all-profiles` for default plus every existing named profile. AgentLog uses structured YAML parsing and only adds/removes its own command. See `docs/hermes-hook-spec.md`.
+
 ### That's It
 
-Use Claude Code or Codex normally. Claude and Codex prompts are logged from their `UserPromptSubmit` hook payloads.
+Use Claude Code, Codex, or Hermes normally. Claude and Codex prompts are logged from `UserPromptSubmit`; Hermes prompts are logged from `pre_llm_call` after Hermes accepts/trusts the shell hook.
 
 ### Backfill Missed Prompts
 
@@ -127,13 +142,13 @@ Backfill scans `~/.codex/sessions/YYYY/MM/DD/*.jsonl` and top-level `~/.claude/p
 
 ### How It Works
 
-1. Claude Code or Codex fires the `UserPromptSubmit` hook
+1. Claude Code/Codex fires `UserPromptSubmit`, or Hermes fires `pre_llm_call`
 2. AgentLog extracts the latest user-visible input and sanitizes it
 3. Resolves your Daily Note path from `.obsidian/daily-notes.json`, then `obsidian daily:path` when needed
 4. If the Daily Note is missing in Obsidian mode, asks `obsidian daily` to create it before writing so your Daily Notes template is preserved
 5. Finds or creates a `## AgentLog` section
 6. Finds or creates a `#### project` subsection matching the current working directory
-7. Inserts a source-prefixed session divider such as `[[claude_...]]` or `[[codex_...]]` if the session changed, then appends the entry
+7. Inserts a source-prefixed session divider such as `[[claude_...]]`, `[[codex_...]]`, or `[[hermes_...]]` if the session changed, then appends the entry
 8. Updates the `> 🕐` latest-entry line at the top of the section
 
 Steady-state overhead is under 50ms per prompt when the Daily Note already exists. Missing-note bootstrap depends on Obsidian CLI startup. Fire-and-forget, never blocks Claude Code.
@@ -144,7 +159,7 @@ Steady-state overhead is under 50ms per prompt when the Daily Note already exist
 
 AgentLog resolves the Daily Note path from `.obsidian/daily-notes.json` first, then `obsidian daily:path` when the vault settings are unavailable or unsupported. If the resolved Daily Note is missing, AgentLog runs `obsidian daily` before writing and only appends after the file exists, preserving the user's Daily Notes template. Obsidian mode does not create a guessed `{vault}/Daily/...` fallback file; if no safe path can be resolved or the CLI cannot bootstrap a missing note, the hook fails softly and skips the write. Plain mode still writes directly to `{dir}/YYYY-MM-DD.md`.
 
-Each working directory gets its own `#### project` subsection. Session changes insert a source-prefixed wiki-link divider such as `[[claude_...]]` or `[[codex_...]]`. The `> 🕐` blockquote at the top always shows the latest entry across all projects.
+Each working directory gets its own `#### project` subsection. Session changes insert a source-prefixed wiki-link divider such as `[[claude_...]]`, `[[codex_...]]`, or `[[hermes_...]]`. The `> 🕐` blockquote at the top always shows the latest entry across all projects.
 
 ```markdown
 ## AgentLog
@@ -178,14 +193,15 @@ Current CLI:
 
 | Command | Description |
 |---------|-------------|
-| `agentlog init [vault] [--plain] [--claude\|--codex\|--all]` | Configure vault and install integrations. `--claude` (default): Claude hook, `--codex`: Codex hook, `--all`: both |
+| `agentlog init [vault] [--plain] [--claude\|--codex\|--hermes\|--all]` | Configure vault and install integrations. `--claude` (default): Claude hook, `--codex`: Codex hook, `--hermes`: Hermes shell hook config, `--all`: Claude+Codex |
 | `agentlog detect` | List detected Obsidian vaults and CLI status |
 | `agentlog backfill [date] [--source all\|claude\|codex] [--dry-run] [--format text\|json]` | Scan local Claude/Codex session JSONL files and append missing prompts to the Daily Note |
+| `agentlog init --hermes [--hermes-profile <name>...] [--hermes-all-profiles] <vault>` | Write Hermes `pre_llm_call` shell-hook config and record profile metadata |
 | `agentlog codex-debug <prompt>` | Run `codex exec "<prompt>"` with Codex hook auto-registered |
-| `agentlog doctor` | Run health checks for the binary, vault, Claude hook registration/format, and Obsidian CLI. Also checks Codex hook status if configured |
+| `agentlog doctor` | Run health checks for the binary, vault, Claude hook registration/format, and Obsidian CLI. Also checks Codex/Hermes hook status if configured |
 | `agentlog open` | Open today's Daily Note in Obsidian (requires CLI 1.12.4+) |
 | `agentlog version` | Print AgentLog version. In `dev` builds, also shows channel and commit |
-| `agentlog uninstall [-y] [--codex\|--all]` | `default`: Remove Claude hook + config, `--codex`: Remove Codex hook and unregister/restore legacy `~/.codex/config.toml` notify if AgentLog set it up, `--all`: Remove both |
+| `agentlog uninstall [-y] [--codex\|--hermes\|--all]` | `default`: Remove Claude hook + config, `--codex`: Remove Codex hook and legacy notify metadata, `--hermes`: remove AgentLog's Hermes hook from configured profiles and clear metadata, `--all`: remove all AgentLog-owned integration state |
 | `agentlog hook` | Invoked automatically by Claude Code or Codex (not for direct use) |
 | `agentlog codex-notify` | Legacy handler for older Codex `notify` installs |
 
@@ -199,8 +215,11 @@ Current CLI:
 | `plain` | `false` | Plain mode that writes simple markdown files without Obsidian integration |
 | `claudeHookInstalled` | `false` | Records that AgentLog expects the Claude hook to be installed, so `doctor` does not downgrade a missing Claude hook in `--all` installs |
 | `codexHookInstalled` | `false` | Records that AgentLog expects the Codex hook to be installed, so `doctor` can detect partial damage |
+| `hermesHookInstalled` | `false` | Records that AgentLog expects Hermes hook config to be present, so `doctor` can detect partial damage |
+| `hermesHome` | unset | Hermes config root used by `init --hermes` when `HERMES_HOME` is set; reused by `doctor` and `uninstall --hermes` |
+| `hermesProfiles` | unset | Hermes profiles selected by `init --hermes`; used by `doctor` and `uninstall --hermes` |
 | `codexNotifyRestore` | unset | Legacy metadata for older Codex `notify` installs |
-| `englishAsk` | unset | Optional Codex prompt evaluator config. Disabled unless `englishAsk.enabled` is `true` |
+| `englishAsk` | unset | Optional hook prompt evaluator config. Disabled unless `englishAsk.enabled` is `true` |
 
 Example EnglishAsk config:
 
@@ -210,12 +229,15 @@ Example EnglishAsk config:
     "enabled": true,
     "mode": "log-only",
     "threshold": 3,
-    "timeoutMs": 8000
+    "timeoutMs": 20000,
+    "maxContextChars": 4000
   }
 }
 ```
 
-When enabled, AgentLog evaluates English Codex user prompts with `codex exec` after writing the normal AgentLog entry. Results are appended to the same Daily Note under `## EnglishAsk`. Evaluator failures and timeouts are ignored. Child evaluator runs set `AGENTLOG_ENGLISHASK_EVAL=1` so AgentLog skips evaluator child notify turns.
+When enabled, AgentLog evaluates English hook prompts with `codex exec` after writing the normal AgentLog entry. The evaluator receives the current raw prompt plus bounded prior user/model context from the hook transcript when available. If no transcript is available, AgentLog falls back to same-session prompt context from the Daily Note. Results are appended to the same Daily Note under `## EnglishAsk`. Evaluator failures and timeouts are ignored. Child evaluator runs set `AGENTLOG_ENGLISHASK_EVAL=1` so AgentLog skips evaluator child turns.
+
+The default evaluator command is `codex exec --ignore-user-config --ephemeral -` so hook-time evaluation avoids loading the user's normal Codex hooks and MCP config. Override it with `englishAsk.evaluatorCommand` when a different evaluator is required.
 
 Environment variables:
 
@@ -276,6 +298,7 @@ Codex 상태 확인은 별도 명령 대신 기존 `agentlog doctor`에 포함�
 bun install
 bun test              # run the test suite
 bun run test:install-smoke
+bun run test:hermes-host
 bun run typecheck     # run tsc --noEmit
 bun run build         # compile to dist/ (optional)
 ```
@@ -293,6 +316,12 @@ agentlog doctor
 
 # Isolated bun link install smoke test
 bun run test:install-smoke
+
+# Real host Hermes install smoke. Mutates your global agentlog link,
+# ~/.agentlog/config.json, selected ~/.hermes config, and Hermes hook allowlist.
+bun run test:hermes-host
+bun run test:hermes-host -- --profile work
+bun run test:hermes-host -- --append-fixture
 
 # Watch mode
 bun run dev:watch

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
       "name": "agentlog",
       "dependencies": {
         "commander": "^14.0.3",
+        "yaml": "^2.9.0",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -24,5 +25,7 @@
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
   }
 }

--- a/docs/codex-hook-spec.md
+++ b/docs/codex-hook-spec.md
@@ -51,12 +51,19 @@ Registration rules:
 1. Use `~/.codex/hooks.json` for user-level Codex integration.
 2. Preserve unrelated hook events and unrelated `UserPromptSubmit` hook groups.
 3. Add the AgentLog hook idempotently; never duplicate the same command.
-4. Omit `matcher` for `UserPromptSubmit`; Codex currently ignores matchers for
+4. Treat a `UserPromptSubmit` handler whose command is exactly `agentlog hook`
+   as an AgentLog legacy Codex handler and migrate it to
+   `agentlog hook --source codex`. Leaving both commands installed logs the same
+   Codex prompt twice and can mislabel one entry as Claude-sourced.
+5. When migration or uninstall changes the `UserPromptSubmit` hook array, drop
+   top-level `state` entries keyed to `:user_prompt_submit:` because Codex hook
+   trust state is index-based and may no longer point at the same command.
+6. Omit `matcher` for `UserPromptSubmit`; Codex currently ignores matchers for
    this event.
-5. Command hooks run with the Codex session `cwd`, but AgentLog still reads
+7. Command hooks run with the Codex session `cwd`, but AgentLog still reads
    `cwd` from hook stdin because it is part of the documented common input.
-6. `type: "command"` is the only handler type AgentLog should emit today.
-7. Do not configure `notify` for new Codex installs. Codex project-local config
+8. `type: "command"` is the only handler type AgentLog should emit today.
+9. Do not configure `notify` for new Codex installs. Codex project-local config
    also cannot override `notify`; user-level notification/hook behavior belongs
    in user-level Codex config.
 

--- a/docs/hermes-hook-spec.md
+++ b/docs/hermes-hook-spec.md
@@ -1,0 +1,72 @@
+# Hermes Hook Spec
+
+AgentLog supports Hermes Agent live prompt capture through the Hermes `pre_llm_call` shell hook.
+
+## Setup
+
+Run:
+
+```bash
+agentlog init --hermes ~/Obsidian
+```
+
+AgentLog writes this command to `hooks.pre_llm_call` in `~/.hermes/config.yaml`:
+
+```yaml
+hooks:
+  pre_llm_call:
+    - command: "agentlog hook --source hermes"
+```
+
+Named Hermes profiles are supported:
+
+```bash
+agentlog init --hermes --hermes-profile work ~/Obsidian
+agentlog init --hermes --hermes-profile alpha --hermes-profile beta ~/Obsidian
+agentlog init --hermes --hermes-all-profiles ~/Obsidian
+```
+
+`--hermes-profile <name>` targets `~/.hermes/profiles/<name>/config.yaml`; `--hermes-all-profiles` targets the default config plus every existing named profile config. `agentlog uninstall --hermes` removes only `agentlog hook --source hermes` from the configured profiles and clears AgentLog metadata.
+
+AgentLog uses structured YAML parsing. It rejects unsupported YAML instead of regex-editing arbitrary `config.yaml` content.
+
+## Input Contract
+
+Hermes shell hooks send JSON on stdin. AgentLog accepts:
+
+```json
+{
+  "hook_event_name": "pre_llm_call",
+  "session_id": "hermes-session-123",
+  "cwd": "/Users/pray/work/js/agentlog",
+  "extra": {
+    "user_message": "prompt text"
+  }
+}
+```
+
+Required fields:
+
+| Field | Requirement |
+|-------|-------------|
+| `hook_event_name` | Must be `pre_llm_call` |
+| `session_id` | Non-empty string |
+| `cwd` | Non-empty string |
+| `extra.user_message` | Non-empty string |
+
+## Output Contract
+
+AgentLog writes the same Daily Note structure as Claude and Codex, using a Hermes source divider:
+
+```markdown
+- - - - [[hermes_hermes-session-123]]
+- 10:53 prompt text
+```
+
+AgentLog emits no stdout on successful hook execution, so it does not inject Hermes context.
+
+## Non-Goals
+
+- No Hermes backfill until transcript format is separately verified.
+- No EnglishAsk evaluation for Hermes.
+- No broad Hermes plugin framework; AgentLog uses the documented shell-hook surface.

--- a/docs/plans/2026-06-21-hook-provider-abstraction-hermes-prd.md
+++ b/docs/plans/2026-06-21-hook-provider-abstraction-hermes-prd.md
@@ -1,0 +1,398 @@
+# Hook Provider Abstraction, Then Hermes
+
+> status: draft
+> created: 2026-06-21
+> updated: 2026-06-21
+> revision: 2
+
+## 0. LLM Work Guide
+
+> **Follow the Spec Execution Protocol (`/sisyphus`).** This PRD is implementation-ready only after the Phase 0 hard gate below passes.
+
+| Item | Section |
+|------|---------|
+| Task Checklist | §6 |
+| Naming Conventions | §3.5 |
+| State file | `docs/plans/2026-06-21-hook-provider-abstraction-hermes-prd.state.md` |
+| Decision Log | §8 |
+| Handoff Snapshot | §9 |
+| Changelog | §10 |
+
+Hard gate:
+
+- Phase 1 provider extraction must not start until Phase 0 coverage matrix, missing regression tests, QA smoke plan, agent-framework readiness review, and PRD gap patch are complete.
+- Phase 0 completion evidence must include `bun test`, `bun run typecheck`, `agentlog doctor`, and `node scripts/prd-redteam.mjs --output docs/plans/2026-06-21-hook-provider-prd-redteam-report.json`.
+- If the red-team report fails, patch this PRD first, then rerun the gate before implementation.
+- If the red-team report is missing, stale for the current PRD revision, invalid JSON, or has `"verdict" != "pass"`, Phase 1 is blocked.
+- The Phase 0 sign-off proof is this exact evidence set:
+  - `docs/plans/2026-06-21-hook-provider-current-behavior-coverage.md` exists and every row has `automated`, `manual QA`, or `not in scope` evidence.
+  - `docs/plans/2026-06-21-hook-provider-agent-readiness.md` exists and lists no blocker with status `open`.
+  - Missing regression tests discovered by those documents are committed before provider extraction.
+  - `docs/plans/2026-06-21-hook-provider-prd-redteam-report.json` exists with `"verdict": "pass"`.
+  - The final implementation note cites the validation commands and their pass/fail output.
+
+Phase 0 command thresholds:
+
+| Command | Required threshold |
+|---------|--------------------|
+| `bun test` | exit code 0 for the full suite |
+| `bun run typecheck` | exit code 0 |
+| `bun run build` | exit code 0 |
+| `agentlog doctor` | exit code 0 in the developer environment |
+| `node scripts/prd-redteam.mjs --output docs/plans/2026-06-21-hook-provider-prd-redteam-report.json` | exit code 0 and report JSON `"verdict": "pass"` |
+
+Phase 0 artifact status:
+
+| Artifact | Required status | Machine-check |
+|----------|-----------------|---------------|
+| `docs/plans/2026-06-21-hook-provider-current-behavior-coverage.md` | present before Phase 1 | `phase0-artifacts-exist` red-team check |
+| `docs/plans/2026-06-21-hook-provider-agent-readiness.md` | present before Phase 1, no open blocker | `phase0-artifacts-exist` red-team check plus reviewer read |
+| `docs/plans/2026-06-21-hook-provider-prd-redteam-report.json` | regenerated after PRD edits | JSON `"verdict": "pass"` |
+
+## 1. Goal
+
+Refactor AgentLog's Claude/Codex hook integration into a small provider layer, then add Hermes Agent as the third hook provider.
+
+This follows the "third time" rule:
+
+- Claude-only did not need an abstraction.
+- Claude + Codex still tolerated explicit branching.
+- Claude + Codex + Hermes creates the third repeated hook lifecycle path, so provider extraction is now justified.
+
+The desired end state:
+
+- Existing Claude and Codex installs, doctor checks, uninstall behavior, and Daily Note output remain unchanged.
+- Hook provider lifecycle logic becomes registry-driven instead of hard-coded throughout `src/cli.ts`.
+- `agentlog hook --source hermes` accepts Hermes `pre_llm_call` shell-hook payloads and writes `[[hermes_<session_id>]]` dividers.
+- Hermes setup is automated for this PRD: `agentlog init --hermes` writes the AgentLog shell hook to Hermes config with structured YAML parsing, records selected profiles, and `agentlog uninstall --hermes` removes only AgentLog's command.
+
+## 2. Non-Goals
+
+- Do not rewrite the Daily Note writer.
+- Do not redesign Obsidian path resolution or Daily Note bootstrap.
+- Do not add Hermes backfill until Hermes transcript format is separately verified.
+- Do not make EnglishAsk run for Hermes.
+- Do not silently include Hermes in `agentlog init --all`; keep `--all` as Claude+Codex for backward compatibility.
+- Do not regex-edit arbitrary YAML for `~/.hermes/config.yaml`.
+- Do not mutate Hermes YAML without a structured parser, idempotency tests, invalid-YAML failure tests, and AgentLog-only unregister tests.
+- Do not add a broad plugin framework beyond the hook-provider boundary.
+
+## 3. Design
+
+### 3.1 Deliverables
+
+| Deliverable | Path | Consumer | Format |
+|-------------|------|----------|--------|
+| Provider type definitions | `src/hook-providers/types.ts` | CLI, hook parser, tests | TypeScript |
+| Provider registry | `src/hook-providers/index.ts` | CLI orchestration | TypeScript |
+| Claude provider adapter | `src/hook-providers/claude.ts` | provider registry | TypeScript |
+| Codex provider adapter | `src/hook-providers/codex.ts` | provider registry | TypeScript |
+| Hermes provider adapter | `src/hook-providers/hermes.ts` | provider registry | TypeScript |
+| Hermes hook fixture | `src/__tests__/fixtures/hermes-pre-llm-call.json` | hook parser tests | JSON |
+| Generic provider lifecycle tests | `src/__tests__/hook-providers.test.ts` | implementation verification | Bun test |
+| Current behavior coverage matrix | `docs/plans/2026-06-21-hook-provider-current-behavior-coverage.md` | implementer, reviewer, agents | Markdown |
+| Agent framework readiness checklist | `docs/plans/2026-06-21-hook-provider-agent-readiness.md` | implementation agents | Markdown |
+| Hermes hook spec docs | `docs/hermes-hook-spec.md` | users and maintainers | Markdown |
+| README updates | `README.md` | users | Markdown |
+
+### 3.2 Interface
+
+Provider lifecycle interface:
+
+```ts
+export type HookProviderId = "claude" | "codex" | "hermes";
+
+export type HookProviderState =
+  | { kind: "registered"; detail: string }
+  | { kind: "missing"; detail: string; repairHint: string; warnOnly?: boolean }
+  | { kind: "needs_migration"; detail: string; repairHint: string }
+  | { kind: "unsupported"; detail: string; repairHint: string };
+
+export interface HookInstallContext {
+  vault: string;
+  plain: boolean;
+}
+
+export interface HookInstallResult {
+  changed: boolean;
+  messages: string[];
+  configPatch?: Partial<AgentLogConfig>;
+}
+
+export interface HookUninstallResult {
+  changed: boolean;
+  messages: string[];
+  configPatch?: Partial<AgentLogConfig>;
+}
+
+export interface HookProvider {
+  id: HookProviderId;
+  label: string;
+  configFlag: "claudeHookInstalled" | "codexHookInstalled" | "hermesHookInstalled";
+  command: string;
+  install(ctx: HookInstallContext): HookInstallResult;
+  uninstall(): HookUninstallResult;
+  inspect(): HookProviderState;
+  isRelevant(config: AgentLogConfig | null): boolean;
+}
+```
+
+Runtime hook input parsing:
+
+```ts
+export interface HookInput {
+  hook_event_name: "UserPromptSubmit" | "pre_llm_call";
+  session_id: string;
+  cwd: string;
+  prompt?: string;
+  message?: { content: string };
+  parts?: Array<{ type: "text"; text: string }>;
+  extra?: {
+    user_message?: string;
+    conversation_history?: unknown[];
+    is_first_turn?: boolean;
+    model?: string;
+    platform?: string;
+  };
+}
+
+export interface ParsedHookInput {
+  sessionId: string;
+  cwd: string;
+  prompt: string;
+}
+
+export function parseHookInput(
+  raw: string,
+  options?: { source?: HookProviderId },
+): ParsedHookInput;
+```
+
+CLI target parsing:
+
+```ts
+export type InitTarget = "claude" | "codex" | "hermes" | "all";
+export type UninstallTarget = "claude" | "codex" | "hermes" | "all";
+
+export function providersForInitTarget(target: InitTarget): HookProviderId[];
+export function providersForUninstallTarget(target: UninstallTarget): HookProviderId[];
+```
+
+Required target behavior:
+
+```ts
+providersForInitTarget("claude") === ["claude"];
+providersForInitTarget("codex") === ["codex"];
+providersForInitTarget("hermes") === ["hermes"];
+providersForInitTarget("all") === ["claude", "codex"];
+```
+
+### 3.3 Flow
+
+Phase 0: lock current behavior before abstraction.
+
+1. Create a current behavior coverage matrix for Claude, Codex, legacy Codex notify, hook parsing, note writing, doctor, init, uninstall, and backfill.
+2. Map each behavior to an existing automated test, a new missing test, or a manual QA check.
+3. Add missing regression tests before refactoring.
+4. Add a QA smoke checklist for real host integration paths:
+   - `agentlog doctor`
+   - `agentlog init --dry-run`
+   - `agentlog init --codex --dry-run`
+   - `agentlog backfill --dry-run --format json`
+   - hook fixture invocation in an isolated `AGENTLOG_CONFIG_DIR`
+5. Validate agent-framework readiness:
+   - PRD has concrete files, interfaces, naming, and test commands.
+   - Tasks can be executed by an agent without asking for hidden decisions.
+   - No Phase 1 implementation decision remains ambiguous.
+   - Required docs/research are referenced by path.
+6. Patch any missing PRD detail discovered during readiness review before code changes.
+7. Run the red-team PRD gate and require a pass before Phase 1:
+   - `node scripts/prd-redteam.mjs --output docs/plans/2026-06-21-hook-provider-prd-redteam-report.json`
+
+Phase 1: extract provider registry without behavior changes.
+
+1. Move Claude install/uninstall/inspect wrapping into `hook-providers/claude.ts`.
+2. Move Codex install/uninstall/inspect wrapping into `hook-providers/codex.ts`.
+3. Introduce registry helpers.
+4. Replace `src/cli.ts` target branches with provider iteration.
+5. Keep output text compatible unless tests explicitly approve small wording updates.
+6. Run existing CLI, Codex, hook, and note-writer tests.
+
+Phase 2: add Hermes runtime provider.
+
+1. Add `"hermes"` to `HookProviderId` and `SourceType`.
+2. Update `src/hook.ts` source resolution so only known providers are accepted; unknown source falls back to Claude only if no `--source` was provided.
+3. Update `parseHookInput()`:
+   - Claude/Codex: keep current `UserPromptSubmit` behavior.
+   - Hermes: require `hook_event_name: "pre_llm_call"` and `extra.user_message`.
+4. Update divider parsing to recognize `hermes`.
+5. Add Hermes fixture and parser/note-writer tests.
+6. Add `docs/hermes-hook-spec.md` and README setup docs.
+7. Hermes logs every valid `pre_llm_call` payload regardless of `extra.platform`; platform filtering is out of scope.
+
+Phase 3: Hermes init/doctor/uninstall automation.
+
+1. Add `hermesHookInstalled?: boolean` and `hermesProfiles?: string[]` to config.
+2. Add `src/hermes-config.ts` for structured YAML read/write of `hooks.pre_llm_call`.
+3. Add `agentlog init --hermes` that writes `agentlog hook --source hermes` to the default Hermes config and records metadata.
+4. Add repeated `--hermes-profile <name>` and `--hermes-all-profiles` support for named Hermes profile configs.
+5. Add `agentlog uninstall --hermes` that removes only AgentLog's command from configured profiles.
+6. Add doctor state for Hermes only when config metadata or installed state makes it relevant; configured missing/partial hooks fail.
+7. Add a real Hermes-profile smoke when the `hermes` binary is available.
+
+### 3.4 Existing Code Impact
+
+| Existing File | Change | Impact |
+|---------------|--------|:------:|
+| `src/cli.ts` | Replace direct Claude/Codex lifecycle branches with provider registry calls | High |
+| `src/types.ts` | Add `hermes` source and optional `hermesHookInstalled` metadata | Medium |
+| `src/hook.ts` | Resolve `--source hermes` and reject/handle unknown source safely | Medium |
+| `src/schema/hook-input.ts` | Add Hermes `pre_llm_call` parser branch | Medium |
+| `src/note-writer.ts` | Recognize `hermes` in divider regex | Low |
+| `src/schema/daily-note.ts` | Type expansion only; formatting already source-parametric | Low |
+| `src/backfill.ts` | Keep Claude/Codex only; `agentlog backfill --source hermes` must fail with `Error: --source must be one of: all, claude, codex` | Low |
+| `README.md` | Document provider model and Hermes automated setup | Medium |
+| `docs/codex-hook-spec.md` | Leave Codex-specific; link to generic/Hermes docs if needed | Low |
+
+### 3.5 Naming Conventions
+
+| Category | Name | Description |
+|----------|------|-------------|
+| type | `HookProviderId` | Provider/source identity: `claude`, `codex`, `hermes` |
+| type | `HookProviderState` | Normalized doctor/install state |
+| interface | `HookProvider` | Install/uninstall/inspect contract |
+| function | `providersForInitTarget` | CLI target to provider list |
+| function | `providersForUninstallTarget` | CLI uninstall target to provider list |
+| function | `parseHookInput` | Provider-aware stdin payload normalization |
+| module | `src/hook-providers/index.ts` | Provider registry |
+| module | `src/hook-providers/claude.ts` | Claude adapter |
+| module | `src/hook-providers/codex.ts` | Codex adapter |
+| module | `src/hook-providers/hermes.ts` | Hermes adapter |
+| fixture | `hermes-pre-llm-call.json` | Hermes shell-hook fixture |
+| docs | `docs/hermes-hook-spec.md` | Hermes provider contract |
+
+### 3.6 Security Considerations
+
+- **Hook command trust**: Claude, Codex, and Hermes all execute user-level commands. AgentLog must install only `agentlog hook --source <provider>` and must not interpolate untrusted user input into hook commands.
+- **Hermes YAML risk**: `~/.hermes/config.yaml` is privileged. If AgentLog writes it, use structured YAML parsing. Do not use regex mutation.
+- **Prompt mutation risk**: Claude/Codex/Hermes prompt hooks can inject context or block prompts. AgentLog logging must emit no stdout in success cases.
+- **Config corruption**: Provider adapters must preserve unrelated config entries and unrelated hook groups.
+- **Doctor scope**: Doctor must not pressure users to install every provider. A provider is relevant only if metadata says AgentLog owns it or an installed hook is detected.
+
+### 3.7 Target Environment
+
+- Platform: macOS primary, cross-platform where existing AgentLog supports it.
+- Runtime: Bun + TypeScript, Node 20-compatible package.
+- Deployment: local CLI package.
+- External tools: Claude Code, Codex CLI, Hermes Agent, Obsidian CLI.
+
+## 4. Verification Criteria
+
+### Functional
+
+- [ ] Given: existing Claude-only config / When: `agentlog init` runs / Then: `~/.claude/settings.json` contains the same AgentLog hook shape as before.
+- [ ] Given: existing Codex hook config with unrelated hooks / When: `agentlog init --codex` runs / Then: unrelated hooks remain and AgentLog Codex hook is idempotent.
+- [ ] Given: `agentlog init --all` / When: provider target resolution runs / Then: it includes only `claude` and `codex`.
+- [ ] Given: Hermes shell-hook payload with `hook_event_name: "pre_llm_call"` and `extra.user_message` / When: `parseHookInput(raw, { source: "hermes" })` runs / Then: it returns `{ sessionId, cwd, prompt }`.
+- [ ] Given: malformed Hermes payload missing `extra.user_message` / When: parser runs / Then: it throws a source-specific parse error.
+- [ ] Given: source `hermes` and session id `sess_abc` / When: Daily Note divider is built / Then: output is `- - - - [[hermes_sess_abc]]`.
+- [ ] Given: existing `[[hermes_sess_abc]]` divider / When: another Hermes prompt in same session is appended / Then: no duplicate divider is inserted.
+- [ ] Given: `agentlog backfill --source hermes` before Hermes backfill exists / When: command runs / Then: it exits non-zero and prints `Error: --source must be one of: all, claude, codex`.
+- [ ] Given: Hermes automated setup docs / When: user follows them / Then: configured shell hook command is `agentlog hook --source hermes`.
+
+### Regression
+
+- [ ] Current behavior coverage matrix exists and every listed behavior has automated coverage or an explicit manual QA check.
+- [ ] Agent framework readiness checklist exists and has no unresolved blocker before implementation.
+- [ ] PRD red-team gate passes before Phase 1 implementation begins: `node scripts/prd-redteam.mjs --output docs/plans/2026-06-21-hook-provider-prd-redteam-report.json`.
+- [ ] Missing tests found in Phase 0 are added before provider extraction.
+- [ ] Existing Claude tests pass.
+- [ ] Existing Codex hook tests pass.
+- [ ] Existing Codex legacy notify tests pass.
+- [ ] Existing note-writer grouping tests pass.
+- [ ] Existing backfill tests pass.
+- [ ] `bun run typecheck` passes.
+- [ ] `agentlog doctor` passes in the developer environment.
+
+### Security/Negative
+
+- [ ] Given: unknown `--source bad` / When: hook runs / Then: it does not silently label the entry as Claude if `--source` was explicitly provided.
+- [ ] Given: Hermes hook command succeeds / When: stdout is captured / Then: stdout is empty or `{}` and does not inject context.
+- [ ] Given: unsupported provider config shape / When: doctor runs / Then: it reports unsupported with a repair hint without mutating files.
+
+## 5. Risks
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Provider abstraction becomes too broad | Larger diff, harder review | Scope only install/uninstall/inspect/source parsing |
+| Existing CLI output changes unexpectedly | Test breakage and user confusion | Preserve current wording where practical; update tests only for intentional changes |
+| Hermes YAML mutation corrupts config | High user impact | Use structured YAML parser; reject unsupported YAML; test idempotency and AgentLog-only removal |
+| Unknown source fallback masks bad config | Mislabelled logs | Only default to Claude when `--source` is absent |
+| Hermes backfill assumed too early | False feature claim | Exclude from scope |
+
+## 6. Task Checklist
+
+- [ ] ✅ Phase 0 current behavior inventory → verify: `docs/plans/2026-06-21-hook-provider-current-behavior-coverage.md` maps each behavior to test/QA evidence.
+- [ ] ✅ Phase 0 missing regression tests → verify: every high-risk current behavior has automated coverage before abstraction.
+- [ ] ✅ Phase 0 QA smoke plan → verify: manual commands and expected outcomes are listed, including isolated hook invocation.
+- [ ] ✅ Phase 0 agent-framework readiness review → verify: `docs/plans/2026-06-21-hook-provider-agent-readiness.md` lists executable tasks, blockers, and any PRD gaps.
+- [ ] ✅ Phase 0 PRD gap patch → verify: blockers from readiness review are resolved before code changes.
+- [ ] ✅ Phase 0 red-team gate → verify: `node scripts/prd-redteam.mjs --output docs/plans/2026-06-21-hook-provider-prd-redteam-report.json` passes before Phase 1.
+- [ ] ✅ Phase 1 research lock: read this PRD plus both research docs → verify: cite source files in implementation notes.
+- [ ] ✅ Add provider type/registry modules → verify: `bun test src/__tests__/hook-providers.test.ts`.
+- [ ] ✅ Wrap Claude provider around existing `claude-settings.ts` → verify: Claude CLI tests unchanged.
+- [ ] ✅ Wrap Codex provider around existing `codex-hooks.ts` and legacy `codex-settings.ts` cleanup → verify: Codex CLI tests unchanged.
+- [ ] ✅ Replace `src/cli.ts` provider branching with registry iteration → verify: `bun test src/__tests__/cli.test.ts src/__tests__/cli-codex.test.ts`.
+- [ ] ✅ Add Hermes parser fixture and parser branch → verify: `bun test src/__tests__/hook-input.test.ts`.
+- [ ] ✅ Add `hermes` source divider support → verify: `bun test src/__tests__/daily-note.test.ts src/__tests__/note-writer.test.ts`.
+- [ ] ✅ Add Hermes docs with automated setup → verify: docs mention `pre_llm_call`, profiles, `extra.user_message`, and `agentlog hook --source hermes`.
+- [ ] ✅ Decide whether `init --hermes` mutates YAML or prints setup instructions → verify: decision logged in §8 before implementation.
+- [ ] ✅ Automate `init --hermes` with structured YAML mutation → verify: `bun test src/__tests__/hermes-config.test.ts src/__tests__/cli-codex.test.ts`.
+- [ ] ✅ Add real Hermes profile smoke → verify: CLI test runs `hermes -p smoke hooks list` when Hermes is installed.
+- [ ] ✅ Keep Hermes out of backfill → verify: `agentlog backfill --source hermes` rejects with the allowed-source error.
+- [ ] ✅ Run full validation → verify: `bun test`, `bun run typecheck`, `agentlog doctor`.
+
+## 7. Open Questions
+
+These are deferred future-product questions. They are not Phase 1 or Phase 2 implementation blockers.
+
+- Should a future `agentlog init --providers claude,codex,hermes` replace expanding flag combinations?
+
+## 8. Decision Log
+
+- 2026-06-21: Provider abstraction is justified now because Hermes is the third hook integration.
+- 2026-06-21: Abstraction boundary is lifecycle/provider parsing only; Daily Note writing remains shared core.
+- 2026-06-21: `agentlog init --all` remains Claude+Codex to preserve existing semantics.
+- 2026-06-21: Hermes backfill is explicitly out of scope until transcript format is verified.
+- 2026-06-21: Phase 0 must lock current behavior with coverage, QA smoke checks, and agent-framework readiness before abstraction starts.
+- 2026-06-22: `agentlog init --hermes` now owns structured Hermes config mutation because Hermes is the third provider and lifecycle abstraction must cover install, inspect, and uninstall. It writes/removes only `agentlog hook --source hermes` and records target profiles.
+- 2026-06-21: `agentlog backfill --source hermes` is rejected until Hermes transcript backfill is separately specified.
+- 2026-06-21: Hermes runtime logging accepts all valid Hermes `pre_llm_call` payloads and does not filter by `extra.platform`.
+
+## 9. Handoff Snapshot
+
+Current status:
+
+- Research docs exist:
+  - `docs/research/2026-06-21-hermes-agentlog-research.md`
+  - `docs/research/2026-06-21-hook-provider-abstraction-research.md`
+- This PRD defines a two-phase implementation: provider extraction, then Hermes.
+- Phase 0 coverage/readiness artifacts now exist:
+  - `docs/plans/2026-06-21-hook-provider-current-behavior-coverage.md`
+  - `docs/plans/2026-06-21-hook-provider-agent-readiness.md`
+- Implementation has started on the `feature/prd-redteam-tool` branch after Phase 0 artifacts were created.
+- The red-team report must be regenerated after every PRD change and must pass before this work is considered ready for review.
+
+Next recommended step:
+
+1. Regenerate `docs/plans/2026-06-21-hook-provider-prd-redteam-report.json`.
+2. Run full validation: `bun test`, `bun run typecheck`, `bun run build`, `agentlog doctor`.
+3. Review the implementation diff only after the red-team report has `"verdict": "pass"`.
+
+## 10. Changelog
+
+| rev | date | summary |
+|-----|------|---------|
+| 1 | 2026-06-21 | Initial PRD for provider abstraction followed by Hermes |
+| 2 | 2026-06-21 | Closed Phase 0 hard gate, initial manual Hermes init decision, and backfill-source rejection contract |
+| 3 | 2026-06-22 | Revised Hermes lifecycle scope to structured YAML automation, profile support, and real Hermes smoke |

--- a/docs/plans/2026-06-21-hook-provider-agent-readiness.md
+++ b/docs/plans/2026-06-21-hook-provider-agent-readiness.md
@@ -1,0 +1,36 @@
+# Hook Provider Agent Readiness
+
+> status: implementation-gate
+> date: 2026-06-21
+> scope: Phase 0 for provider abstraction + Hermes runtime support
+
+## Executable Task Boundaries
+
+| Task | Agent Inputs | Expected Output | Verification |
+|------|--------------|-----------------|--------------|
+| Provider registry | PRD §3.2, existing Claude/Codex modules | `src/hook-providers/*` | `bun test src/__tests__/hook-providers.test.ts` |
+| Hermes parser | Hermes fixture and research docs | `parseHookInput(..., { source: "hermes" })` | `bun test src/__tests__/hook-input.test.ts` |
+| Source-aware writing | `SourceType` expansion and divider regex | `[[hermes_<session_id>]]` without duplicate divider | `bun test src/__tests__/daily-note.test.ts src/__tests__/note-writer.test.ts` |
+| Hermes config automation | research Option A + structured YAML parser guardrail | default/profile/all-profile config write-remove lifecycle | `bun test src/__tests__/hermes-config.test.ts src/__tests__/cli-codex.test.ts` |
+| Red-team gate | PRD + coverage/readiness docs | mechanical + model report | `bun run prd:redteam` |
+
+## Decisions Locked
+
+| Decision | Status | Reason |
+|----------|--------|--------|
+| `init --all` excludes Hermes | locked | avoids surprising privileged Hermes hook config |
+| Hermes YAML mutation | locked | allowed only through structured YAML parsing; no regex mutation |
+| Hermes backfill | out of scope | transcript format not verified |
+| EnglishAsk for Hermes | out of scope | Codex-specific evaluator should not run accidentally |
+
+## Agent Framework Checks
+
+- Files, commands, interfaces, and test commands are named in the PRD.
+- Ambiguous choices are either locked above or left out of implementation scope.
+- Phase 0 coverage matrix exists before provider extraction.
+- Red-team script validates PRD structure and required Phase 0 artifacts.
+- Agent loop script runs implementation tests before model review.
+
+## Remaining Risk
+
+Nested `codex exec` can hang when it reuses a large or inconsistent global `~/.codex` state. The red-team gate runs model review with an isolated temporary `CODEX_HOME` that copies auth and writes a minimal config; timeout is still treated as a model-gate failure with captured evidence.

--- a/docs/plans/2026-06-21-hook-provider-current-behavior-coverage.md
+++ b/docs/plans/2026-06-21-hook-provider-current-behavior-coverage.md
@@ -1,0 +1,67 @@
+# Hook Provider Current Behavior Coverage
+
+> status: implementation-gate
+> date: 2026-06-21
+> scope: Phase 0 for hook provider abstraction before Hermes
+
+## Purpose
+
+Lock current Claude and Codex behavior before provider extraction.
+
+## Coverage Matrix
+
+| Area | Behavior | Evidence |
+|------|----------|----------|
+| Claude init | `agentlog init` writes config and registers `agentlog hook` in `~/.claude/settings.json` | `src/__tests__/cli.test.ts` |
+| Claude hook migration | stale object matcher is migrated to string matcher | `src/__tests__/cli.test.ts` |
+| Claude doctor | missing/unsupported Claude hook fails unless Codex-only warning path applies | `src/__tests__/cli.test.ts`, `src/__tests__/cli-codex.test.ts` |
+| Codex init | `agentlog init --codex` writes `agentlog hook --source codex` and records metadata | `src/__tests__/cli-codex.test.ts` |
+| Codex hook preservation | unrelated Codex hooks and trusted state are preserved | `src/__tests__/codex-hooks.test.ts`, `src/__tests__/cli-codex.test.ts` |
+| Codex legacy migration | legacy `agentlog hook` is migrated to `--source codex` | `src/__tests__/codex-hooks.test.ts`, `src/__tests__/cli-codex.test.ts` |
+| `init --all` compatibility | `--all` remains Claude + Codex, not Hermes | `src/__tests__/cli-codex.test.ts`, `src/__tests__/hook-providers.test.ts` |
+| Hook parser | Claude fallbacks and Codex required `prompt` stay intact | `src/__tests__/hook-input.test.ts` |
+| Daily Note writer | project sections, source-aware dividers, latest line, and plain mode remain intact | `src/__tests__/daily-note.test.ts`, `src/__tests__/note-writer.test.ts` |
+| Backfill | Claude/Codex JSONL backfill remains scoped to `all`, `claude`, `codex` | `src/__tests__/backfill.test.ts` |
+| Uninstall | Claude, Codex, legacy notify, and `--all` paths preserve current cleanup behavior | `src/__tests__/cli.test.ts`, `src/__tests__/cli-codex.test.ts` |
+
+## Added Regression Coverage
+
+| New Risk | Evidence |
+|----------|----------|
+| Provider registry accidentally includes Hermes in `init --all` | `src/__tests__/hook-providers.test.ts` |
+| Hermes parser accepts wrong event or wrong field | `src/__tests__/hook-input.test.ts` |
+| Unknown explicit source silently becomes Claude | `src/__tests__/cli-codex.test.ts` |
+| Hermes divider duplicates in same session | `src/__tests__/note-writer.test.ts` |
+| Hermes YAML mutation corrupts unrelated config | `src/__tests__/hermes-config.test.ts` verifies structured YAML mutation, idempotency, invalid YAML rejection, and AgentLog-only unregister |
+| Hermes profile targeting regresses | `src/__tests__/hermes-config.test.ts`, `src/__tests__/cli-codex.test.ts` cover default, repeated `--hermes-profile`, and `--hermes-all-profiles` |
+| Real Hermes CLI integration drifts from config shape | `src/__tests__/cli-codex.test.ts` includes a real `hermes -p smoke hooks list` smoke when the Hermes binary is available |
+
+## QA Smoke
+
+Run before abstraction PR review:
+
+```bash
+agentlog doctor
+bun test
+bun run typecheck
+bun run prd:redteam
+bun run agent:redteam-loop
+```
+
+Manual host checks:
+
+```bash
+agentlog init --dry-run ~/Obsidian
+agentlog init --codex --dry-run ~/Obsidian
+agentlog init --hermes --dry-run ~/Obsidian
+agentlog backfill --dry-run --format json
+```
+
+Hermes isolated fixture check:
+
+```bash
+tmp="$(mktemp -d)"
+mkdir -p "$tmp/notes" "$tmp/cfg"
+printf '{"vault":"%s/notes","plain":true,"hermesHookInstalled":true}' "$tmp" > "$tmp/cfg/config.json"
+AGENTLOG_CONFIG_DIR="$tmp/cfg" bun run src/cli.ts hook --source hermes < src/__tests__/fixtures/hermes-pre-llm-call.json
+```

--- a/docs/plans/2026-06-21-hook-provider-prd-redteam-report.json
+++ b/docs/plans/2026-06-21-hook-provider-prd-redteam-report.json
@@ -1,0 +1,115 @@
+{
+  "checkedAt": "2026-06-21T15:16:16.963Z",
+  "prd": "docs/plans/2026-06-21-hook-provider-abstraction-hermes-prd.md",
+  "verdict": "pass",
+  "mechanical": {
+    "verdict": "pass",
+    "total": 15,
+    "passed": 15,
+    "failed": 0,
+    "checks": [
+      {
+        "id": "required-sections",
+        "description": "PRD has all execution sections from work guide through changelog",
+        "passed": true,
+        "evidence": ""
+      },
+      {
+        "id": "third-provider-rationale",
+        "description": "Goal explains why abstraction is justified only at Claude+Codex+Hermes",
+        "passed": true,
+        "evidence": ""
+      },
+      {
+        "id": "phase0-before-phase1",
+        "description": "Phase 0 behavior lock appears before provider extraction",
+        "passed": true,
+        "evidence": "Phase 0 index=243, Phase 1 index=538"
+      },
+      {
+        "id": "phase0-coverage-matrix",
+        "description": "Phase 0 requires current behavior coverage matrix before refactoring",
+        "passed": true,
+        "evidence": ""
+      },
+      {
+        "id": "phase0-missing-tests",
+        "description": "Phase 0 requires missing regression tests before provider extraction",
+        "passed": true,
+        "evidence": ""
+      },
+      {
+        "id": "phase0-qa-smoke",
+        "description": "Phase 0 lists QA smoke commands and isolated hook fixture invocation",
+        "passed": true,
+        "evidence": ""
+      },
+      {
+        "id": "phase0-agent-readiness",
+        "description": "Phase 0 requires agent-framework readiness review and PRD gap patching",
+        "passed": true,
+        "evidence": ""
+      },
+      {
+        "id": "phase0-artifacts-exist",
+        "description": "Phase 0 coverage/readiness/research artifacts exist on disk",
+        "passed": true,
+        "evidence": ""
+      },
+      {
+        "id": "non-goals-guardrails",
+        "description": "PRD excludes risky or out-of-scope Hermes behavior",
+        "passed": true,
+        "evidence": ""
+      },
+      {
+        "id": "provider-interface",
+        "description": "PRD defines a bounded HookProvider interface and target mapping",
+        "passed": true,
+        "evidence": ""
+      },
+      {
+        "id": "hermes-runtime-contract",
+        "description": "PRD captures Hermes runtime input, parser, and divider behavior",
+        "passed": true,
+        "evidence": ""
+      },
+      {
+        "id": "negative-security-tests",
+        "description": "Verification includes unknown source, stdout, and unsupported provider negatives",
+        "passed": true,
+        "evidence": ""
+      },
+      {
+        "id": "research-links",
+        "description": "Handoff references both research documents needed by implementation agents",
+        "passed": true,
+        "evidence": ""
+      },
+      {
+        "id": "init-hermes-automation-decision",
+        "description": "PRD resolves init --hermes as structured Hermes YAML automation with profile support",
+        "passed": true,
+        "evidence": ""
+      },
+      {
+        "id": "backfill-source-contract",
+        "description": "PRD explicitly rejects Hermes backfill source until separately specified",
+        "passed": true,
+        "evidence": ""
+      }
+    ]
+  },
+  "model": {
+    "invoked": true,
+    "verdict": "pass",
+    "findings": [],
+    "missingRequirements": [],
+    "stdout": "{\"verdict\":\"pass\",\"findings\":[],\"missingRequirements\":[]}\n",
+    "stderr": "Reading additional input from stdin...\nOpenAI Codex v0.141.0\n--------\nworkdir: /Users/pray/worktrees/agentlog-prd-redteam\nmodel: gpt-5.3-codex-spark\nprovider: openai\napproval: never\nsandbox: danger-full-access\nreasoning effort: low\nreasoning summaries: none\nsession id: 019eeac0-e0a8-73e2-a656-87416715d1d8\n--------\nuser\nYou are red-teaming an implementation PRD for AgentLog.\n\nReturn only compact JSON with this exact shape:\n{\"verdict\":\"pass\"|\"fail\",\"findings\":[{\"severity\":\"high\"|\"medium\"|\"low\",\"message\":\"...\",\"evidence\":\"...\"}],\"missingRequirements\":[\"...\"]}\n\nPass only if the PRD is executable by a coding agent and fully covers the user's Phase 0 requirement:\n- current behavior coverage tests before abstraction\n- QA smoke validation tests\n- agent-framework readiness validation\n- PRD gap patching before provider code changes\n- provider lifecycle abstraction before Hermes automation\n- Hermes config automation with profile support only through structured YAML parsing\n\nFail if any required Phase 0 deliverable, guardrail, or verification criterion is missing or ambiguous.\n\nPRD:\n# Hook Provider Abstraction, Then Hermes\n\n> status: draft\n> created: 2026-06-21\n> updated: 2026-06-21\n> revision: 2\n\n## 0. LLM Work Guide\n\n> **Follow the Spec Execution Protocol (`/sisyphus`).** This PRD is implementation-ready only after the Phase 0 hard gate below passes.\n\n| Item | Section |\n|------|---------|\n| Task Checklist | §6 |\n| Naming Conventions | §3.5 |\n| State file | `docs/plans/2026-06-21-hook-provider-abstraction-hermes-prd.state.md` |\n| Decision Log | §8 |\n| Handoff Snapshot | §9 |\n| Changelog | §10 |\n\nHard gate:\n\n- Phase 1 provider extraction must not start until Phase 0 coverage matrix, missing regression tests, QA smoke plan, agent-framework readiness review, and PRD gap patch are complete.\n- Phase 0 completion evidence must include `bun test`, `bun run typecheck`, `agentlog doctor`, and `node scripts/prd-redteam.mjs --output docs/plans/2026-06-21-hook-provider-prd-redteam-report.json`.\n- If the red-team report fails, patch this PRD first, then rerun the gate before implementation.\n- If the red-team report is missing, stale for the current PRD revision, invalid JSON, or has `\"verdict\" != \"pass\"`, Phase 1 is blocked.\n- The Phase 0 sign-off proof is this exact evidence set:\n  - `docs/plans/2026-06-21-hook-provider-current-behavior-coverage.md` exists and every row has `automated`, `manual QA`, or `not in scope` evidence.\n  - `docs/plans/2026-06-21-hook-provider-agent-readiness.md` exists and lists no blocker with status `open`.\n  - Missing regression tests discovered by those documents are committed before provider extraction.\n  - `docs/plans/2026-06-21-hook-provider-prd-redteam-report.json` exists with `\"verdict\": \"pass\"`.\n  - The final implementation note cites the validation commands and their pass/fail output.\n\nPhase 0 command thresholds:\n\n| Command | Required threshold |\n|---------|--------------------|\n| `bun test` | exit code 0 for the full suite |\n| `bun run typecheck` | exit code 0 |\n| `bun run build` | exit code 0 |\n| `agentlog doctor` | exit code 0 in the developer environment |\n| `node scripts/prd-redteam.mjs --output docs/plans/2026-06-21-hook-provider-prd-redteam-report.json` | exit code 0 and report JSON `\"verdict\": \"pass\"` |\n\nPhase 0 artifact status:\n\n| Artifact | Required status | Machine-check |\n|----------|-----------------|---------------|\n| `docs/plans/2026-06-21-hook-provider-current-behavior-coverage.md` | present before Phase 1 | `phase0-artifacts-exist` red-team check |\n| `docs/plans/2026-06-21-hook-provider-agent-readiness.md` | present before Phase 1, no open blocker | `phase0-artifacts-exist` red-team check plus reviewer read |\n| `docs/plans/2026-06-21-hook-provider-prd-redteam-report.json` | regenerated after PRD edits | JSON `\"verdict\": \"pass\"` |\n\n## 1. Goal\n\nRefactor AgentLog's Claude/Codex hook integration into a small provider layer, then add Hermes Agent as the third hook provider.\n\nThis follows the \"third tim\n[truncated 20353 chars]",
+    "exitCode": 0,
+    "model": "gpt-5.3-codex-spark",
+    "reasoningEffort": "low",
+    "timeoutMs": 120000
+  }
+}

--- a/docs/research/2026-06-21-hermes-agentlog-research.md
+++ b/docs/research/2026-06-21-hermes-agentlog-research.md
@@ -1,0 +1,241 @@
+# Hermes Agent Integration Research
+
+**Date:** 2026-06-21
+**Status:** Research
+**Target:** Add Hermes Agent prompt capture to AgentLog.
+
+## Goal
+
+Support Hermes Agent as a third AgentLog source beside Claude Code and Codex CLI, so Hermes user turns are appended to the same Obsidian Daily Note format with `[[hermes_<session_id>]]` session dividers.
+
+## Scope
+
+This is research only. No implementation changes are included here.
+
+Acceptance criteria for the later implementation:
+
+- Hermes user prompts are captured from the correct Hermes turn-start hook.
+- Daily Note output preserves the current AgentLog section structure.
+- Claude and Codex behavior remain unchanged.
+- `agentlog doctor` can distinguish configured, missing, and unsupported Hermes integration state if AgentLog owns installation.
+- Tests cover hook input parsing, source divider behavior, CLI install/uninstall/doctor behavior, and any Hermes fixture payload.
+
+## External Evidence
+
+Official Hermes docs identify the relevant lifecycle hook as `pre_llm_call`:
+
+- Event Hooks docs: <https://hermes-agent.nousresearch.com/docs/user-guide/features/hooks>
+  - `pre_llm_call` fires once per turn before the tool-calling loop.
+  - Callback parameters include `session_id`, `user_message`, `conversation_history`, `is_first_turn`, `model`, and `platform`.
+  - Shell hooks receive JSON on stdin with `hook_event_name`, `session_id`, `cwd`, and `extra`; for non-tool events, `tool_name` and `tool_input` are `null`.
+  - `extra` carries event-specific kwargs, including `user_message` and `conversation_history`.
+  - Hermes docs explicitly say Claude Code `UserPromptSubmit` is not a separate Hermes event; `pre_llm_call` fires at the same place.
+  - Shell hooks are configured under `hooks:` in `~/.hermes/config.yaml`.
+  - Malformed JSON, non-zero exits, and timeouts warn but do not abort the agent loop.
+
+- Configuration docs: <https://hermes-agent.nousresearch.com/docs/user-guide/configuration>
+  - Hermes stores config under `~/.hermes/config.yaml`.
+  - Secrets live in `~/.hermes/.env`; non-secret config belongs in `config.yaml`.
+  - `hermes config`, `hermes config edit`, `hermes config set`, `hermes config check`, and `hermes config migrate` are the documented management commands.
+
+- Plugin guide: <https://hermes-agent.nousresearch.com/docs/guides/build-a-hermes-plugin>
+  - General plugins live under `~/.hermes/plugins/<plugin-name>/` with `plugin.yaml` and `__init__.py`.
+  - Plugins register hooks through `ctx.register_hook(...)`.
+  - Shell hooks are the documented no-Python path for running scripts on lifecycle events.
+
+## Current AgentLog Architecture
+
+Current source support is hard-coded to two sources:
+
+- `src/types.ts`
+  - `SourceType = "claude" | "codex"`.
+  - `AgentLogConfig` has `claudeHookInstalled?` and `codexHookInstalled?`, no generalized integration map.
+
+- `src/hook.ts`
+  - `resolveSource()` accepts `--source codex`; every other value becomes `claude`.
+  - The same entry point parses hook stdin and writes a `LogEntry`.
+
+- `src/schema/hook-input.ts`
+  - Parser requires `hook_event_name: "UserPromptSubmit"`.
+  - Codex mode requires top-level `prompt`.
+  - Claude mode supports `prompt`, `message.content`, or `parts[].text`.
+  - No Hermes payload shape is accepted.
+
+- `src/schema/daily-note.ts`
+  - `buildSessionDivider(sessionId, source)` already formats source-prefixed wiki-links.
+  - It will work with `hermes` after `SourceType` expands.
+
+- `src/note-writer.ts`
+  - `dividerRe` only recognizes `claude|codex|ses`.
+  - This must include `hermes`, or existing Hermes sections will not be source-aware on subsequent writes.
+
+- `src/backfill.ts`
+  - `BackfillSource = SourceType | "all"`.
+  - Backfill knows Claude JSONL and Codex JSONL locations only.
+  - Hermes backfill should be a separate decision, because the researched hook path does not prove a stable Hermes local transcript format.
+
+- CLI install/doctor/uninstall
+  - Claude install writes `~/.claude/settings.json` through `src/claude-settings.ts`.
+  - Codex install writes `~/.codex/hooks.json` through `src/codex-hooks.ts`.
+  - Hermes would need a new module if AgentLog edits `~/.hermes/config.yaml`.
+
+## Integration Options
+
+### Option A: Hermes shell hook, AgentLog-owned config mutation
+
+AgentLog adds `agentlog init --hermes ~/Obsidian`, modifies `~/.hermes/config.yaml`, and registers:
+
+```yaml
+hooks:
+  pre_llm_call:
+    - command: "agentlog hook --source hermes"
+```
+
+AgentLog then parses Hermes shell-hook stdin:
+
+```json
+{
+  "hook_event_name": "pre_llm_call",
+  "tool_name": null,
+  "tool_input": null,
+  "session_id": "sess_abc123",
+  "cwd": "/home/user/project",
+  "extra": {
+    "user_message": "the prompt",
+    "conversation_history": [],
+    "is_first_turn": true,
+    "model": "anthropic/claude-sonnet-4.6",
+    "platform": "cli"
+  }
+}
+```
+
+Pros:
+
+- Smallest user-facing setup: `agentlog init --hermes`.
+- Reuses current executable and Daily Note writer.
+- Matches Hermes docs for no-Python shell hooks.
+
+Cons:
+
+- Requires YAML read/modify/write support. Current dependencies do not include a YAML parser.
+- YAML mutation must preserve unrelated user config and avoid duplicate hook entries.
+- Security-sensitive: Hermes treats `hooks:` as privileged shell config.
+
+### Option B: Documented manual Hermes shell hook
+
+AgentLog supports `agentlog hook --source hermes`, but `init --hermes` only prints instructions or writes a sample script/doc. User edits Hermes config manually.
+
+Pros:
+
+- Avoids YAML parser dependency.
+- Avoids AgentLog taking ownership of privileged Hermes config mutation.
+- Fastest low-risk implementation path.
+
+Cons:
+
+- Weaker setup UX than Claude/Codex.
+- `doctor` can only inspect best-effort state unless config parsing is added.
+
+### Option C: Hermes Python plugin
+
+Ship or document a Hermes plugin under `~/.hermes/plugins/agentlog/` that calls AgentLog from Python or writes directly.
+
+Pros:
+
+- Native Hermes plugin surface.
+- Can use `ctx.register_hook("pre_llm_call", ...)`.
+
+Cons:
+
+- Larger maintenance surface.
+- Cross-language packaging and install complexity.
+- Less aligned with current AgentLog CLI-first integration model.
+
+## Recommendation
+
+Start with Option B unless the product requirement explicitly demands one-command installation.
+
+Implement the runtime path first:
+
+1. Add `hermes` to `SourceType`.
+2. Teach `agentlog hook --source hermes` to preserve the source instead of falling back to `claude`.
+3. Add a Hermes parser branch:
+   - accept `hook_event_name: "pre_llm_call"`
+   - extract `session_id`
+   - extract `cwd`
+   - extract prompt from `extra.user_message`
+4. Update `note-writer` divider recognition to include `hermes`.
+5. Add tests with a Hermes shell-hook fixture.
+6. Document manual Hermes setup under README and/or a dedicated spec.
+
+Then add AgentLog-owned `init --hermes` only if YAML mutation is acceptable. If added, use a real YAML parser or a tightly scoped structured mutation strategy; do not regex-edit arbitrary `config.yaml`.
+
+## Proposed Files For Implementation
+
+Runtime:
+
+- `src/types.ts`
+- `src/hook.ts`
+- `src/schema/hook-input.ts`
+- `src/note-writer.ts`
+- `src/schema/daily-note.ts` tests
+
+Docs:
+
+- `README.md`
+- `docs/hermes-hook-spec.md` or equivalent
+
+Tests:
+
+- `src/__tests__/hook-input.test.ts`
+- `src/__tests__/daily-note.test.ts`
+- `src/__tests__/note-writer.test.ts`
+- new fixture: `src/__tests__/fixtures/hermes-pre-llm-call.json`
+
+Optional install/doctor work:
+
+- new `src/hermes-config.ts`
+- `src/cli.ts`
+- CLI tests for `init --hermes`, `init --all`, `uninstall --hermes`, and `doctor`
+
+## Open Questions
+
+- Should `agentlog init --all` include Hermes? Current `--all` means Claude plus Codex. Adding Hermes could surprise users because it writes another tool's privileged shell-hook config.
+- Should Hermes be runtime-only first, with manual setup docs, or should AgentLog own Hermes config mutation from day one?
+- Does Hermes have stable local session logs suitable for backfill? The hook docs prove live capture, not backfill.
+- Which platforms should be logged? `platform` can be `cli`, `telegram`, `discord`, etc. AgentLog may want all platforms by default, or only `cli` to match Claude/Codex terminal-agent scope.
+
+## Verification Plan For Later Code
+
+Minimum:
+
+```bash
+bun test src/__tests__/hook-input.test.ts src/__tests__/daily-note.test.ts src/__tests__/note-writer.test.ts
+bun run typecheck
+```
+
+If CLI setup is added:
+
+```bash
+bun test src/__tests__/cli.test.ts
+agentlog doctor
+```
+
+Manual QA:
+
+1. Add a Hermes shell hook for `pre_llm_call` that runs `agentlog hook --source hermes`.
+2. Run a Hermes CLI turn from a known project directory.
+3. Confirm today's Daily Note contains:
+   - `#### HH:MM · <parent>/<project>`
+   - `<!-- cwd=<project cwd> -->`
+   - `- - - - [[hermes_<session_id>]]`
+   - `- HH:MM <user message>`
+
+## Risks
+
+- YAML config mutation can corrupt unrelated Hermes config if implemented with ad hoc string edits.
+- `pre_llm_call` can inject context; AgentLog must return empty output or `{}` so it does not alter the user's Hermes turn.
+- Shell hooks run with full user credentials. Docs must say users should review any command added under `~/.hermes/config.yaml`.
+- Existing `dividerRe` must recognize `hermes`; otherwise repeated writes may duplicate session dividers or fail source-aware grouping.
+- Backfill should not be promised until Hermes transcript format is separately verified.

--- a/docs/research/2026-06-21-hook-provider-abstraction-research.md
+++ b/docs/research/2026-06-21-hook-provider-abstraction-research.md
@@ -1,0 +1,183 @@
+# Hook Provider Abstraction Research
+
+**Date:** 2026-06-21
+**Status:** Research
+**Related:** [Hermes Agent Integration Research](./2026-06-21-hermes-agentlog-research.md)
+
+## Question
+
+AgentLog currently supports Claude Code and Codex through separate hook install/check code paths. Hermes is the third provider. Under the "third time" rule, the question is whether the third provider justifies a hook-provider abstraction before adding Hermes.
+
+## Conclusion
+
+Yes, but only at the hook-provider boundary.
+
+The abstraction should cover repeated integration lifecycle concerns:
+
+- provider identity and config metadata
+- install/uninstall/inspect operations
+- provider-specific hook command and config path
+- provider-specific stdin payload normalization into AgentLog's internal `{ sessionId, cwd, prompt }`
+- doctor output state mapping
+
+It should not generalize the Daily Note writer, prompt formatter, Obsidian resolver, or backfill collectors. Those are not provider-specific enough yet.
+
+## External Evidence
+
+### Claude Code
+
+Official Claude Code hook docs: <https://code.claude.com/docs/en/hooks>
+
+Relevant evidence:
+
+- Command hooks receive event JSON on stdin and communicate through exit codes/stdout.
+- `UserPromptSubmit` runs when the user submits a prompt before Claude processes it.
+- `UserPromptSubmit` input contains common fields plus `prompt`.
+- The documented input includes `session_id`, `transcript_path`, `cwd`, `permission_mode`, `hook_event_name`, and `prompt`.
+- A stuck `UserPromptSubmit` hook blocks model processing until it completes, so AgentLog must stay fail-soft and return no output.
+
+### Codex
+
+Official Codex hook docs: <https://developers.openai.com/codex/hooks>
+
+Relevant evidence:
+
+- Hooks are deterministic scripts during the Codex lifecycle.
+- Codex discovers hooks from `hooks.json` or inline `[hooks]` tables.
+- User-level practical locations include `~/.codex/hooks.json` and `~/.codex/config.toml`.
+- Command hooks receive one JSON object on stdin.
+- Common fields include `session_id`, `transcript_path`, `cwd`, `hook_event_name`, and `model`.
+- `UserPromptSubmit` adds `turn_id` and `prompt`; matcher is not supported for that event.
+- Exit `0` with no output is success and continues.
+- Non-managed hooks require trust review.
+
+### Hermes Agent
+
+Official Hermes hook docs: <https://hermes-agent.nousresearch.com/docs/user-guide/features/hooks>
+
+Relevant evidence:
+
+- Plugin hooks and shell hooks share lifecycle events.
+- `pre_llm_call` fires once per turn before the tool-calling loop.
+- `pre_llm_call` can inject context by returning `{"context": "..."}`.
+- Shell hooks live under `hooks:` in `~/.hermes/config.yaml`.
+- Shell hook JSON payload includes `hook_event_name`, `tool_name`, `tool_input`, `session_id`, `cwd`, and `extra`.
+- For non-tool events such as `pre_llm_call`, `tool_name` and `tool_input` are `null`, and `extra` carries event-specific kwargs such as `user_message` and `conversation_history`.
+- Hermes explicitly treats `pre_llm_call` as the Claude-Code `UserPromptSubmit` equivalent.
+- Shell hooks run with full user credentials; Hermes docs call `hooks:` privileged config.
+
+## Local Evidence
+
+### Current duplication
+
+`src/cli.ts` has separate Claude/Codex branches:
+
+- `InitTarget = "claude" | "codex" | "all"` and `UninstallTarget = "claude" | "codex" | "all"`.
+- `runInit()` handles Claude registration.
+- `runCodexInit()` handles Codex registration.
+- `runAllInit()` manually repeats both flows.
+- `cmdDoctor()` manually decides whether Codex is relevant, then prints Claude and Codex checks separately.
+- `cmdUninstall()` manually switches between Claude/Codex/all.
+- `cmdBackfill()` hard-codes `["all", "claude", "codex"]`.
+
+Provider adapters already exist, but only as separate modules:
+
+- `src/claude-settings.ts`: Claude settings mutation and inspection.
+- `src/codex-hooks.ts`: Codex hooks mutation and inspection.
+- `src/codex-settings.ts`: legacy Codex notify migration/uninstall support.
+
+### Current provider assumptions
+
+Runtime source support is still hard-coded:
+
+- `src/types.ts`: `SourceType = "claude" | "codex"`.
+- `src/hook.ts`: `--source codex` maps to Codex; any other value maps to Claude.
+- `src/schema/hook-input.ts`: parser accepts `UserPromptSubmit` only.
+- `src/note-writer.ts`: divider regex recognizes only `claude|codex|ses`.
+
+### Existing architecture rule
+
+`docs/architecture/cli-layering.md` says:
+
+- command handlers should stay thin
+- reusable workflow support should live outside `src/cli.ts`
+- external side effects should stay behind adapter modules
+
+Hook-provider abstraction follows that rule by moving install/doctor/uninstall branching out of `src/cli.ts` while leaving file-format side effects inside provider adapters.
+
+## Abstraction Boundary
+
+Recommended minimal abstraction:
+
+```ts
+export type HookProviderId = "claude" | "codex" | "hermes";
+
+export type HookProviderState =
+  | { kind: "registered"; detail: string }
+  | { kind: "missing"; detail: string; repairHint: string }
+  | { kind: "needs_migration"; detail: string; repairHint: string }
+  | { kind: "unsupported"; detail: string; repairHint: string };
+
+export interface HookProvider {
+  id: HookProviderId;
+  label: string;
+  configFlag: "claudeHookInstalled" | "codexHookInstalled" | "hermesHookInstalled";
+  command: string;
+  install?(ctx: HookInstallContext): HookInstallResult;
+  uninstall?(ctx: HookUninstallContext): HookUninstallResult;
+  inspect(): HookProviderState;
+}
+```
+
+Separate runtime payload normalization:
+
+```ts
+export interface ParsedHookInput {
+  sessionId: string;
+  cwd: string;
+  prompt: string;
+}
+
+export function parseHookInput(raw: string, options: { source: HookProviderId }): ParsedHookInput;
+```
+
+Keep install/check provider abstraction separate from parsing if that keeps the diff smaller. The shared type name can still be `HookProviderId`.
+
+## Non-Abstractions
+
+Do not abstract these now:
+
+- Daily Note writer: same for all sources.
+- Obsidian CLI path/bootstrap: not provider-specific.
+- EnglishAsk: currently Codex-specific behavior; Hermes should not inherit it by accident.
+- Backfill collectors: Hermes transcript format is not yet verified.
+- YAML mutation engine: only needed if AgentLog-owned `init --hermes` is in scope.
+
+## Product Direction
+
+Recommended PRD direction:
+
+1. First refactor Claude/Codex hook integration into a provider registry while preserving behavior.
+2. Add Hermes as a third provider using the same registry.
+3. Keep Hermes install conservative:
+   - runtime parser and docs are required
+   - AgentLog-owned `~/.hermes/config.yaml` mutation is optional and should be gated behind explicit scope
+4. Keep `agentlog init --all` meaning Claude+Codex for backward compatibility unless the user explicitly chooses Hermes.
+
+## Risks
+
+- Over-abstracting before Hermes details are implemented can create a framework that still misses Hermes's unique `pre_llm_call` payload shape.
+- Mutating `~/.hermes/config.yaml` safely likely requires a YAML parser dependency or a very narrow append-only strategy.
+- Hermes `pre_llm_call` can alter prompts; AgentLog must emit no context and no stdout.
+- Doctor output can become noisy if all providers are checked unconditionally; provider relevance should come from config metadata or existing installed state.
+
+## Recommended Next Artifact
+
+Create a PRD/spec for:
+
+> Hook Provider Abstraction, then Hermes provider implementation.
+
+The spec should split work into two phases:
+
+- Phase 1: provider registry extraction for Claude/Codex, no behavior change.
+- Phase 2: Hermes runtime provider and docs, with optional install/doctor support only if YAML mutation is accepted.

--- a/llms.txt
+++ b/llms.txt
@@ -83,7 +83,7 @@ Fields:
 - `claudeHookInstalled` (optional): marks that AgentLog expects the Claude hook to be installed
 - `codexHookInstalled` (optional): marks that AgentLog expects the Codex hook to be installed
 - `codexNotifyRestore` (optional): saved previous Codex notify value, restored on uninstall
-- `englishAsk` (optional): Codex prompt evaluator config. Disabled unless `englishAsk.enabled` is true. Results append under `## EnglishAsk`.
+- `englishAsk` (optional): hook prompt evaluator config. Disabled unless `englishAsk.enabled` is true. Evaluator input includes current prompt plus bounded prior user/model transcript context when available, otherwise same-session Daily Note prompt context. Results append under `## EnglishAsk`.
 
 Environment variables:
 - `AGENTLOG_CONFIG_DIR`: override config directory (default: `~/.agentlog`)

--- a/package.json
+++ b/package.json
@@ -27,9 +27,12 @@
     "build": "bun build src/cli.ts src/hook.ts --outdir dist --target node",
     "dev": "bun run src/cli.ts",
     "dev:watch": "bun run --watch src/cli.ts",
+    "agent:redteam-loop": "node scripts/agent-redteam-loop.mjs",
     "prepublishOnly": "bun run typecheck",
+    "prd:redteam": "node scripts/prd-redteam.mjs",
     "self-review": "node scripts/self-review.mjs",
     "test": "bun test",
+    "test:hermes-host": "bun run scripts/end-user-hermes-host-smoke.ts",
     "test:install-smoke": "bun run scripts/e2e-bun-link-smoke.ts",
     "typecheck": "tsc --noEmit",
     "postinstall": "node scripts/postinstall.mjs"
@@ -51,6 +54,7 @@
     "typescript": "^5.4.0"
   },
   "dependencies": {
-    "commander": "^14.0.3"
+    "commander": "^14.0.3",
+    "yaml": "^2.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@albireo3754/agentlog",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Auto-log Claude Code prompts to Obsidian Daily Notes",
   "type": "module",
   "bin": {

--- a/scripts/agent-redteam-loop.mjs
+++ b/scripts/agent-redteam-loop.mjs
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+
+const DEFAULT_STEPS = [
+  ["bun", ["test"]],
+  ["bun", ["run", "typecheck"]],
+  ["node", ["scripts/prd-redteam.mjs", "--output", "docs/plans/2026-06-21-hook-provider-prd-redteam-report.json"]],
+];
+
+function run(command, args) {
+  console.log(`\n$ ${[command, ...args].join(" ")}`);
+  const result = spawnSync(command, args, { stdio: "inherit", env: { ...process.env } });
+  if (result.error) {
+    console.error(result.error.message);
+    return false;
+  }
+  return result.status === 0;
+}
+
+for (const [command, args] of DEFAULT_STEPS) {
+  if (!run(command, args)) {
+    console.error(`\nagent-redteam-loop: failed at ${command} ${args.join(" ")}`);
+    process.exit(1);
+  }
+}
+
+console.log("\nagent-redteam-loop: pass");

--- a/scripts/e2e-bun-link-smoke.ts
+++ b/scripts/e2e-bun-link-smoke.ts
@@ -11,13 +11,19 @@ interface Result {
   exitCode: number;
 }
 
-async function run(cmd: string[], env: Record<string, string>, cwd = process.cwd()): Promise<Result> {
+async function run(cmd: string[], env: Record<string, string>, cwd = process.cwd(), input?: string): Promise<Result> {
   const proc = spawn(cmd, {
     cwd,
     env: { ...process.env, ...env },
+    stdin: input === undefined ? undefined : "pipe",
     stdout: "pipe",
     stderr: "pipe",
   });
+
+  if (input !== undefined) {
+    proc.stdin.write(input);
+    proc.stdin.end();
+  }
 
   const [stdout, stderr, exitCode] = await Promise.all([
     new Response(proc.stdout).text(),
@@ -95,18 +101,23 @@ async function main(): Promise<void> {
     assertOk(installed, "agentlog init --codex --plain");
 
     const configJsonPath = join(home, ".agentlog", "config.json");
-    const configTomlPath = join(home, ".codex", "config.toml");
+    const hooksJsonPath = join(home, ".codex", "hooks.json");
     if (!existsSync(configJsonPath)) {
       throw new Error(`config.json missing after init: ${configJsonPath}`);
     }
-    if (!existsSync(configTomlPath)) {
-      throw new Error(`config.toml missing after init: ${configTomlPath}`);
+    if (!existsSync(hooksJsonPath)) {
+      throw new Error(`hooks.json missing after init: ${hooksJsonPath}`);
     }
 
     const config = JSON.parse(readFileSync(configJsonPath, "utf-8")) as {
       vault: string;
       plain?: boolean;
       codexNotifyRestore?: string[] | null;
+      englishAsk?: {
+        enabled?: boolean;
+        mode?: string;
+        evaluatorCommand?: string[];
+      };
     };
     if (config.vault !== notesDir) {
       throw new Error(`config vault mismatch: expected ${notesDir}, got ${config.vault}`);
@@ -115,32 +126,68 @@ async function main(): Promise<void> {
       throw new Error("config plain flag was not set to true");
     }
 
-    const configToml = readFileSync(configTomlPath, "utf-8");
-    if (!configToml.includes('notify = ["agentlog", "codex-notify"]')) {
-      throw new Error("config.toml did not register Codex notify");
+    const hooksJson = readFileSync(hooksJsonPath, "utf-8");
+    if (!hooksJson.includes("agentlog hook --source codex")) {
+      throw new Error("hooks.json did not register Codex UserPromptSubmit hook");
     }
 
-    const notifyFixturePath = join(repoRoot, "src", "__tests__", "fixtures", "codex-notify-single.json");
-    const notifyRaw = readFileSync(notifyFixturePath, "utf-8");
-    const notified = await run(["agentlog", "codex-notify", notifyRaw], env);
-    assertOk(notified, "agentlog codex-notify");
+    const evaluatorPath = join(root, "englishask-eval.sh");
+    const evaluatorInputPath = join(root, "englishask-input.txt");
+    writeExecutable(
+      evaluatorPath,
+      `#!/bin/sh
+test "$AGENTLOG_ENGLISHASK_EVAL" = "1" || exit 7
+cat > "$1"
+printf '%s\\n' 'Score: 4/5' 'Natural version: Reply with exactly OK.' 'Missing context: none' 'Rewrite with: exact expected output'
+`
+    );
+    writeFileSync(
+      configJsonPath,
+      JSON.stringify(
+        {
+          ...config,
+          englishAsk: {
+            enabled: true,
+            mode: "log-only",
+            evaluatorCommand: [evaluatorPath, evaluatorInputPath],
+          },
+        },
+        null,
+        2
+      ),
+      "utf-8"
+    );
+
+    const hookFixturePath = join(repoRoot, "src", "__tests__", "fixtures", "codex-hook-user-prompt-submit.json");
+    const hookRaw = readFileSync(hookFixturePath, "utf-8");
+    const hooked = await run(["agentlog", "hook", "--source", "codex"], env, process.cwd(), hookRaw);
+    assertOk(hooked, "agentlog hook --source codex");
 
     const noteNames = readdirSync(notesDir).filter((name) => /^\d{4}-\d{2}-\d{2}\.md$/.test(name));
     if (noteNames.length === 0) {
-      throw new Error("daily note was not created by codex notify");
+      throw new Error("daily note was not created by Codex hook");
     }
 
     const noteContent = readFileSync(join(notesDir, noteNames[0]), "utf-8");
     if (!noteContent.includes("Reply with exactly: OK")) {
       throw new Error("daily note did not include expected prompt text");
     }
+    if (!noteContent.includes("## EnglishAsk")) {
+      throw new Error("daily note did not include EnglishAsk feedback");
+    }
+    if (!noteContent.includes("- score: 4/5")) {
+      throw new Error("daily note did not include expected EnglishAsk score");
+    }
+    if (!readFileSync(evaluatorInputPath, "utf-8").includes("User prompt:\nReply with exactly: OK")) {
+      throw new Error("EnglishAsk evaluator did not receive the raw prompt");
+    }
 
     const uninstalled = await run(["agentlog", "uninstall", "--codex", "-y"], env);
     assertOk(uninstalled, "agentlog uninstall --codex");
 
-    const postUninstallToml = readFileSync(configTomlPath, "utf-8");
-    if (postUninstallToml.includes('notify = ["agentlog", "codex-notify"]')) {
-      throw new Error("agentlog notify was still present after uninstall");
+    const postUninstallHooks = existsSync(hooksJsonPath) ? readFileSync(hooksJsonPath, "utf-8") : "";
+    if (postUninstallHooks.includes("agentlog hook --source codex")) {
+      throw new Error("agentlog Codex hook was still present after uninstall");
     }
     if (!existsSync(configJsonPath)) {
       throw new Error("config.json should remain after uninstall --codex");
@@ -149,10 +196,10 @@ async function main(): Promise<void> {
     const reinstalled = await run(["agentlog", "init", "--codex", "--plain", notesDir], env);
     assertOk(reinstalled, "reinstall agentlog init --codex --plain");
 
-    const reinstallToml = readFileSync(configTomlPath, "utf-8");
-    const notifyOccurrences = reinstallToml.match(/notify = \["agentlog", "codex-notify"\]/g)?.length ?? 0;
-    if (notifyOccurrences !== 1) {
-      throw new Error(`expected exactly one agentlog notify registration, got ${notifyOccurrences}`);
+    const reinstallHooks = readFileSync(hooksJsonPath, "utf-8");
+    const hookOccurrences = reinstallHooks.match(/agentlog hook --source codex/g)?.length ?? 0;
+    if (hookOccurrences !== 1) {
+      throw new Error(`expected exactly one agentlog Codex hook registration, got ${hookOccurrences}`);
     }
 
     const doctor = await run(["agentlog", "doctor"], env);

--- a/scripts/end-user-hermes-host-smoke.ts
+++ b/scripts/end-user-hermes-host-smoke.ts
@@ -1,0 +1,257 @@
+#!/usr/bin/env bun
+
+import { existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "fs";
+import { spawn } from "bun";
+import { homedir, tmpdir } from "os";
+import { dirname, join, resolve } from "path";
+
+interface Result {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+interface Args {
+  vault?: string;
+  profiles: string[];
+  allProfiles: boolean;
+  skipLink: boolean;
+  appendFixture: boolean;
+}
+
+async function run(cmd: string[], cwd = process.cwd(), env: Record<string, string> = {}): Promise<Result> {
+  const proc = spawn(cmd, {
+    cwd,
+    env: { ...process.env, ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+
+  return { stdout, stderr, exitCode };
+}
+
+function assertOk(result: Result, label: string): void {
+  if (result.exitCode !== 0) {
+    throw new Error(`${label} failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+  }
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {
+    profiles: [],
+    allProfiles: false,
+    skipLink: false,
+    appendFixture: false,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--vault") args.vault = argv[++i];
+    else if (arg === "--profile") args.profiles.push(argv[++i]);
+    else if (arg === "--all-profiles") args.allProfiles = true;
+    else if (arg === "--skip-link") args.skipLink = true;
+    else if (arg === "--append-fixture") args.appendFixture = true;
+    else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (args.profiles.length > 0 && args.allProfiles) {
+    throw new Error("Choose either --profile or --all-profiles");
+  }
+  return args;
+}
+
+function printHelp(): void {
+  console.log(`Usage: bun run scripts/end-user-hermes-host-smoke.ts [--vault ~/Obsidian] [--profile name...] [--all-profiles] [--skip-link] [--append-fixture]
+
+Mutates the real user environment:
+  1. optionally links this checkout as the global agentlog command
+  2. runs agentlog init --hermes against the real vault
+  3. verifies agentlog doctor
+  4. approves the hook in Hermes shell-hooks-allowlist.json
+  5. verifies Hermes sees the installed hook and hooks doctor is healthy
+
+--append-fixture also invokes agentlog hook --source hermes with the test fixture and writes one real Daily Note entry.
+`);
+}
+
+function defaultVault(): string {
+  const configPath = process.env.AGENTLOG_CONFIG_DIR
+    ? join(process.env.AGENTLOG_CONFIG_DIR, "config.json")
+    : join(homedir(), ".agentlog", "config.json");
+
+  if (existsSync(configPath)) {
+    const config = JSON.parse(readFileSync(configPath, "utf-8")) as { vault?: string };
+    if (config.vault) return config.vault;
+  }
+  return join(homedir(), "Obsidian");
+}
+
+function hookCommandPresent(output: string): boolean {
+  return output.includes("agentlog hook --source hermes");
+}
+
+function shellQuote(value: string): string {
+  if (/^[A-Za-z0-9_/:=.,@%+-]+$/.test(value)) return value;
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function hermesHookCommand(agentlogPath: string): string {
+  return `${shellQuote(agentlogPath)} hook --source hermes`;
+}
+
+function hermesHomes(args: Args): string[] {
+  const root = join(homedir(), ".hermes");
+  if (args.allProfiles) {
+    const homes = [root];
+    const profilesRoot = join(root, "profiles");
+    if (existsSync(profilesRoot)) {
+      for (const name of readdirSync(profilesRoot).sort()) {
+        const profileHome = join(profilesRoot, name);
+        if (existsSync(join(profileHome, "config.yaml"))) homes.push(profileHome);
+      }
+    }
+    return homes;
+  }
+  if (args.profiles.length > 0) {
+    return args.profiles.map((profile) => join(root, "profiles", profile));
+  }
+  return [root];
+}
+
+function approveHermesHook(args: Args, command: string, agentlogPath: string): void {
+  const approval = {
+    event: "pre_llm_call",
+    command,
+    approved_at: new Date().toISOString().replace("+00:00", "Z"),
+    script_mtime_at_approval: statSync(agentlogPath).mtime.toISOString().replace("+00:00", "Z"),
+  };
+
+  for (const home of hermesHomes(args)) {
+    const allowlistPath = join(home, "shell-hooks-allowlist.json");
+    let data: { approvals: unknown[] } = { approvals: [] };
+    if (existsSync(allowlistPath)) {
+      const parsed = JSON.parse(readFileSync(allowlistPath, "utf-8")) as { approvals?: unknown[] };
+      data = { approvals: Array.isArray(parsed.approvals) ? parsed.approvals : [] };
+    }
+    data.approvals = data.approvals.filter((entry) => {
+      return !(typeof entry === "object" && entry !== null
+        && "event" in entry
+        && "command" in entry
+        && (entry as { event?: unknown; command?: unknown }).event === approval.event
+        && (entry as { event?: unknown; command?: unknown }).command === approval.command);
+    });
+    data.approvals.push(approval);
+    mkdirSync(dirname(allowlistPath), { recursive: true });
+    writeFileSync(allowlistPath, JSON.stringify(data, null, 2), "utf-8");
+    console.log(`approved Hermes hook: ${allowlistPath}`);
+  }
+}
+
+async function main(): Promise<void> {
+  const repoRoot = resolve(join(import.meta.dir, ".."));
+  const args = parseArgs(Bun.argv.slice(2));
+  const vault = resolve(args.vault ?? defaultVault());
+
+  if (!existsSync(vault)) {
+    throw new Error(`Vault not found: ${vault}`);
+  }
+
+  if (!args.skipLink) {
+    const linked = await run([process.execPath, "link"], repoRoot);
+    assertOk(linked, "bun link");
+  }
+
+  const resolved = await run(["/bin/sh", "-lc", "command -v agentlog"]);
+  assertOk(resolved, "resolve agentlog");
+  const agentlogPath = resolved.stdout.trim();
+  console.log(`agentlog: ${agentlogPath}`);
+
+  const version = await run(["agentlog", "version"]);
+  assertOk(version, "agentlog version");
+  console.log(version.stdout.trim());
+
+  const initArgs = ["agentlog", "init", "--hermes"];
+  for (const profile of args.profiles) initArgs.push("--hermes-profile", profile);
+  if (args.allProfiles) initArgs.push("--hermes-all-profiles");
+  initArgs.push(vault);
+
+  const installed = await run(initArgs);
+  assertOk(installed, initArgs.join(" "));
+  console.log(installed.stdout.trim());
+
+  const doctor = await run(["agentlog", "doctor"]);
+  assertOk(doctor, "agentlog doctor");
+  if (!doctor.stdout.includes("✅ hermes")) {
+    throw new Error(`doctor did not report Hermes success\n${doctor.stdout}`);
+  }
+  console.log("agentlog doctor: hermes ok");
+
+  const hermesListArgs = args.profiles.length === 1
+    ? ["hermes", "-p", args.profiles[0], "hooks", "list"]
+    : ["hermes", "hooks", "list"];
+  const hooks = await run(hermesListArgs);
+  assertOk(hooks, hermesListArgs.join(" "));
+  if (!hookCommandPresent(hooks.stdout + hooks.stderr)) {
+    throw new Error(`Hermes hook list did not include AgentLog command\nstdout:\n${hooks.stdout}\nstderr:\n${hooks.stderr}`);
+  }
+  console.log(hooks.stdout.trim());
+
+  approveHermesHook(args, hermesHookCommand(agentlogPath), agentlogPath);
+
+  const doctorArgs = args.profiles.length === 1
+    ? ["hermes", "-p", args.profiles[0], "hooks", "doctor"]
+    : ["hermes", "hooks", "doctor"];
+  const doctorRoot = mkdtempSync(join(tmpdir(), "agentlog-hermes-host-doctor-"));
+  try {
+    const doctorConfigDir = join(doctorRoot, "cfg");
+    const doctorNotesDir = join(doctorRoot, "notes");
+    mkdirSync(doctorConfigDir, { recursive: true });
+    mkdirSync(doctorNotesDir, { recursive: true });
+    writeFileSync(
+      join(doctorConfigDir, "config.json"),
+      JSON.stringify({ vault: doctorNotesDir, plain: true, hermesHookInstalled: true }, null, 2),
+      "utf-8"
+    );
+    const hermesDoctor = await run(doctorArgs, process.cwd(), { AGENTLOG_CONFIG_DIR: doctorConfigDir });
+    assertOk(hermesDoctor, doctorArgs.join(" "));
+    if (!hermesDoctor.stdout.includes("All shell hooks look healthy.")) {
+      throw new Error(`Hermes hooks doctor did not report healthy hooks\nstdout:\n${hermesDoctor.stdout}\nstderr:\n${hermesDoctor.stderr}`);
+    }
+  } finally {
+    rmSync(doctorRoot, { recursive: true, force: true });
+  }
+  console.log("hermes hooks doctor: healthy");
+
+  if (args.appendFixture) {
+    const fixturePath = join(repoRoot, "src", "__tests__", "fixtures", "hermes-pre-llm-call.json");
+    const appended = Bun.spawn(["agentlog", "hook", "--source", "hermes"], {
+      cwd: repoRoot,
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+      env: process.env,
+    });
+    appended.stdin.write(readFileSync(fixturePath));
+    appended.stdin.end();
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(appended.stdout).text(),
+      new Response(appended.stderr).text(),
+      appended.exited,
+    ]);
+    assertOk({ stdout, stderr, exitCode }, "agentlog hook --source hermes fixture");
+    console.log("fixture append: ok");
+  }
+}
+
+await main();

--- a/scripts/prd-redteam.mjs
+++ b/scripts/prd-redteam.mjs
@@ -1,0 +1,444 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+const DEFAULT_PRD = "docs/plans/2026-06-21-hook-provider-abstraction-hermes-prd.md";
+
+function parseArgs(argv) {
+  const args = {
+    prd: DEFAULT_PRD,
+    output: null,
+    json: false,
+    model: "gpt-5.3-codex-spark",
+    reasoningEffort: "low",
+    skipModel: false,
+    timeoutMs: 120_000,
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--prd") args.prd = argv[++i];
+    else if (arg === "--output") args.output = argv[++i];
+    else if (arg === "--json") args.json = true;
+    else if (arg === "--model") args.model = argv[++i];
+    else if (arg === "--reasoning-effort") args.reasoningEffort = argv[++i];
+    else if (arg === "--skip-model") args.skipModel = true;
+    else if (arg === "--timeout-ms") args.timeoutMs = Number(argv[++i]);
+    else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else {
+      fail(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!Number.isFinite(args.timeoutMs) || args.timeoutMs <= 0) {
+    fail(`Invalid --timeout-ms: ${args.timeoutMs}`);
+  }
+  return args;
+}
+
+function printHelp() {
+  console.log(`Usage: node scripts/prd-redteam.mjs [--prd ${DEFAULT_PRD}] [--output report.json]
+
+Runs a two-layer PRD red-team gate:
+  1. mechanical checks for required Phase 0 PRD coverage
+  2. model review through isolated: codex exec --ephemeral --ignore-rules -- <prompt>
+
+Options:
+  --json          Print the full JSON report to stdout
+  --model         Codex model for model review (default: gpt-5.3-codex-spark)
+  --reasoning-effort
+                  Codex model_reasoning_effort override (default: low)
+  --skip-model    Run only mechanical checks, intended for local triage
+  --timeout-ms    codex exec timeout in milliseconds (default: 120000)
+`);
+}
+
+function fail(message) {
+  console.error(`[prd-redteam] ${message}`);
+  process.exit(2);
+}
+
+function check(id, description, passed, evidence = "") {
+  return { id, description, passed: Boolean(passed), evidence };
+}
+
+function includesAll(text, needles) {
+  return needles.every((needle) => text.includes(needle));
+}
+
+function matchesAll(text, patterns) {
+  return patterns.every((pattern) => pattern.test(text));
+}
+
+const REQUIRED_PHASE0_FILES = [
+  "docs/plans/2026-06-21-hook-provider-current-behavior-coverage.md",
+  "docs/plans/2026-06-21-hook-provider-agent-readiness.md",
+  "docs/research/2026-06-21-hermes-agentlog-research.md",
+  "docs/research/2026-06-21-hook-provider-abstraction-research.md",
+];
+
+function mechanicalChecks(prd, rootDir = process.cwd()) {
+  const sections = [
+    "## 0. LLM Work Guide",
+    "## 1. Goal",
+    "## 2. Non-Goals",
+    "## 3. Design",
+    "## 4. Verification Criteria",
+    "## 5. Risks",
+    "## 6. Task Checklist",
+    "## 7. Open Questions",
+    "## 8. Decision Log",
+    "## 9. Handoff Snapshot",
+    "## 10. Changelog",
+  ];
+
+  const phase0Index = prd.indexOf("Phase 0");
+  const phase1Index = prd.indexOf("Phase 1");
+
+  return [
+    check(
+      "required-sections",
+      "PRD has all execution sections from work guide through changelog",
+      includesAll(prd, sections),
+      sections.filter((section) => !prd.includes(section)).join(", ")
+    ),
+    check(
+      "third-provider-rationale",
+      "Goal explains why abstraction is justified only at Claude+Codex+Hermes",
+      matchesAll(prd, [/third time/i, /Claude \+ Codex \+ Hermes/, /third repeated hook lifecycle path/])
+    ),
+    check(
+      "phase0-before-phase1",
+      "Phase 0 behavior lock appears before provider extraction",
+      phase0Index >= 0 && phase1Index >= 0 && phase0Index < phase1Index,
+      `Phase 0 index=${phase0Index}, Phase 1 index=${phase1Index}`
+    ),
+    check(
+      "phase0-coverage-matrix",
+      "Phase 0 requires current behavior coverage matrix before refactoring",
+      includesAll(prd, [
+        "current behavior coverage matrix",
+        "docs/plans/2026-06-21-hook-provider-current-behavior-coverage.md",
+        "Claude, Codex, legacy Codex notify, hook parsing, note writing, doctor, init, uninstall, and backfill",
+      ])
+    ),
+    check(
+      "phase0-missing-tests",
+      "Phase 0 requires missing regression tests before provider extraction",
+      includesAll(prd, [
+        "Add missing regression tests before refactoring",
+        "Missing tests found in Phase 0 are added before provider extraction",
+      ])
+    ),
+    check(
+      "phase0-qa-smoke",
+      "Phase 0 lists QA smoke commands and isolated hook fixture invocation",
+      includesAll(prd, [
+        "agentlog doctor",
+        "agentlog init --dry-run",
+        "agentlog init --codex --dry-run",
+        "agentlog backfill --dry-run --format json",
+        "hook fixture invocation in an isolated `AGENTLOG_CONFIG_DIR`",
+      ])
+    ),
+    check(
+      "phase0-agent-readiness",
+      "Phase 0 requires agent-framework readiness review and PRD gap patching",
+      includesAll(prd, [
+        "Validate agent-framework readiness",
+        "docs/plans/2026-06-21-hook-provider-agent-readiness.md",
+        "Patch any missing PRD detail discovered during readiness review before code changes",
+      ])
+    ),
+    check(
+      "phase0-artifacts-exist",
+      "Phase 0 coverage/readiness/research artifacts exist on disk",
+      REQUIRED_PHASE0_FILES.every((file) => existsSync(resolve(rootDir, file))),
+      REQUIRED_PHASE0_FILES.filter((file) => !existsSync(resolve(rootDir, file))).join(", ")
+    ),
+    check(
+      "non-goals-guardrails",
+      "PRD excludes risky or out-of-scope Hermes behavior",
+      includesAll(prd, [
+        "Do not rewrite the Daily Note writer",
+        "Do not add Hermes backfill until Hermes transcript format is separately verified",
+        "Do not make EnglishAsk run for Hermes",
+        "Do not silently include Hermes in `agentlog init --all`",
+        "Do not regex-edit arbitrary YAML for `~/.hermes/config.yaml`",
+        "Do not mutate Hermes YAML without a structured parser",
+      ])
+    ),
+    check(
+      "provider-interface",
+      "PRD defines a bounded HookProvider interface and target mapping",
+      includesAll(prd, [
+        "export interface HookProvider",
+        "providersForInitTarget(\"all\") === [\"claude\", \"codex\"]",
+        "HookProviderId = \"claude\" | \"codex\" | \"hermes\"",
+      ])
+    ),
+    check(
+      "hermes-runtime-contract",
+      "PRD captures Hermes runtime input, parser, and divider behavior",
+      includesAll(prd, [
+        "hook_event_name: \"pre_llm_call\"",
+        "extra.user_message",
+        "agentlog hook --source hermes",
+        "[[hermes_sess_abc]]",
+      ])
+    ),
+    check(
+      "negative-security-tests",
+      "Verification includes unknown source, stdout, and unsupported provider negatives",
+      includesAll(prd, [
+        "unknown `--source bad`",
+        "stdout is empty or `{}`",
+        "unsupported provider config shape",
+      ])
+    ),
+    check(
+      "research-links",
+      "Handoff references both research documents needed by implementation agents",
+      includesAll(prd, [
+        "docs/research/2026-06-21-hermes-agentlog-research.md",
+        "docs/research/2026-06-21-hook-provider-abstraction-research.md",
+      ])
+    ),
+    check(
+      "init-hermes-automation-decision",
+      "PRD resolves init --hermes as structured Hermes YAML automation with profile support",
+      includesAll(prd, [
+        "`agentlog init --hermes` now owns structured Hermes config mutation",
+        "records target profiles",
+        "--hermes-profile <name>",
+        "--hermes-all-profiles",
+        "real Hermes-profile smoke",
+      ])
+    ),
+    check(
+      "backfill-source-contract",
+      "PRD explicitly rejects Hermes backfill source until separately specified",
+      includesAll(prd, [
+        "agentlog backfill --source hermes",
+        "Error: --source must be one of: all, claude, codex",
+        "Hermes transcript backfill is separately specified",
+      ])
+    ),
+  ];
+}
+
+function modelPrompt(prd) {
+  return `You are red-teaming an implementation PRD for AgentLog.
+
+Return only compact JSON with this exact shape:
+{"verdict":"pass"|"fail","findings":[{"severity":"high"|"medium"|"low","message":"...","evidence":"..."}],"missingRequirements":["..."]}
+
+Pass only if the PRD is executable by a coding agent and fully covers the user's Phase 0 requirement:
+- current behavior coverage tests before abstraction
+- QA smoke validation tests
+- agent-framework readiness validation
+- PRD gap patching before provider code changes
+- provider lifecycle abstraction before Hermes automation
+- Hermes config automation with profile support only through structured YAML parsing
+
+Fail if any required Phase 0 deliverable, guardrail, or verification criterion is missing or ambiguous.
+
+PRD:
+${prd}`;
+}
+
+function extractJson(stdout) {
+  const trimmed = stdout.trim();
+  if (!trimmed) throw new Error("codex exec returned empty stdout");
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    const start = trimmed.indexOf("{");
+    const end = trimmed.lastIndexOf("}");
+    if (start < 0 || end <= start) throw new Error("codex exec stdout did not contain a JSON object");
+    return JSON.parse(trimmed.slice(start, end + 1));
+  }
+}
+
+function trimOutput(value, maxChars = 4000) {
+  if (!value) return "";
+  if (value.length <= maxChars) return value;
+  return `${value.slice(0, maxChars)}\n[truncated ${value.length - maxChars} chars]`;
+}
+
+function createIsolatedCodexHome(args) {
+  const codexHome = mkdtempSync(join(tmpdir(), "agentlog-prd-redteam-codex-"));
+  const sourceHome = process.env.CODEX_HOME || join(homedir(), ".codex");
+  const authPath = join(sourceHome, "auth.json");
+  if (existsSync(authPath)) {
+    copyFileSync(authPath, join(codexHome, "auth.json"));
+  }
+  writeFileSync(
+    join(codexHome, "config.toml"),
+    [
+      `model = "${args.model}"`,
+      `model_reasoning_effort = "${args.reasoningEffort}"`,
+      `approval_policy = "never"`,
+      `sandbox_mode = "danger-full-access"`,
+      "",
+    ].join("\n"),
+    "utf-8"
+  );
+  return codexHome;
+}
+
+function runCodexReview(prd, args) {
+  const isolatedCodexHome = createIsolatedCodexHome(args);
+  let result;
+  try {
+    result = spawnSync("codex", [
+      "exec",
+      "--skip-git-repo-check",
+      "--ignore-rules",
+      "--ephemeral",
+      "-m",
+      args.model,
+      "-c",
+      `model_reasoning_effort="${args.reasoningEffort}"`,
+      "--",
+      modelPrompt(prd),
+    ], {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: args.timeoutMs,
+      env: {
+        ...process.env,
+        AGENTLOG_ENGLISHASK_EVAL: "1",
+        CODEX_HOME: isolatedCodexHome,
+      },
+    });
+  } finally {
+    rmSync(isolatedCodexHome, { recursive: true, force: true });
+  }
+
+  if (result.error) {
+    return {
+      invoked: true,
+      verdict: "fail",
+      findings: [{ severity: "high", message: result.error.message, evidence: "codex exec failed to start or timed out" }],
+      missingRequirements: [],
+      stdout: trimOutput(result.stdout ?? ""),
+      stderr: trimOutput(result.stderr ?? ""),
+      exitCode: result.status ?? null,
+      model: args.model,
+      reasoningEffort: args.reasoningEffort,
+      timeoutMs: args.timeoutMs,
+    };
+  }
+
+  if (result.status !== 0) {
+    return {
+      invoked: true,
+      verdict: "fail",
+      findings: [{ severity: "high", message: `codex exec exited ${result.status}`, evidence: result.stderr.trim() }],
+      missingRequirements: [],
+      stdout: trimOutput(result.stdout ?? ""),
+      stderr: trimOutput(result.stderr ?? ""),
+      exitCode: result.status,
+      model: args.model,
+      reasoningEffort: args.reasoningEffort,
+      timeoutMs: args.timeoutMs,
+    };
+  }
+
+  try {
+    const parsed = extractJson(result.stdout ?? "");
+    return {
+      invoked: true,
+      verdict: parsed.verdict === "pass" ? "pass" : "fail",
+      findings: Array.isArray(parsed.findings) ? parsed.findings : [],
+      missingRequirements: Array.isArray(parsed.missingRequirements) ? parsed.missingRequirements : [],
+      stdout: trimOutput(result.stdout ?? ""),
+      stderr: trimOutput(result.stderr ?? ""),
+      exitCode: result.status,
+      model: args.model,
+      reasoningEffort: args.reasoningEffort,
+      timeoutMs: args.timeoutMs,
+    };
+  } catch (error) {
+    return {
+      invoked: true,
+      verdict: "fail",
+      findings: [{ severity: "high", message: error.message, evidence: trimOutput(result.stdout ?? "", 1000) }],
+      missingRequirements: [],
+      stdout: trimOutput(result.stdout ?? ""),
+      stderr: trimOutput(result.stderr ?? ""),
+      exitCode: result.status,
+      model: args.model,
+      reasoningEffort: args.reasoningEffort,
+      timeoutMs: args.timeoutMs,
+    };
+  }
+}
+
+function summarize(result) {
+  console.log(`prd-redteam: ${result.verdict}`);
+  console.log(`prd: ${result.prd}`);
+  console.log(`mechanical: ${result.mechanical.verdict} (${result.mechanical.passed}/${result.mechanical.total} checks passed)`);
+  for (const item of result.mechanical.checks) {
+    console.log(`- ${item.passed ? "PASS" : "FAIL"} ${item.id}: ${item.description}`);
+  }
+  console.log(`model: ${result.model.invoked ? result.model.verdict : "skipped"}`);
+  if (result.model.invoked) {
+    console.log(`model config: ${result.model.model} / ${result.model.reasoningEffort} timeout=${result.model.timeoutMs}ms`);
+  }
+  for (const finding of result.model.findings ?? []) {
+    console.log(`- [${finding.severity ?? "unknown"}] ${finding.message}${finding.evidence ? ` (${finding.evidence})` : ""}`);
+  }
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const prdPath = resolve(process.cwd(), args.prd);
+  if (!existsSync(prdPath)) {
+    fail(`PRD not found: ${args.prd}`);
+  }
+
+  const prd = readFileSync(prdPath, "utf-8");
+  const checks = mechanicalChecks(prd, process.cwd());
+  const failed = checks.filter((item) => !item.passed);
+  const mechanical = {
+    verdict: failed.length === 0 ? "pass" : "fail",
+    total: checks.length,
+    passed: checks.length - failed.length,
+    failed: failed.length,
+    checks,
+  };
+
+  const model = args.skipModel || mechanical.verdict === "fail"
+    ? { invoked: false, verdict: "skipped", findings: [], missingRequirements: [] }
+    : runCodexReview(prd, args);
+
+  const result = {
+    checkedAt: new Date().toISOString(),
+    prd: args.prd,
+    verdict: mechanical.verdict === "pass" && (args.skipModel || model.verdict === "pass") ? "pass" : "fail",
+    mechanical,
+    model,
+  };
+
+  if (args.output) {
+    const outputPath = resolve(process.cwd(), args.output);
+    mkdirSync(dirname(outputPath), { recursive: true });
+    writeFileSync(outputPath, `${JSON.stringify(result, null, 2)}\n`, "utf-8");
+  }
+
+  if (args.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    summarize(result);
+  }
+
+  process.exit(result.verdict === "pass" ? 0 : 1);
+}
+
+main();

--- a/src/__tests__/backfill.test.ts
+++ b/src/__tests__/backfill.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import { tmpdir } from "os";
-import { collectBackfillEntries, parseDateArg, runBackfill } from "../backfill.js";
+import { collectBackfillEntries, hasPathSegment, parseDateArg, runBackfill } from "../backfill.js";
 import type { AgentLogConfig } from "../types.js";
 
 function makeTmpDir(): string {
@@ -25,6 +25,17 @@ describe("backfill", () => {
 
   afterEach(() => {
     rmSync(root, { recursive: true, force: true });
+  });
+
+  it("rejects impossible calendar dates", () => {
+    expect(() => parseDateArg("2026-13-99")).toThrow("valid YYYY-MM-DD calendar date");
+    expect(() => parseDateArg("2026-02-30")).toThrow("valid YYYY-MM-DD calendar date");
+  });
+
+  it("detects path segments with POSIX or Windows separators", () => {
+    expect(hasPathSegment("/Users/me/.claude/projects/subagents/agent.jsonl", "subagents")).toBe(true);
+    expect(hasPathSegment("C:\\Users\\me\\.claude\\projects\\subagents\\agent.jsonl", "subagents")).toBe(true);
+    expect(hasPathSegment("/Users/me/.claude/projects/not-subagents/agent.jsonl", "subagents")).toBe(false);
   });
 
   it("collects Codex user_message entries without logging injected context", () => {
@@ -129,5 +140,54 @@ describe("backfill", () => {
     expect(second.skipped).toBe(1);
     const note = readFileSync(join(vault, "2026-06-19.md"), "utf-8");
     expect(note.match(/write once/g)?.length).toBe(1);
+  });
+
+  it("only treats an entry as duplicate inside the matching session block", () => {
+    const codexHome = join(root, ".codex");
+    const vault = join(root, "vault");
+    mkdirSync(join(vault, ".obsidian"), { recursive: true });
+    writeFileSync(join(vault, ".obsidian", "daily-notes.json"), JSON.stringify({ folder: "", format: "YYYY-MM-DD" }), "utf-8");
+    writeFileSync(
+      join(vault, "2026-06-19.md"),
+      [
+        "## AgentLog",
+        "> 🕐 12:01 — js/other › existing",
+        "",
+        "#### 09:00 · js/other",
+        "<!-- cwd=/Users/me/work/js/other -->",
+        "- - - - [[codex_codex-session]]",
+        "- 09:00 existing",
+        "",
+        "#### 12:00 · js/agentlog",
+        "<!-- cwd=/Users/me/work/js/agentlog -->",
+        "- - - - [[codex_other-session]]",
+        "- 12:01 same prompt",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    writeJsonl(join(codexHome, "sessions", "2026", "06", "19", "rollout.jsonl"), [
+      {
+        timestamp: "2026-06-19T12:00:00",
+        type: "session_meta",
+        payload: { id: "codex-session", cwd: "/Users/me/work/js/agentlog", thread_source: "user" },
+      },
+      {
+        timestamp: "2026-06-19T12:01:00",
+        type: "event_msg",
+        payload: { type: "user_message", message: "same prompt" },
+      },
+    ]);
+
+    const result = runBackfill(
+      { vault, plain: false },
+      { date: parseDateArg("2026-06-19"), source: "codex", codexHome },
+    );
+
+    expect(result.inserted).toBe(1);
+    expect(result.skipped).toBe(0);
+    const note = readFileSync(join(vault, "2026-06-19.md"), "utf-8");
+    expect(note.match(/^- 12:01 same prompt$/gm)?.length).toBe(2);
+    expect(note).toContain("- - - - [[codex_codex-session]]\n- 12:01 same prompt");
   });
 });

--- a/src/__tests__/backfill.test.ts
+++ b/src/__tests__/backfill.test.ts
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { dirname, join } from "path";
+import { tmpdir } from "os";
+import { collectBackfillEntries, parseDateArg, runBackfill } from "../backfill.js";
+import type { AgentLogConfig } from "../types.js";
+
+function makeTmpDir(): string {
+  const dir = join(tmpdir(), `agentlog-backfill-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function writeJsonl(path: string, rows: unknown[]): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, rows.map((row) => JSON.stringify(row)).join("\n") + "\n", "utf-8");
+}
+
+describe("backfill", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = makeTmpDir();
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("collects Codex user_message entries without logging injected context", () => {
+    const codexHome = join(root, ".codex");
+    writeJsonl(join(codexHome, "sessions", "2026", "06", "19", "rollout.jsonl"), [
+      {
+        timestamp: "2026-06-19T10:00:00",
+        type: "session_meta",
+        payload: { id: "codex-session", cwd: "/Users/me/work/js/agentlog", thread_source: "user" },
+      },
+      {
+        timestamp: "2026-06-19T10:00:01",
+        type: "response_item",
+        payload: { type: "message", role: "user", content: [{ type: "input_text", text: "# AGENTS.md instructions" }] },
+      },
+      {
+        timestamp: "2026-06-19T10:01:00",
+        type: "event_msg",
+        payload: { type: "user_message", message: "backfill this prompt" },
+      },
+    ]);
+
+    const result = collectBackfillEntries({
+      date: parseDateArg("2026-06-19"),
+      source: "codex",
+      codexHome,
+    });
+
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0]).toMatchObject({
+      time: "10:01",
+      prompt: "backfill this prompt",
+      sessionId: "codex-session",
+      project: "js/agentlog",
+      source: "codex",
+    });
+  });
+
+  it("collects Claude user text and skips tool-result shaped user messages", () => {
+    const claudeHome = join(root, ".claude");
+    const sessionPath = join(claudeHome, "projects", "-Users-me-work-js-agentlog", "claude-session.jsonl");
+    writeJsonl(sessionPath, [
+      {
+        timestamp: "2026-06-19T11:00:00",
+        type: "user",
+        sessionId: "claude-session",
+        cwd: "/Users/me/work/js/agentlog",
+        isSidechain: false,
+        message: { role: "user", content: "claude backfill prompt" },
+      },
+      {
+        timestamp: "2026-06-19T11:01:00",
+        type: "user",
+        sessionId: "claude-session",
+        cwd: "/Users/me/work/js/agentlog",
+        message: { role: "user", content: [{ type: "tool_result", content: "not a prompt" }] },
+      },
+    ]);
+    writeJsonl(join(claudeHome, "projects", "-Users-me-work-js-agentlog", "claude-session", "subagents", "agent.jsonl"), [
+      {
+        timestamp: "2026-06-19T11:02:00",
+        type: "user",
+        sessionId: "subagent",
+        cwd: "/Users/me/work/js/agentlog",
+        message: { role: "user", content: "subagent prompt" },
+      },
+    ]);
+
+    const result = collectBackfillEntries({
+      date: parseDateArg("2026-06-19"),
+      source: "claude",
+      claudeHome,
+    });
+
+    expect(result.entries.map((entry) => entry.prompt)).toEqual(["claude backfill prompt"]);
+  });
+
+  it("appends missing entries and skips duplicates on the next run", () => {
+    const codexHome = join(root, ".codex");
+    const vault = join(root, "notes");
+    mkdirSync(vault, { recursive: true });
+    writeJsonl(join(codexHome, "sessions", "2026", "06", "19", "rollout.jsonl"), [
+      {
+        timestamp: "2026-06-19T12:00:00",
+        type: "session_meta",
+        payload: { id: "codex-session", cwd: "/Users/me/work/js/agentlog", thread_source: "user" },
+      },
+      {
+        timestamp: "2026-06-19T12:01:00",
+        type: "event_msg",
+        payload: { type: "user_message", message: "write once" },
+      },
+    ]);
+
+    const config: AgentLogConfig = { vault, plain: true };
+    const opts = { date: parseDateArg("2026-06-19"), source: "codex" as const, codexHome };
+    const first = runBackfill(config, opts);
+    const second = runBackfill(config, opts);
+
+    expect(first.inserted).toBe(1);
+    expect(second.inserted).toBe(0);
+    expect(second.skipped).toBe(1);
+    const note = readFileSync(join(vault, "2026-06-19.md"), "utf-8");
+    expect(note.match(/write once/g)?.length).toBe(1);
+  });
+});

--- a/src/__tests__/cli-codex.test.ts
+++ b/src/__tests__/cli-codex.test.ts
@@ -184,6 +184,49 @@ describe("cli codex commands", () => {
     expect(config.claudeHookInstalled).toBeUndefined();
   });
 
+  it("init --codex migrates a legacy Codex UserPromptSubmit AgentLog hook", async () => {
+    const vault = join(tmpHome, "Obsidian");
+    const cfgDir = join(tmpHome, ".agentlog");
+    const pathWithCodex = makeFakeCodexPath(tmpHome);
+    mkdirSync(join(vault, ".obsidian"), { recursive: true });
+    mkdirSync(join(tmpHome, ".codex"), { recursive: true });
+    writeFileSync(
+      join(tmpHome, ".codex", "hooks.json"),
+      JSON.stringify({
+        hooks: {
+          UserPromptSubmit: [
+            { hooks: [{ type: "command", command: "agentlog hook" }] },
+            { hooks: [{ type: "command", command: "node /opt/omx/codex-native-hook.js" }] },
+          ],
+        },
+        state: {
+          "/tmp/hooks.json:user_prompt_submit:0:0": { trusted_hash: "sha256:old-user-prompt-submit" },
+          "/tmp/hooks.json:stop:0:0": { trusted_hash: "sha256:stop" },
+        },
+      }),
+      "utf-8"
+    );
+
+    const { exitCode } = await runCli(["init", "--codex", vault], {
+      HOME: tmpHome,
+      AGENTLOG_CONFIG_DIR: cfgDir,
+      PATH: pathWithCodex,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(readCodexHooks(tmpHome)).toEqual({
+      hooks: {
+        UserPromptSubmit: [
+          { hooks: [{ type: "command", command: "node /opt/omx/codex-native-hook.js" }] },
+          { hooks: [{ type: "command", command: "agentlog hook --source codex" }] },
+        ],
+      },
+      state: {
+        "/tmp/hooks.json:stop:0:0": { trusted_hash: "sha256:stop" },
+      },
+    });
+  });
+
   it("init --codex aborts on unsupported hooks.json", async () => {
     const vault = join(tmpHome, "Obsidian");
     const cfgDir = join(tmpHome, ".agentlog");
@@ -738,6 +781,52 @@ describe("cli codex commands", () => {
     expect(existsSync(join(cfgDir, "config.json"))).toBe(false);
   });
 
+  it("default uninstall warns when Codex hooks need migration", async () => {
+    const vault = join(tmpHome, "notes");
+    const cfgDir = join(tmpHome, ".agentlog");
+    mkdirSync(vault, { recursive: true });
+    mkdirSync(cfgDir, { recursive: true });
+    mkdirSync(join(tmpHome, ".claude"), { recursive: true });
+    mkdirSync(join(tmpHome, ".codex"), { recursive: true });
+    writeFileSync(
+      join(tmpHome, ".claude", "settings.json"),
+      JSON.stringify({
+        hooks: {
+          UserPromptSubmit: [
+            { matcher: "", hooks: [{ type: "command", command: "agentlog hook" }] },
+          ],
+        },
+      }),
+      "utf-8"
+    );
+    writeFileSync(
+      join(tmpHome, ".codex", "hooks.json"),
+      JSON.stringify({
+        hooks: {
+          UserPromptSubmit: [
+            { hooks: [{ type: "command", command: "agentlog hook" }] },
+            { hooks: [{ type: "command", command: "agentlog hook --source codex" }] },
+          ],
+        },
+      }),
+      "utf-8"
+    );
+    writeFileSync(
+      join(cfgDir, "config.json"),
+      JSON.stringify({ vault, plain: true, claudeHookInstalled: true }),
+      "utf-8"
+    );
+
+    const { stderr, exitCode } = await runCli(["uninstall", "-y"], {
+      HOME: tmpHome,
+      AGENTLOG_CONFIG_DIR: cfgDir,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toContain("Codex hook is still registered");
+    expect(existsSync(join(tmpHome, ".codex", "hooks.json"))).toBe(true);
+  });
+
   it("doctor succeeds when Codex hook is installed", async () => {
     const vault = join(tmpHome, "notes");
     const cfgDir = join(tmpHome, ".agentlog");
@@ -861,5 +950,41 @@ describe("cli codex commands", () => {
     expect(exitCode).not.toBe(0);
     expect(stdout).toContain("unsupported");
     expect(stdout).not.toContain("stack trace");
+  });
+
+  it("doctor reports legacy Codex hook entries as needing migration", async () => {
+    const vault = join(tmpHome, "notes");
+    const cfgDir = join(tmpHome, ".agentlog");
+    const pathWithCodex = makeFakeCodexPath(tmpHome);
+    mkdirSync(vault, { recursive: true });
+    mkdirSync(cfgDir, { recursive: true });
+    mkdirSync(join(tmpHome, ".codex"), { recursive: true });
+    writeFileSync(
+      join(tmpHome, ".codex", "hooks.json"),
+      JSON.stringify({
+        hooks: {
+          UserPromptSubmit: [
+            { hooks: [{ type: "command", command: "agentlog hook" }] },
+            { hooks: [{ type: "command", command: "agentlog hook --source codex" }] },
+          ],
+        },
+      }),
+      "utf-8"
+    );
+    writeFileSync(
+      join(cfgDir, "config.json"),
+      JSON.stringify({ vault, plain: true, codexHookInstalled: true }),
+      "utf-8"
+    );
+
+    const { stdout, exitCode } = await runCli(["doctor"], {
+      HOME: tmpHome,
+      AGENTLOG_CONFIG_DIR: cfgDir,
+      PATH: pathWithCodex,
+    });
+
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toContain("legacy AgentLog Codex hook remains");
+    expect(stdout).toContain("agentlog init --codex");
   });
 });

--- a/src/__tests__/cli-codex.test.ts
+++ b/src/__tests__/cli-codex.test.ts
@@ -9,7 +9,7 @@ const CLI_PATH = fileURLToPath(new URL("../cli.ts", import.meta.url));
 
 async function runCli(
   args: string[],
-  opts: { HOME?: string; AGENTLOG_CONFIG_DIR?: string; PATH?: string; AGENTLOG_ENGLISHASK_EVAL?: string } = {}
+  opts: { HOME?: string; AGENTLOG_CONFIG_DIR?: string; PATH?: string; AGENTLOG_ENGLISHASK_EVAL?: string; HERMES_HOME?: string } = {}
 ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   const env = { ...process.env, ...opts };
   const proc = Bun.spawn(
@@ -315,6 +315,134 @@ describe("cli codex commands", () => {
     const config = JSON.parse(readFileSync(join(cfgDir, "config.json"), "utf-8"));
     expect(config.codexHookInstalled).toBe(true);
     expect(config.claudeHookInstalled).toBe(true);
+    expect(config.hermesHookInstalled).toBeUndefined();
+  });
+
+  it("init --all preflights Codex before writing Claude settings", async () => {
+    const vault = join(tmpHome, "Obsidian");
+    const cfgDir = join(tmpHome, ".agentlog");
+    mkdirSync(join(vault, ".obsidian"), { recursive: true });
+
+    const { stderr, exitCode } = await runCli(["init", "--all", vault], {
+      HOME: tmpHome,
+      AGENTLOG_CONFIG_DIR: cfgDir,
+      PATH: "/usr/bin:/bin",
+    });
+
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("Codex CLI not found");
+    expect(existsSync(join(tmpHome, ".claude", "settings.json"))).toBe(false);
+    expect(existsSync(join(cfgDir, "config.json"))).toBe(false);
+  });
+
+  it("init --hermes writes the default Hermes config and records metadata", async () => {
+    const vault = join(tmpHome, "Obsidian");
+    const cfgDir = join(tmpHome, ".agentlog");
+    mkdirSync(join(vault, ".obsidian"), { recursive: true });
+    mkdirSync(join(tmpHome, ".hermes"), { recursive: true });
+    writeFileSync(join(tmpHome, ".hermes", "config.yaml"), "display:\n  theme: dark\nhooks: {}\n", "utf-8");
+
+    const { stdout, stderr, exitCode } = await runCli(["init", "--hermes", vault], {
+      HOME: tmpHome,
+      AGENTLOG_CONFIG_DIR: cfgDir,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("Hermes hook registered");
+    expect(stdout).toContain("agentlog hook --source hermes");
+    const config = JSON.parse(readFileSync(join(cfgDir, "config.json"), "utf-8"));
+    expect(config.hermesHookInstalled).toBe(true);
+    expect(config.hermesProfiles).toEqual(["default"]);
+    const hermesConfig = readFileSync(join(tmpHome, ".hermes", "config.yaml"), "utf-8");
+    expect(hermesConfig).toContain("theme: dark");
+    expect(hermesConfig).toContain("pre_llm_call");
+    expect(hermesConfig).toContain("agentlog hook --source hermes");
+  });
+
+  it("init --hermes supports multiple named profiles", async () => {
+    const vault = join(tmpHome, "Obsidian");
+    const cfgDir = join(tmpHome, ".agentlog");
+    mkdirSync(join(vault, ".obsidian"), { recursive: true });
+    for (const profile of ["alpha", "beta"]) {
+      mkdirSync(join(tmpHome, ".hermes", "profiles", profile), { recursive: true });
+      writeFileSync(join(tmpHome, ".hermes", "profiles", profile, "config.yaml"), "hooks: {}\n", "utf-8");
+    }
+
+    const { stdout, stderr, exitCode } = await runCli(
+      ["init", "--hermes", "--hermes-profile", "alpha", "--hermes-profile", "beta", vault],
+      {
+        HOME: tmpHome,
+        AGENTLOG_CONFIG_DIR: cfgDir,
+      }
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stderr).toBe("");
+    expect(stdout).toContain("Hermes hook registered");
+    for (const profile of ["alpha", "beta"]) {
+      expect(readFileSync(join(tmpHome, ".hermes", "profiles", profile, "config.yaml"), "utf-8")).toContain(
+        "agentlog hook --source hermes"
+      );
+    }
+    expect(existsSync(join(tmpHome, ".hermes", "config.yaml"))).toBe(false);
+    const config = JSON.parse(readFileSync(join(cfgDir, "config.json"), "utf-8"));
+    expect(config.hermesProfiles).toEqual(["alpha", "beta"]);
+  });
+
+  it("init and uninstall --hermes use HERMES_HOME for named profiles", async () => {
+    const vault = join(tmpHome, "Obsidian");
+    const cfgDir = join(tmpHome, ".agentlog");
+    const hermesHome = join(tmpHome, "custom-hermes");
+    const profileConfig = join(hermesHome, "profiles", "alpha", "config.yaml");
+    mkdirSync(join(vault, ".obsidian"), { recursive: true });
+    mkdirSync(join(hermesHome, "profiles", "alpha"), { recursive: true });
+    writeFileSync(profileConfig, "hooks: {}\n", "utf-8");
+
+    const init = await runCli(["init", "--hermes", "--hermes-profile", "alpha", vault], {
+      HOME: tmpHome,
+      HERMES_HOME: hermesHome,
+      AGENTLOG_CONFIG_DIR: cfgDir,
+    });
+
+    expect(init.exitCode).toBe(0);
+    expect(readFileSync(profileConfig, "utf-8")).toContain("agentlog hook --source hermes");
+    expect(existsSync(join(tmpHome, ".hermes", "profiles", "alpha", "config.yaml"))).toBe(false);
+    expect(JSON.parse(readFileSync(join(cfgDir, "config.json"), "utf-8")).hermesHome).toBe(hermesHome);
+
+    const uninstall = await runCli(["uninstall", "--hermes", "-y"], {
+      HOME: tmpHome,
+      AGENTLOG_CONFIG_DIR: cfgDir,
+    });
+
+    expect(uninstall.exitCode).toBe(0);
+    expect(readFileSync(profileConfig, "utf-8")).not.toContain("agentlog hook --source hermes");
+  });
+
+  it("init --hermes --hermes-all-profiles writes default and every existing profile config", async () => {
+    const vault = join(tmpHome, "Obsidian");
+    const cfgDir = join(tmpHome, ".agentlog");
+    mkdirSync(join(vault, ".obsidian"), { recursive: true });
+    for (const profile of ["alpha", "beta"]) {
+      mkdirSync(join(tmpHome, ".hermes", "profiles", profile), { recursive: true });
+      writeFileSync(join(tmpHome, ".hermes", "profiles", profile, "config.yaml"), "hooks: {}\n", "utf-8");
+    }
+
+    const { exitCode } = await runCli(["init", "--hermes", "--hermes-all-profiles", vault], {
+      HOME: tmpHome,
+      AGENTLOG_CONFIG_DIR: cfgDir,
+    });
+
+    expect(exitCode).toBe(0);
+    for (const path of [
+      join(tmpHome, ".hermes", "config.yaml"),
+      join(tmpHome, ".hermes", "profiles", "alpha", "config.yaml"),
+      join(tmpHome, ".hermes", "profiles", "beta", "config.yaml"),
+    ]) {
+      expect(readFileSync(path, "utf-8")).toContain("agentlog hook --source hermes");
+    }
+    const config = JSON.parse(readFileSync(join(cfgDir, "config.json"), "utf-8"));
+    expect(config.hermesProfiles).toEqual(["default", "alpha", "beta"]);
   });
 
   it("codex-notify writes a Daily Note entry and forwards the saved notify command", async () => {
@@ -434,6 +562,7 @@ describe("cli codex commands", () => {
     expect(content).toContain("## EnglishAsk");
     expect(content).toContain("- score: 3/5");
     expect(readFileSync(evaluator.inputPath, "utf-8")).toContain("User prompt:\nReply with exactly: OK");
+    expect(readFileSync(evaluator.inputPath, "utf-8")).toContain("assistant: OK");
   });
 
   it("codex-notify evaluates the raw prompt to EnglishAsk while logging a pretty prompt", async () => {
@@ -629,6 +758,197 @@ describe("cli codex commands", () => {
     expect(readFileSync(findPlainNotePath(vault), "utf-8")).toContain("Reply with exactly: OK");
   });
 
+  it("agentlog hook --source codex appends EnglishAsk feedback when enabled", async () => {
+    const vault = join(tmpHome, "notes");
+    const cfgDir = join(tmpHome, ".agentlog");
+    const evaluator = makeFakeEnglishAskEvaluator(tmpHome);
+    mkdirSync(vault, { recursive: true });
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(
+      join(cfgDir, "config.json"),
+      JSON.stringify({
+        vault,
+        plain: true,
+        codexHookInstalled: true,
+        englishAsk: {
+          enabled: true,
+          mode: "log-only",
+          evaluatorCommand: evaluator.command,
+        },
+      }),
+      "utf-8"
+    );
+
+    const raw = fixture("codex-hook-user-prompt-submit.json");
+    const proc = Bun.spawn([BUN_BIN, "run", CLI_PATH, "hook", "--source", "codex"], {
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, HOME: tmpHome, AGENTLOG_CONFIG_DIR: cfgDir },
+    });
+    proc.stdin.write(raw);
+    proc.stdin.end();
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    const content = readFileSync(findPlainNotePath(vault), "utf-8");
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe("");
+    expect(stderr).toBe("");
+    expect(content).toContain("Reply with exactly: OK");
+    expect(content).toContain("## EnglishAsk");
+    expect(content).toContain("- session: [[codex_019cb123-ac48-7d22-b5bf-195ee34699af]]");
+    expect(content).toContain("- score: 3/5");
+    expect(readFileSync(evaluator.inputPath, "utf-8")).toContain("User prompt:\nReply with exactly: OK");
+  });
+
+  it("agentlog hook --source hermes writes a Hermes-sourced Daily Note entry", async () => {
+    const vault = join(tmpHome, "notes");
+    const cfgDir = join(tmpHome, ".agentlog");
+    mkdirSync(vault, { recursive: true });
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(
+      join(cfgDir, "config.json"),
+      JSON.stringify({ vault, plain: true, hermesHookInstalled: true }),
+      "utf-8"
+    );
+
+    const raw = fixture("hermes-pre-llm-call.json");
+    const proc = Bun.spawn([BUN_BIN, "run", CLI_PATH, "hook", "--source", "hermes"], {
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, HOME: tmpHome, AGENTLOG_CONFIG_DIR: cfgDir },
+    });
+    proc.stdin.write(raw);
+    proc.stdin.end();
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe("");
+    expect(stderr).toBe("");
+    const content = readFileSync(findPlainNotePath(vault), "utf-8");
+    expect(content).toContain("Hermes prompt capture");
+  });
+
+  it("agentlog hook --source hermes skips non-first pre_llm_call payloads", async () => {
+    const vault = join(tmpHome, "notes");
+    const cfgDir = join(tmpHome, ".agentlog");
+    mkdirSync(vault, { recursive: true });
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(
+      join(cfgDir, "config.json"),
+      JSON.stringify({ vault, plain: true, hermesHookInstalled: true }),
+      "utf-8"
+    );
+
+    const raw = JSON.stringify({
+      hook_event_name: "pre_llm_call",
+      session_id: "hermes-session-123",
+      cwd: "/Users/pray/work/js/agentlog",
+      extra: {
+        user_message: "Hermes prompt capture",
+        is_first_turn: false,
+      },
+    });
+    const proc = Bun.spawn([BUN_BIN, "run", CLI_PATH, "hook", "--source", "hermes"], {
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, HOME: tmpHome, AGENTLOG_CONFIG_DIR: cfgDir },
+    });
+    proc.stdin.write(raw);
+    proc.stdin.end();
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe("");
+    expect(stderr).toBe("");
+    expect(readdirSync(vault).some((name) => /^\d{4}-\d{2}-\d{2}\.md$/.test(name))).toBe(false);
+  });
+
+  it("agentlog hook skips guarded EnglishAsk evaluator child turns", async () => {
+    const vault = join(tmpHome, "notes");
+    const cfgDir = join(tmpHome, ".agentlog");
+    mkdirSync(vault, { recursive: true });
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(
+      join(cfgDir, "config.json"),
+      JSON.stringify({
+        vault,
+        plain: true,
+        codexHookInstalled: true,
+        englishAsk: {
+          enabled: true,
+        },
+      }),
+      "utf-8"
+    );
+
+    const raw = fixture("codex-hook-user-prompt-submit.json");
+    const proc = Bun.spawn([BUN_BIN, "run", CLI_PATH, "hook", "--source", "codex"], {
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        HOME: tmpHome,
+        AGENTLOG_CONFIG_DIR: cfgDir,
+        AGENTLOG_ENGLISHASK_EVAL: "1",
+      },
+    });
+    proc.stdin.write(raw);
+    proc.stdin.end();
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe("");
+    expect(stderr).toBe("");
+    expect(readdirSync(vault).some((name) => /^\d{4}-\d{2}-\d{2}\.md$/.test(name))).toBe(false);
+  });
+
+  it("agentlog hook with unknown explicit source does not fall back to Claude", async () => {
+    const vault = join(tmpHome, "notes");
+    const cfgDir = join(tmpHome, ".agentlog");
+    mkdirSync(vault, { recursive: true });
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(join(cfgDir, "config.json"), JSON.stringify({ vault, plain: true }), "utf-8");
+
+    const proc = Bun.spawn([BUN_BIN, "run", CLI_PATH, "hook", "--source", "bad"], {
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, HOME: tmpHome, AGENTLOG_CONFIG_DIR: cfgDir },
+    });
+    proc.stdin.write(fixture("codex-hook-user-prompt-submit.json"));
+    proc.stdin.end();
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe("");
+    expect(stderr).toContain("Unsupported source: bad");
+    expect(() => findPlainNotePath(vault)).toThrow();
+  });
+
   it("legacy codex-uninstall command is rejected", async () => {
     const vault = join(tmpHome, "notes");
     const cfgDir = join(tmpHome, ".agentlog");
@@ -779,6 +1099,78 @@ describe("cli codex commands", () => {
     expect(existsSync(join(tmpHome, ".codex", "hooks.json"))).toBe(false);
     expect(existsSync(join(tmpHome, ".claude", "settings.json"))).toBe(false);
     expect(existsSync(join(cfgDir, "config.json"))).toBe(false);
+  });
+
+  it("uninstall --all preflights Codex before removing Claude settings", async () => {
+    const vault = join(tmpHome, "notes");
+    const cfgDir = join(tmpHome, ".agentlog");
+    mkdirSync(vault, { recursive: true });
+    mkdirSync(cfgDir, { recursive: true });
+    mkdirSync(join(tmpHome, ".claude"), { recursive: true });
+    mkdirSync(join(tmpHome, ".codex"), { recursive: true });
+    writeFileSync(
+      join(tmpHome, ".claude", "settings.json"),
+      JSON.stringify({
+        hooks: {
+          UserPromptSubmit: [
+            { matcher: "", hooks: [{ type: "command", command: "agentlog hook" }] },
+          ],
+        },
+      }),
+      "utf-8"
+    );
+    writeFileSync(join(tmpHome, ".codex", "hooks.json"), "{bad", "utf-8");
+    writeFileSync(
+      join(cfgDir, "config.json"),
+      JSON.stringify({ vault, plain: true, claudeHookInstalled: true, codexHookInstalled: true }),
+      "utf-8"
+    );
+
+    const { stderr, exitCode } = await runCli(["uninstall", "--all", "-y"], {
+      HOME: tmpHome,
+      AGENTLOG_CONFIG_DIR: cfgDir,
+    });
+
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("hooks.json is invalid JSON");
+    expect(existsSync(join(tmpHome, ".claude", "settings.json"))).toBe(true);
+    expect(existsSync(join(cfgDir, "config.json"))).toBe(true);
+  });
+
+  it("uninstall --hermes removes AgentLog hook from configured Hermes profiles", async () => {
+    const vault = join(tmpHome, "notes");
+    const cfgDir = join(tmpHome, ".agentlog");
+    mkdirSync(vault, { recursive: true });
+    mkdirSync(cfgDir, { recursive: true });
+    for (const profile of ["alpha", "beta"]) {
+      mkdirSync(join(tmpHome, ".hermes", "profiles", profile), { recursive: true });
+      writeFileSync(
+        join(tmpHome, ".hermes", "profiles", profile, "config.yaml"),
+        'hooks:\n  pre_llm_call:\n    - command: echo keep\n    - command: agentlog hook --source hermes\n',
+        "utf-8"
+      );
+    }
+    writeFileSync(
+      join(cfgDir, "config.json"),
+      JSON.stringify({ vault, plain: true, hermesHookInstalled: true, hermesProfiles: ["alpha", "beta"] }),
+      "utf-8"
+    );
+
+    const { stdout, exitCode } = await runCli(["uninstall", "--hermes", "-y"], {
+      HOME: tmpHome,
+      AGENTLOG_CONFIG_DIR: cfgDir,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Hermes hook removed");
+    for (const profile of ["alpha", "beta"]) {
+      const content = readFileSync(join(tmpHome, ".hermes", "profiles", profile, "config.yaml"), "utf-8");
+      expect(content).toContain("command: echo keep");
+      expect(content).not.toContain("agentlog hook --source hermes");
+    }
+    const config = JSON.parse(readFileSync(join(cfgDir, "config.json"), "utf-8"));
+    expect(config.hermesHookInstalled).toBeUndefined();
+    expect(config.hermesProfiles).toBeUndefined();
   });
 
   it("default uninstall warns when Codex hooks need migration", async () => {
@@ -986,5 +1378,114 @@ describe("cli codex commands", () => {
     expect(exitCode).not.toBe(0);
     expect(stdout).toContain("legacy AgentLog Codex hook remains");
     expect(stdout).toContain("agentlog init --codex");
+  });
+
+  it("doctor fails when Hermes metadata expects an installed hook but it is missing", async () => {
+    const vault = join(tmpHome, "notes");
+    const cfgDir = join(tmpHome, ".agentlog");
+    mkdirSync(vault, { recursive: true });
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(
+      join(cfgDir, "config.json"),
+      JSON.stringify({ vault, plain: true, hermesHookInstalled: true }),
+      "utf-8"
+    );
+
+    const { stdout, exitCode } = await runCli(["doctor"], {
+      HOME: tmpHome,
+      AGENTLOG_CONFIG_DIR: cfgDir,
+      HERMES_HOME: join(tmpHome, ".hermes"),
+    });
+
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toContain("❌ hermes");
+    expect(stdout).toContain("hook command not detected");
+  });
+
+  it("doctor passes Hermes when config.yaml contains the manual hook command", async () => {
+    const vault = join(tmpHome, "notes");
+    const cfgDir = join(tmpHome, ".agentlog");
+    const pathWithAgentlog = makeFakeCodexPath(tmpHome);
+    mkdirSync(vault, { recursive: true });
+    mkdirSync(cfgDir, { recursive: true });
+    mkdirSync(join(tmpHome, ".hermes"), { recursive: true });
+    writeFileSync(
+      join(cfgDir, "config.json"),
+      JSON.stringify({ vault, plain: true, hermesHookInstalled: true }),
+      "utf-8"
+    );
+    writeFileSync(
+      join(tmpHome, ".hermes", "config.yaml"),
+      'hooks:\n  pre_llm_call:\n    - command: "agentlog hook --source hermes"\n',
+      "utf-8"
+    );
+
+    const { stdout, exitCode } = await runCli(["doctor"], {
+      HOME: tmpHome,
+      AGENTLOG_CONFIG_DIR: cfgDir,
+      HERMES_HOME: join(tmpHome, ".hermes"),
+      PATH: pathWithAgentlog,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("✅ hermes");
+    expect(stdout).toContain("hook command present");
+  });
+
+  it("runs a real Hermes-profile smoke through init, Hermes hooks list, hook fixture, doctor, and uninstall", async () => {
+    const hermesBin = Bun.which("hermes");
+    if (!hermesBin) return;
+
+    const vault = join(tmpHome, "notes");
+    const cfgDir = join(tmpHome, ".agentlog");
+    const hermesHome = join(tmpHome, ".hermes");
+    const profileHome = join(hermesHome, "profiles", "smoke");
+    mkdirSync(vault, { recursive: true });
+    mkdirSync(cfgDir, { recursive: true });
+    mkdirSync(profileHome, { recursive: true });
+    writeFileSync(join(profileHome, "config.yaml"), "hooks: {}\n", "utf-8");
+
+    const init = await runCli(["init", "--plain", "--hermes", "--hermes-profile", "smoke", vault], {
+      HOME: tmpHome,
+      AGENTLOG_CONFIG_DIR: cfgDir,
+      HERMES_HOME: hermesHome,
+    });
+    expect(init.exitCode).toBe(0);
+
+    const list = Bun.spawnSync([hermesBin, "-p", "smoke", "hooks", "list"], {
+      env: { ...process.env, HOME: tmpHome },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const listOutput = `${list.stdout.toString()}${list.stderr.toString()}`;
+    expect(list.exitCode).toBe(0);
+    expect(listOutput).toContain("agentlog hook --source hermes");
+
+    const proc = Bun.spawn([BUN_BIN, "run", CLI_PATH, "hook", "--source", "hermes"], {
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, HOME: tmpHome, AGENTLOG_CONFIG_DIR: cfgDir },
+    });
+    proc.stdin.write(fixture("hermes-pre-llm-call.json"));
+    proc.stdin.end();
+    expect(await proc.exited).toBe(0);
+    expect(readFileSync(findPlainNotePath(vault), "utf-8")).toContain("Hermes prompt capture");
+
+    const doctor = await runCli(["doctor"], {
+      HOME: tmpHome,
+      AGENTLOG_CONFIG_DIR: cfgDir,
+      HERMES_HOME: hermesHome,
+    });
+    expect(doctor.exitCode).toBe(0);
+    expect(doctor.stdout).toContain("✅ hermes");
+
+    const uninstall = await runCli(["uninstall", "--hermes", "-y"], {
+      HOME: tmpHome,
+      AGENTLOG_CONFIG_DIR: cfgDir,
+      HERMES_HOME: hermesHome,
+    });
+    expect(uninstall.exitCode).toBe(0);
+    expect(readFileSync(join(profileHome, "config.yaml"), "utf-8")).not.toContain("agentlog hook --source hermes");
   });
 });

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from "fs";
+import { chmodSync, mkdirSync, writeFileSync, readFileSync, readdirSync, rmSync, existsSync } from "fs";
 import { join } from "path";
 import { homedir, tmpdir } from "os";
 import { fileURLToPath } from "url";
@@ -44,6 +44,30 @@ function makeTmpHome(): string {
   const dir = join(tmpdir(), `agentlog-home-${Date.now()}-${Math.random().toString(36).slice(2)}`);
   mkdirSync(dir, { recursive: true });
   return dir;
+}
+
+function makeFakeEnglishAskEvaluator(home: string): { command: string[]; inputPath: string } {
+  const script = join(home, "englishask-eval.sh");
+  const inputPath = join(home, "englishask-input.txt");
+  writeFileSync(
+    script,
+    `#!/bin/sh
+test "$AGENTLOG_ENGLISHASK_EVAL" = "1" || exit 7
+cat > "$1"
+printf 'Score: 3/5\\nNatural version: Explain current status.\\nMissing context: none\\nRewrite with: exact provider/result\\n'
+`,
+    "utf-8"
+  );
+  chmodSync(script, 0o755);
+  return { command: [script, inputPath], inputPath };
+}
+
+function findPlainNotePath(vault: string): string {
+  const file = readdirSync(vault).find((name) => /^\d{4}-\d{2}-\d{2}\.md$/.test(name));
+  if (!file) {
+    throw new Error(`No plain note found in ${vault}`);
+  }
+  return join(vault, file);
 }
 
 describe("cli init command", () => {
@@ -371,6 +395,25 @@ describe("cli doctor command", () => {
   });
 });
 
+describe("cli backfill command", () => {
+  let tmpHome: string;
+
+  beforeEach(() => {
+    tmpHome = makeTmpHome();
+  });
+
+  afterEach(() => {
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("rejects Hermes as a backfill source until Hermes transcript backfill exists", async () => {
+    const { stderr, exitCode } = await runCli(["backfill", "--source", "hermes", "--dry-run"], { HOME: tmpHome });
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Error: --source must be one of: all, claude, codex");
+  });
+});
+
 describe("cli codex-debug command", () => {
   let tmpHome: string;
 
@@ -512,6 +555,20 @@ describe("cli init --dry-run", () => {
     expect(stdout).toContain("[dry-run]");
     expect(stdout).toContain("No changes were made");
   });
+
+  it("prints targeted Hermes profile config paths in init dry-run", async () => {
+    const vault = join(tmpHome, "Obsidian");
+    mkdirSync(join(vault, ".obsidian"), { recursive: true });
+
+    const { stdout, exitCode } = await runCli(
+      ["init", "--hermes", "--hermes-profile", "alpha", "--dry-run", vault],
+      { HOME: tmpHome }
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Would write Hermes hook config:");
+    expect(stdout).toContain(`alpha:${join(tmpHome, ".hermes", "profiles", "alpha", "config.yaml")}`);
+  });
 });
 
 describe("cli uninstall --dry-run", () => {
@@ -553,6 +610,109 @@ describe("cli uninstall --dry-run", () => {
     expect(existsSync(join(tmpHome, ".claude", "settings.json"))).toBe(true);
     const settings = JSON.parse(readFileSync(join(tmpHome, ".claude", "settings.json"), "utf-8"));
     expect(settings.hooks).toBeDefined();
+  });
+
+  it("prints targeted Hermes profile config paths in uninstall dry-run", async () => {
+    const { stdout, exitCode } = await runCli(
+      ["uninstall", "--hermes", "--hermes-profile", "alpha", "--dry-run"],
+      { HOME: tmpHome }
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Would remove Hermes hook config from:");
+    expect(stdout).toContain(`alpha:${join(tmpHome, ".hermes", "profiles", "alpha", "config.yaml")}`);
+  });
+
+  it("rejects Hermes profile options with uninstall --all", async () => {
+    const { stderr, exitCode } = await runCli(
+      ["uninstall", "--all", "--hermes-profile", "alpha", "--dry-run"],
+      { HOME: tmpHome }
+    );
+
+    expect(exitCode).not.toBe(0);
+    expect(stderr).toContain("Hermes profile options require --hermes");
+  });
+});
+
+describe("hook command", () => {
+  let tmpHome: string;
+
+  beforeEach(() => {
+    tmpHome = makeTmpHome();
+  });
+
+  afterEach(() => {
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("appends EnglishAsk feedback for the default Claude source when enabled", async () => {
+    const vault = join(tmpHome, "notes");
+    const cfgDir = join(tmpHome, ".agentlog");
+    const evaluator = makeFakeEnglishAskEvaluator(tmpHome);
+    const transcriptPath = join(tmpHome, "claude-transcript.jsonl");
+    mkdirSync(vault, { recursive: true });
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(
+      transcriptPath,
+      [
+        JSON.stringify({
+          type: "user",
+          message: { role: "user", content: "Enable EnglishAsk everywhere" },
+        }),
+        JSON.stringify({
+          type: "assistant",
+          message: { role: "assistant", content: [{ type: "text", text: "EnglishAsk runs on hook path now" }] },
+        }),
+      ].join("\n"),
+      "utf-8"
+    );
+    writeFileSync(
+      join(cfgDir, "config.json"),
+      JSON.stringify({
+        vault,
+        plain: true,
+        claudeHookInstalled: true,
+        englishAsk: {
+          enabled: true,
+          mode: "log-only",
+          evaluatorCommand: evaluator.command,
+        },
+      }),
+      "utf-8"
+    );
+
+    const raw = JSON.stringify({
+      hook_event_name: "UserPromptSubmit",
+      session_id: "claude-english-session",
+      cwd: "/Users/pray/work/js/agentlog",
+      transcript_path: transcriptPath,
+      prompt: "Explain current EnglishAsk status",
+    });
+    const proc = Bun.spawn(["bun", "run", CLI_PATH, "hook"], {
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, HOME: tmpHome, AGENTLOG_CONFIG_DIR: cfgDir },
+    });
+    proc.stdin.write(raw);
+    proc.stdin.end();
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    const content = readFileSync(findPlainNotePath(vault), "utf-8");
+    expect(exitCode).toBe(0);
+    expect(stdout).toBe("");
+    expect(stderr).toBe("");
+    expect(content).toContain("Explain current EnglishAsk status");
+    expect(content).toContain("## EnglishAsk");
+    expect(content).toContain("- session: [[claude_claude-english-session]]");
+    expect(content).toContain("- score: 3/5");
+    expect(readFileSync(evaluator.inputPath, "utf-8")).toContain("User prompt:\nExplain current EnglishAsk status");
+    expect(readFileSync(evaluator.inputPath, "utf-8")).toContain("user: Enable EnglishAsk everywhere");
+    expect(readFileSync(evaluator.inputPath, "utf-8")).toContain("assistant: EnglishAsk runs on hook path now");
   });
 });
 

--- a/src/__tests__/codex-hooks.test.ts
+++ b/src/__tests__/codex-hooks.test.ts
@@ -109,6 +109,21 @@ describe("codex hook config", () => {
     });
   });
 
+  it("detects the current AgentLog hook even when legacy hooks need migration", () => {
+    const hooksJson = JSON.stringify({
+      hooks: {
+        UserPromptSubmit: [
+          { hooks: [{ type: "command", command: "agentlog hook" }] },
+          { hooks: [{ type: "command", command: "agentlog hook --source codex" }] },
+        ],
+      },
+    });
+
+    expect(inspectCodexHookState(hooksJson).kind).toBe("needs_migration");
+    expect(hasAgentlogCodexHook(hooksJson)).toBe(true);
+    expect(hasAgentlogCodexHook("{bad")).toBe(false);
+  });
+
   it("removes only the AgentLog Codex hook", () => {
     const installed = installCodexHook(JSON.stringify({
       hooks: {

--- a/src/__tests__/codex-hooks.test.ts
+++ b/src/__tests__/codex-hooks.test.ts
@@ -48,6 +48,67 @@ describe("codex hook config", () => {
     expect(hasAgentlogCodexHook(second.json)).toBe(true);
   });
 
+  it("migrates legacy AgentLog Codex hooks while preserving Codex trusted state", () => {
+    const existing = JSON.stringify({
+      hooks: {
+        SessionStart: [
+          { hooks: [{ type: "command", command: "node /opt/omx/codex-native-hook.js" }] },
+        ],
+        UserPromptSubmit: [
+          { hooks: [{ type: "command", command: "agentlog hook" }] },
+          { hooks: [{ type: "command", command: "node /opt/omx/codex-native-hook.js" }] },
+        ],
+      },
+      state: {
+        "/Users/me/.codex/hooks.json:user_prompt_submit:0:0": {
+          trusted_hash: "sha256:old-user-prompt-submit",
+        },
+        "/Users/me/.codex/hooks.json:stop:0:0": {
+          trusted_hash: "sha256:stop",
+        },
+      },
+    });
+
+    const first = installCodexHook(existing);
+    const second = installCodexHook(first.json);
+    const parsed = JSON.parse(second.json);
+
+    expect(first.changed).toBe(true);
+    expect(second.changed).toBe(false);
+    expect(parsed.state).toEqual({
+      "/Users/me/.codex/hooks.json:stop:0:0": {
+        trusted_hash: "sha256:stop",
+      },
+    });
+    expect(parsed.hooks.SessionStart).toHaveLength(1);
+    expect(parsed.hooks.UserPromptSubmit).toEqual([
+      { hooks: [{ type: "command", command: "node /opt/omx/codex-native-hook.js" }] },
+      { hooks: [{ type: "command", command: "agentlog hook --source codex" }] },
+    ]);
+  });
+
+  it("reports legacy AgentLog Codex hooks as needing migration", () => {
+    expect(inspectCodexHookState(JSON.stringify({
+      hooks: {
+        UserPromptSubmit: [{ hooks: [{ type: "command", command: "agentlog hook" }] }],
+      },
+    }))).toEqual({
+      kind: "needs_migration",
+      reason: "legacy AgentLog Codex hook must be migrated to --source codex",
+    });
+    expect(inspectCodexHookState(JSON.stringify({
+      hooks: {
+        UserPromptSubmit: [
+          { hooks: [{ type: "command", command: "agentlog hook" }] },
+          { hooks: [{ type: "command", command: "agentlog hook --source codex" }] },
+        ],
+      },
+    }))).toEqual({
+      kind: "needs_migration",
+      reason: "legacy AgentLog Codex hook remains beside the current hook",
+    });
+  });
+
   it("removes only the AgentLog Codex hook", () => {
     const installed = installCodexHook(JSON.stringify({
       hooks: {
@@ -87,6 +148,48 @@ describe("codex hook config", () => {
     expect(parsed.hooks.UserPromptSubmit).toEqual([
       { hooks: [{ type: "command", command: "echo keep-me" }] },
     ]);
+  });
+
+  it("preserves Codex trusted state while removing AgentLog Codex handlers", () => {
+    const installed = JSON.stringify({
+      hooks: {
+        UserPromptSubmit: [
+          {
+            hooks: [
+              { type: "command", command: "agentlog hook" },
+              { type: "command", command: "agentlog hook --source codex" },
+              { type: "command", command: "node /opt/omx/codex-native-hook.js" },
+            ],
+          },
+        ],
+      },
+      state: {
+        "/Users/me/.codex/hooks.json:user_prompt_submit:0:0": {
+          trusted_hash: "sha256:old-user-prompt-submit",
+        },
+        "/Users/me/.codex/hooks.json:stop:0:0": {
+          trusted_hash: "sha256:stop",
+        },
+      },
+    });
+
+    const removed = uninstallCodexHook(installed);
+    const parsed = JSON.parse(removed.json);
+
+    expect(removed.changed).toBe(true);
+    expect(hasAgentlogCodexHook(removed.json)).toBe(false);
+    expect(parsed).toEqual({
+      hooks: {
+        UserPromptSubmit: [
+          { hooks: [{ type: "command", command: "node /opt/omx/codex-native-hook.js" }] },
+        ],
+      },
+      state: {
+        "/Users/me/.codex/hooks.json:stop:0:0": {
+          trusted_hash: "sha256:stop",
+        },
+      },
+    });
   });
 
   it("removes hooks.json when AgentLog was the only hook", () => {

--- a/src/__tests__/codex-notify-input.test.ts
+++ b/src/__tests__/codex-notify-input.test.ts
@@ -15,6 +15,7 @@ describe("parseCodexNotifyInput", () => {
       sessionId: "019cb123-ac48-7d22-b5bf-195ee34699af",
       cwd: "/Users/pray/Obsidian",
       prompt: "Reply with exactly: OK",
+      lastAssistantMessage: "OK",
     });
   });
 

--- a/src/__tests__/daily-note.test.ts
+++ b/src/__tests__/daily-note.test.ts
@@ -87,6 +87,10 @@ describe("buildSessionDivider", () => {
     );
   });
 
+  it("returns divider with hermes prefix when source is hermes", () => {
+    expect(buildSessionDivider("sess_abc", "hermes")).toBe("- - - - [[hermes_sess_abc]]");
+  });
+
   it("uses full sessionId when shorter than 8 chars", () => {
     expect(buildSessionDivider("abc", "claude")).toBe("- - - - [[claude_abc]]");
   });

--- a/src/__tests__/english-ask.test.ts
+++ b/src/__tests__/english-ask.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "os";
 import {
   ENGLISHASK_GUARD_ENV,
   appendEnglishAskFeedback,
+  buildEnglishAskContext,
   englishAskSuggestion,
   evaluateEnglishAsk,
   shouldEvaluateEnglishAsk,
@@ -81,6 +82,59 @@ describe("EnglishAsk", () => {
     expect(readFileSync(inputPath, "utf-8")).toContain("User prompt:\nWhat should I do next?");
   });
 
+  it("uses a low-overhead Codex exec command by default", () => {
+    const binDir = join(tmp, "bin");
+    const argsPath = join(tmp, "codex-args.txt");
+    const envPath = join(tmp, "codex-env.txt");
+    mkdirSync(binDir, { recursive: true });
+    writeFileSync(
+      join(binDir, "codex"),
+      `#!/bin/sh
+printf '%s\\n' "$@" > "${argsPath}"
+printf '%s\\n' "$${ENGLISHASK_GUARD_ENV}" > "${envPath}"
+cat >/dev/null
+printf 'Score: 5/5\\nNatural version: ok\\nMissing context: none\\nRewrite with: none\\n'
+`,
+      "utf-8"
+    );
+    chmodSync(join(binDir, "codex"), 0o755);
+    const oldPath = process.env.PATH;
+    process.env.PATH = `${binDir}:${oldPath ?? ""}`;
+
+    try {
+      const result = evaluateEnglishAsk(
+        { vault: tmp, englishAsk: { enabled: true } },
+        "What should I do next?",
+        tmp
+      );
+
+      expect(result?.score).toBe(5);
+      expect(readFileSync(argsPath, "utf-8")).toBe("exec\n--ignore-user-config\n--ephemeral\n-\n");
+      expect(readFileSync(envPath, "utf-8")).toBe("1\n");
+    } finally {
+      process.env.PATH = oldPath;
+    }
+  });
+
+  it("includes bounded prior context in evaluator input", () => {
+    const { command, inputPath } = fakeEvaluator(
+      "Score: 4/5\nNatural version: yes\nMissing context: none\nRewrite with: none"
+    );
+
+    const result = evaluateEnglishAsk(
+      { vault: tmp, englishAsk: { enabled: true, evaluatorCommand: command } },
+      "what about this session?",
+      tmp,
+      "10:01 Please inspect EnglishAsk\n10:02 Turn it on for hook providers"
+    );
+
+    const input = readFileSync(inputPath, "utf-8");
+    expect(result?.score).toBe(4);
+    expect(input).toContain("Prior user/model context:\n10:01 Please inspect EnglishAsk");
+    expect(input).toContain("10:02 Turn it on for hook providers");
+    expect(input).toContain("User prompt:\nwhat about this session?");
+  });
+
   it("returns null when evaluator fails", () => {
     const script = join(tmp, "fail-englishask.sh");
     writeFileSync(script, "#!/bin/sh\nexit 42\n", "utf-8");
@@ -142,6 +196,132 @@ describe("EnglishAsk", () => {
     expect(result?.prompt).toContain("[redacted-api-key]");
     expect(result?.prompt).toContain("[truncated]");
     expect(readFileSync(inputPath, "utf-8")).not.toContain("sk-abcdefghijklmnopqrstuvwxyz");
+  });
+
+  it("builds context from the matching source session section", () => {
+    const filePath = join(tmp, "2026-03-02.md");
+    writeFileSync(
+      filePath,
+      [
+        "## AgentLog",
+        "#### 10:00 · js/agentlog",
+        "<!-- cwd=/Users/pray/work/js/agentlog -->",
+        "- - - - [[codex_session-a]]",
+        "- 10:00 Start EnglishAsk work",
+        "- 10:01 Add hook support",
+        "- - - - [[claude_session-a]]",
+        "- 10:02 Different provider should not leak",
+        "#### 10:03 · other/project",
+        "- 10:03 Other prompt",
+        "",
+      ].join("\n"),
+      "utf-8"
+    );
+
+    const context = buildEnglishAskContext(filePath, {
+      source: "codex",
+      sessionId: "session-a",
+    });
+
+    expect(context).toBe("10:00 Start EnglishAsk work\n10:01 Add hook support");
+  });
+
+  it("does not fall back to unrelated Daily Note prompts when session context is missing", () => {
+    const filePath = join(tmp, "2026-03-02.md");
+    writeFileSync(
+      filePath,
+      [
+        "## AgentLog",
+        "#### 10:00 · js/agentlog",
+        "<!-- cwd=/Users/pray/work/js/agentlog -->",
+        "- - - - [[codex_session-a]]",
+        "- 10:00 Start EnglishAsk work",
+        "#### 10:03 · other/project",
+        "- 10:03 Other prompt",
+        "",
+      ].join("\n"),
+      "utf-8"
+    );
+
+    const context = buildEnglishAskContext(filePath, {
+      source: "codex",
+      sessionId: "missing-session",
+    });
+
+    expect(context).toBeNull();
+  });
+
+  it("prefers transcript user and assistant turns over Daily Note prompt-only context", () => {
+    const notePath = join(tmp, "2026-03-02.md");
+    const transcriptPath = join(tmp, "transcript.jsonl");
+    writeFileSync(
+      notePath,
+      [
+        "## AgentLog",
+        "#### 10:00 · js/agentlog",
+        "<!-- cwd=/Users/pray/work/js/agentlog -->",
+        "- - - - [[codex_session-a]]",
+        "- 10:00 Daily note prompt only",
+        "",
+      ].join("\n"),
+      "utf-8"
+    );
+    writeFileSync(
+      transcriptPath,
+      [
+        JSON.stringify({
+          type: "event_msg",
+          payload: { type: "user_message", message: "Turn on EnglishAsk for hooks" },
+        }),
+        JSON.stringify({
+          type: "event_msg",
+          payload: { type: "agent_message", message: "EnglishAsk now runs from hook.ts" },
+        }),
+        JSON.stringify({
+          type: "event_msg",
+          payload: { type: "user_message", message: "What about followups?" },
+        }),
+      ].join("\n"),
+      "utf-8"
+    );
+
+    const context = buildEnglishAskContext(notePath, {
+      source: "codex",
+      sessionId: "session-a",
+      transcriptPath,
+    });
+
+    expect(context).toContain("user: Turn on EnglishAsk for hooks");
+    expect(context).toContain("assistant: EnglishAsk now runs from hook.ts");
+    expect(context).toContain("user: What about followups?");
+    expect(context).not.toContain("Daily note prompt only");
+  });
+
+  it("keeps transcript context bounded to recent turns", () => {
+    const notePath = join(tmp, "2026-03-02.md");
+    const transcriptPath = join(tmp, "large-transcript.jsonl");
+    writeFileSync(notePath, "## AgentLog\n- 10:00 fallback\n", "utf-8");
+    writeFileSync(
+      transcriptPath,
+      Array.from({ length: 20 }, (_, index) =>
+        JSON.stringify({
+          type: "event_msg",
+          payload: { type: "user_message", message: `turn-${index}` },
+        })
+      ).join("\n"),
+      "utf-8"
+    );
+
+    const context = buildEnglishAskContext(notePath, {
+      source: "codex",
+      sessionId: "session-a",
+      transcriptPath,
+    });
+
+    expect(context).not.toContain("turn-0");
+    expect(context).not.toContain("turn-7");
+    expect(context).toContain("turn-8");
+    expect(context).toContain("turn-19");
   });
 
   it("appends feedback to an EnglishAsk Daily Note section", () => {

--- a/src/__tests__/fixtures/hermes-pre-llm-call.json
+++ b/src/__tests__/fixtures/hermes-pre-llm-call.json
@@ -1,0 +1,14 @@
+{
+  "hook_event_name": "pre_llm_call",
+  "tool_name": null,
+  "tool_input": null,
+  "session_id": "hermes-session-123",
+  "cwd": "/Users/pray/work/js/agentlog",
+  "extra": {
+    "user_message": "Hermes prompt capture",
+    "conversation_history": [],
+    "is_first_turn": true,
+    "model": "nous/hermes",
+    "platform": "cli"
+  }
+}

--- a/src/__tests__/hermes-config.test.ts
+++ b/src/__tests__/hermes-config.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { existsSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  AGENTLOG_HERMES_HOOK_COMMAND,
+  readHermesHookState,
+  registerHermesHook,
+  resolveHermesConfigTargets,
+  unregisterHermesHook,
+} from "../hermes-config.js";
+
+let tmpHome: string;
+
+function makeTmpHome(): string {
+  const dir = join(tmpdir(), `agentlog-hermes-config-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function read(path: string): string {
+  return readFileSync(path, "utf-8");
+}
+
+describe("Hermes config automation", () => {
+  beforeEach(() => {
+    tmpHome = makeTmpHome();
+  });
+
+  afterEach(() => {
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("registers the AgentLog pre_llm_call hook in default config.yaml while preserving unrelated config", () => {
+    const hermesDir = join(tmpHome, ".hermes");
+    mkdirSync(hermesDir, { recursive: true });
+    writeFileSync(join(hermesDir, "config.yaml"), "model:\n  provider: openai\nhooks: {}\n", "utf-8");
+
+    const result = registerHermesHook({ homeDir: tmpHome });
+
+    expect(result.changed).toBe(true);
+    expect(result.targets).toEqual([{ profile: "default", path: join(hermesDir, "config.yaml"), changed: true }]);
+    const content = read(join(hermesDir, "config.yaml"));
+    expect(content).toContain("provider: openai");
+    expect(content).toContain("pre_llm_call:");
+    expect(content).toContain(`command: ${AGENTLOG_HERMES_HOOK_COMMAND}`);
+  });
+
+  it("is idempotent and preserves other pre_llm_call hook commands", () => {
+    const configPath = join(tmpHome, ".hermes", "config.yaml");
+    mkdirSync(join(tmpHome, ".hermes"), { recursive: true });
+    writeFileSync(
+      configPath,
+      [
+        "hooks:",
+        "  pre_llm_call:",
+        "    - command: echo keep",
+        `    - command: ${AGENTLOG_HERMES_HOOK_COMMAND}`,
+        "",
+      ].join("\n"),
+      "utf-8"
+    );
+
+    const result = registerHermesHook({ homeDir: tmpHome });
+
+    expect(result.changed).toBe(false);
+    expect(read(configPath).match(new RegExp(AGENTLOG_HERMES_HOOK_COMMAND, "g"))).toHaveLength(1);
+    expect(read(configPath)).toContain("command: echo keep");
+  });
+
+  it("replaces older bare AgentLog hook command with the requested executable path", () => {
+    const configPath = join(tmpHome, ".hermes", "config.yaml");
+    mkdirSync(join(tmpHome, ".hermes"), { recursive: true });
+    writeFileSync(
+      configPath,
+      'hooks:\n  pre_llm_call:\n    - command: "agentlog hook --source hermes"\n    - command: echo keep\n',
+      "utf-8"
+    );
+
+    const command = "/Users/pray/.bun/bin/agentlog hook --source hermes";
+    const result = registerHermesHook({ homeDir: tmpHome, command });
+
+    expect(result.changed).toBe(true);
+    const content = read(configPath);
+    expect(content).toContain(command);
+    expect(content).not.toContain('command: agentlog hook --source hermes\n');
+    expect(content).toContain("echo keep");
+    expect(content.match(/hook --source hermes/g)).toHaveLength(1);
+  });
+
+  it("supports default plus multiple named Hermes profiles", () => {
+    mkdirSync(join(tmpHome, ".hermes", "profiles", "alpha"), { recursive: true });
+    mkdirSync(join(tmpHome, ".hermes", "profiles", "beta"), { recursive: true });
+    writeFileSync(join(tmpHome, ".hermes", "profiles", "alpha", "config.yaml"), "hooks: {}\n", "utf-8");
+    writeFileSync(join(tmpHome, ".hermes", "profiles", "beta", "config.yaml"), "display:\n  theme: dark\n", "utf-8");
+
+    const targets = resolveHermesConfigTargets({ homeDir: tmpHome, profiles: ["default", "alpha", "beta"] });
+    const result = registerHermesHook({ homeDir: tmpHome, profiles: ["default", "alpha", "beta"] });
+
+    expect(targets.map((target) => target.profile)).toEqual(["default", "alpha", "beta"]);
+    expect(result.changed).toBe(true);
+    for (const target of targets) {
+      expect(read(target.path)).toContain(AGENTLOG_HERMES_HOOK_COMMAND);
+    }
+    expect(read(join(tmpHome, ".hermes", "profiles", "beta", "config.yaml"))).toContain("theme: dark");
+  });
+
+  it("resolves selected profiles under HERMES_HOME when provided", () => {
+    const hermesHome = join(tmpHome, "custom-hermes");
+    mkdirSync(join(hermesHome, "profiles", "alpha"), { recursive: true });
+    writeFileSync(join(hermesHome, "profiles", "alpha", "config.yaml"), "hooks: {}\n", "utf-8");
+
+    const targets = resolveHermesConfigTargets({
+      homeDir: tmpHome,
+      hermesHome,
+      profiles: ["default", "alpha"],
+    });
+
+    expect(targets).toEqual([
+      { profile: "default", path: join(hermesHome, "config.yaml") },
+      { profile: "alpha", path: join(hermesHome, "profiles", "alpha", "config.yaml") },
+    ]);
+  });
+
+  it("expands allProfiles to every existing named profile plus default", () => {
+    mkdirSync(join(tmpHome, ".hermes", "profiles", "alpha"), { recursive: true });
+    mkdirSync(join(tmpHome, ".hermes", "profiles", "beta"), { recursive: true });
+    mkdirSync(join(tmpHome, ".hermes", "profiles", "not-a-profile"), { recursive: true });
+    writeFileSync(join(tmpHome, ".hermes", "profiles", "alpha", "config.yaml"), "hooks: {}\n", "utf-8");
+    writeFileSync(join(tmpHome, ".hermes", "profiles", "beta", "config.yaml"), "hooks: {}\n", "utf-8");
+
+    const targets = resolveHermesConfigTargets({ homeDir: tmpHome, allProfiles: true });
+
+    expect(targets.map((target) => target.profile)).toEqual(["default", "alpha", "beta"]);
+  });
+
+  it("skips dangling profile links when expanding allProfiles", () => {
+    const profilesRoot = join(tmpHome, ".hermes", "profiles");
+    mkdirSync(join(profilesRoot, "alpha"), { recursive: true });
+    writeFileSync(join(profilesRoot, "alpha", "config.yaml"), "hooks: {}\n", "utf-8");
+    symlinkSync(join(profilesRoot, "missing"), join(profilesRoot, "broken"));
+
+    const targets = resolveHermesConfigTargets({ homeDir: tmpHome, allProfiles: true });
+
+    expect(targets.map((target) => target.profile)).toEqual(["default", "alpha"]);
+  });
+
+  it("unregisters only the AgentLog hook from selected profiles", () => {
+    const configPath = join(tmpHome, ".hermes", "config.yaml");
+    mkdirSync(join(tmpHome, ".hermes"), { recursive: true });
+    writeFileSync(
+      configPath,
+      [
+        "hooks:",
+        "  pre_llm_call:",
+        "    - command: echo keep",
+        `    - command: ${AGENTLOG_HERMES_HOOK_COMMAND}`,
+        "",
+      ].join("\n"),
+      "utf-8"
+    );
+
+    const result = unregisterHermesHook({ homeDir: tmpHome });
+
+    expect(result.changed).toBe(true);
+    expect(read(configPath)).toContain("command: echo keep");
+    expect(read(configPath)).not.toContain(AGENTLOG_HERMES_HOOK_COMMAND);
+  });
+
+  it("preserves user comments when mutating Hermes config YAML", () => {
+    const configPath = join(tmpHome, ".hermes", "config.yaml");
+    mkdirSync(join(tmpHome, ".hermes"), { recursive: true });
+    writeFileSync(
+      configPath,
+      "# keep top comment\nmodel:\n  provider: openai # keep inline comment\nhooks:\n  pre_llm_call:\n    - command: echo keep\n",
+      "utf-8"
+    );
+
+    registerHermesHook({ homeDir: tmpHome });
+
+    const content = read(configPath);
+    expect(content).toContain("# keep top comment");
+    expect(content).toContain("provider: openai # keep inline comment");
+    expect(content).toContain("command: echo keep");
+    expect(content).toContain(AGENTLOG_HERMES_HOOK_COMMAND);
+  });
+
+  it("replaces stale quoted AgentLog hook commands", () => {
+    const configPath = join(tmpHome, ".hermes", "config.yaml");
+    mkdirSync(join(tmpHome, ".hermes"), { recursive: true });
+    writeFileSync(
+      configPath,
+      "hooks:\n  pre_llm_call:\n    - command: \"'/Applications/Agent Log/bin/agentlog' hook --source hermes\"\n",
+      "utf-8"
+    );
+
+    const command = "/Users/pray/.bun/bin/agentlog hook --source hermes";
+    const result = registerHermesHook({ homeDir: tmpHome, command });
+
+    expect(result.changed).toBe(true);
+    const content = read(configPath);
+    expect(content).toContain(command);
+    expect(content).not.toContain("Applications/Agent Log");
+    expect(content.match(/hook --source hermes/g)).toHaveLength(1);
+  });
+
+  it("reports missing and partial profile state", () => {
+    mkdirSync(join(tmpHome, ".hermes", "profiles", "alpha"), { recursive: true });
+    writeFileSync(join(tmpHome, ".hermes", "profiles", "alpha", "config.yaml"), "hooks: {}\n", "utf-8");
+    registerHermesHook({ homeDir: tmpHome, profiles: ["default"] });
+
+    const state = readHermesHookState({ homeDir: tmpHome, profiles: ["default", "alpha"] });
+
+    expect(state.kind).toBe("partial");
+    if (state.kind === "partial") {
+      expect(state.registered.map((target) => target.profile)).toEqual(["default"]);
+      expect(state.missing.map((target) => target.profile)).toEqual(["alpha"]);
+    }
+  });
+
+  it("rejects invalid YAML without modifying the file", () => {
+    const configPath = join(tmpHome, ".hermes", "config.yaml");
+    mkdirSync(join(tmpHome, ".hermes"), { recursive: true });
+    writeFileSync(configPath, "hooks: [\n", "utf-8");
+
+    expect(() => registerHermesHook({ homeDir: tmpHome })).toThrow("Unsupported Hermes config");
+    expect(read(configPath)).toBe("hooks: [\n");
+    expect(existsSync(configPath)).toBe(true);
+  });
+});

--- a/src/__tests__/hook-input.test.ts
+++ b/src/__tests__/hook-input.test.ts
@@ -118,6 +118,7 @@ describe("parseHookInput", () => {
       sessionId: "019cb123-ac48-7d22-b5bf-195ee34699af",
       cwd: "/Users/pray/opensource/agentlog",
       prompt: "Reply with exactly: OK",
+      transcriptPath: "/Users/pray/.codex/sessions/example.jsonl",
     });
   });
 
@@ -143,5 +144,60 @@ describe("parseHookInput", () => {
     });
 
     expect(() => parseHookInput(input)).toThrow("UserPromptSubmit");
+  });
+
+  it("parses a Hermes pre_llm_call shell-hook payload", () => {
+    const result = parseHookInput(fixture("hermes-pre-llm-call.json"), { source: "hermes" });
+
+    expect(result).toEqual({
+      sessionId: "hermes-session-123",
+      cwd: "/Users/pray/work/js/agentlog",
+      prompt: "Hermes prompt capture",
+    });
+  });
+
+  it("marks non-first Hermes pre_llm_call payloads as skipped", () => {
+    const result = parseHookInput(
+      JSON.stringify({
+        hook_event_name: "pre_llm_call",
+        session_id: "hermes-session-123",
+        cwd: "/some/dir",
+        extra: {
+          user_message: "Hermes prompt capture",
+          is_first_turn: false,
+        },
+      }),
+      { source: "hermes" }
+    );
+
+    expect(result).toEqual({
+      sessionId: "hermes-session-123",
+      cwd: "/some/dir",
+      prompt: "Hermes prompt capture",
+      shouldLog: false,
+    });
+  });
+
+  it("requires extra.user_message for Hermes pre_llm_call payloads", () => {
+    const input = JSON.stringify({
+      hook_event_name: "pre_llm_call",
+      session_id: "hermes-session-123",
+      cwd: "/some/dir",
+      prompt: "top-level prompt must not satisfy Hermes",
+      extra: {},
+    });
+
+    expect(() => parseHookInput(input, { source: "hermes" })).toThrow("extra.user_message");
+  });
+
+  it("requires pre_llm_call for Hermes source", () => {
+    const input = JSON.stringify({
+      hook_event_name: "UserPromptSubmit",
+      session_id: "hermes-session-123",
+      cwd: "/some/dir",
+      extra: { user_message: "hello" },
+    });
+
+    expect(() => parseHookInput(input, { source: "hermes" })).toThrow("pre_llm_call");
   });
 });

--- a/src/__tests__/hook-providers.test.ts
+++ b/src/__tests__/hook-providers.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  hookProviders,
+  providersForInitTarget,
+  providersForUninstallTarget,
+} from "../hook-providers/index.js";
+
+let tmpHome: string;
+
+function makeTmpHome(): string {
+  const dir = join(tmpdir(), `agentlog-hook-providers-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+describe("hook provider registry", () => {
+  beforeEach(() => {
+    tmpHome = makeTmpHome();
+  });
+
+  afterEach(() => {
+    rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("maps init targets to providers while preserving --all as Claude plus Codex", () => {
+    expect(providersForInitTarget("claude")).toEqual(["claude"]);
+    expect(providersForInitTarget("codex")).toEqual(["codex"]);
+    expect(providersForInitTarget("hermes")).toEqual(["hermes"]);
+    expect(providersForInitTarget("all")).toEqual(["claude", "codex"]);
+  });
+
+  it("maps uninstall --all to every provider metadata surface", () => {
+    expect(providersForUninstallTarget("all")).toEqual(["claude", "codex", "hermes"]);
+  });
+
+  it("declares canonical hook commands for all supported providers", () => {
+    expect(hookProviders.claude.command).toBe("agentlog hook");
+    expect(hookProviders.codex.command).toBe("agentlog hook --source codex");
+    expect(hookProviders.hermes.command).toBe("agentlog hook --source hermes");
+  });
+
+  it("runs Hermes install, inspect, and uninstall through the provider lifecycle", () => {
+    const profileHome = join(tmpHome, ".hermes", "profiles", "alpha");
+    mkdirSync(profileHome, { recursive: true });
+    writeFileSync(join(profileHome, "config.yaml"), "hooks: {}\n", "utf-8");
+
+    const install = hookProviders.hermes.install({
+      vault: join(tmpHome, "notes"),
+      plain: true,
+      hermesProfiles: ["alpha"],
+      homeDir: tmpHome,
+    });
+    expect(install.changed).toBe(true);
+    expect(install.configPatch).toEqual({ hermesHookInstalled: true, hermesProfiles: ["alpha"] });
+    expect(readFileSync(join(profileHome, "config.yaml"), "utf-8")).toContain("agentlog hook --source hermes");
+
+    const state = hookProviders.hermes.inspect({ hermesProfiles: ["alpha"], homeDir: tmpHome });
+    expect(state.kind).toBe("registered");
+
+    const uninstall = hookProviders.hermes.uninstall({ hermesProfiles: ["alpha"], homeDir: tmpHome });
+    expect(uninstall.changed).toBe(true);
+    expect(uninstall.configPatch).toEqual({
+      hermesHookInstalled: undefined,
+      hermesHome: undefined,
+      hermesProfiles: undefined,
+    });
+    expect(readFileSync(join(profileHome, "config.yaml"), "utf-8")).not.toContain("agentlog hook --source hermes");
+  });
+});

--- a/src/__tests__/note-writer.test.ts
+++ b/src/__tests__/note-writer.test.ts
@@ -482,6 +482,21 @@ describe("appendEntry — session-grouped AgentLog section", () => {
     expect(content).not.toContain("claude_");
   });
 
+  it("emits hermes-prefixed divider and does not duplicate an existing Hermes session divider", () => {
+    const filePath = writeDailyFile();
+    const sessionId = "hermes-session-123";
+
+    appendEntry(config, makeEntry({ time: "10:53", source: "hermes", sessionId, prompt: "첫 Hermes 작업" }), TEST_DATE);
+    appendEntry(config, makeEntry({ time: "11:07", source: "hermes", sessionId, prompt: "두 번째 Hermes 작업" }), TEST_DATE);
+
+    const content = readFileSync(filePath, "utf-8");
+    expect(content).toContain(`- - - - [[hermes_${sessionId}]]`);
+    expect(content).toContain("- 10:53 첫 Hermes 작업");
+    expect(content).toContain("- 11:07 두 번째 Hermes 작업");
+    const hermesDividerCount = (content.match(/\[\[hermes_hermes-session-123\]\]/g) ?? []).length;
+    expect(hermesDividerCount).toBe(1);
+  });
+
   // N5c: source differs but session id collides → insert a source-specific divider
   // (Codex IDs can look UUID-like and collide with an existing claude_ id; must not be mislabeled.)
   it("inserts a codex divider when source differs from an existing claude divider with the same id", () => {

--- a/src/__tests__/prd-redteam.test.ts
+++ b/src/__tests__/prd-redteam.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { chmodSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { fileURLToPath } from "url";
+
+const ROOT = fileURLToPath(new URL("../..", import.meta.url));
+const SCRIPT_PATH = fileURLToPath(new URL("../../scripts/prd-redteam.mjs", import.meta.url));
+const PRD_PATH = "docs/plans/2026-06-21-hook-provider-abstraction-hermes-prd.md";
+
+let tmp: string;
+
+function makeTmp(): string {
+  const dir = join(tmpdir(), `agentlog-prd-redteam-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function shQuote(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function makeFakeCodex(): { path: string; argsFile: string } {
+  const binDir = join(tmp, "bin");
+  const argsFile = join(tmp, "codex-args.txt");
+  mkdirSync(binDir, { recursive: true });
+  const codex = join(binDir, "codex");
+  writeFileSync(
+    codex,
+    `#!/bin/sh
+printf '%s\\n' "$@" > ${shQuote(argsFile)}
+printf '%s\\n' '{"verdict":"pass","findings":[],"missingRequirements":[]}'
+`,
+    "utf-8"
+  );
+  chmodSync(codex, 0o755);
+  return {
+    path: `${binDir}:${process.env.PATH ?? "/usr/bin:/bin"}`,
+    argsFile,
+  };
+}
+
+async function runRedteam(
+  args: string[],
+  opts: { PATH?: string; cwd?: string } = {}
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const proc = Bun.spawn(["node", SCRIPT_PATH, ...args], {
+    cwd: opts.cwd ?? ROOT,
+    env: { ...process.env, ...(opts.PATH ? { PATH: opts.PATH } : {}) },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const exitCode = await proc.exited;
+  return { stdout, stderr, exitCode };
+}
+
+describe("PRD red-team verifier", () => {
+  beforeEach(() => {
+    tmp = makeTmp();
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("passes the hook-provider PRD and invokes codex exec with a model-review prompt", async () => {
+    const fakeCodex = makeFakeCodex();
+    const reportPath = join(tmp, "report.json");
+
+    const result = await runRedteam(["--prd", PRD_PATH, "--output", reportPath], { PATH: fakeCodex.path });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("prd-redteam: pass");
+
+    const codexArgs = readFileSync(fakeCodex.argsFile, "utf-8");
+    expect(codexArgs).toStartWith("exec\n--skip-git-repo-check\n--ignore-rules\n--ephemeral\n-m\ngpt-5.3-codex-spark\n-c\n");
+    expect(codexArgs).toContain('model_reasoning_effort="low"');
+    expect(codexArgs).toContain("\n--\n");
+    expect(codexArgs).toContain("current behavior coverage tests before abstraction");
+    expect(codexArgs).toContain("agent-framework readiness validation");
+
+    const report = JSON.parse(readFileSync(reportPath, "utf-8"));
+    expect(report.verdict).toBe("pass");
+    expect(report.mechanical.verdict).toBe("pass");
+    expect(report.model.invoked).toBe(true);
+  });
+
+  it("fails mechanically before codex exec when Phase 0 coverage is missing", async () => {
+    const badPrd = join(tmp, "bad-prd.md");
+    writeFileSync(
+      badPrd,
+      "# Hook Provider Abstraction\n\n## 1. Goal\n\nAdd Hermes someday.\n",
+      "utf-8"
+    );
+    const reportPath = join(tmp, "bad-report.json");
+
+    const result = await runRedteam(["--prd", badPrd, "--output", reportPath], { cwd: ROOT });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toContain("mechanical: fail");
+
+    const report = JSON.parse(readFileSync(reportPath, "utf-8"));
+    expect(report.verdict).toBe("fail");
+    expect(report.model.invoked).toBe(false);
+    expect(report.mechanical.checks.some((item: { id: string; passed: boolean }) =>
+      item.id === "phase0-coverage-matrix" && item.passed === false
+    )).toBe(true);
+  });
+
+  it("passes mechanical-only triage when --skip-model is set", async () => {
+    const result = await runRedteam(["--prd", PRD_PATH, "--skip-model", "--json"]);
+
+    expect(result.exitCode).toBe(0);
+    const report = JSON.parse(result.stdout);
+    expect(report.verdict).toBe("pass");
+    expect(report.mechanical.verdict).toBe("pass");
+    expect(report.model.invoked).toBe(false);
+  });
+});

--- a/src/backfill.ts
+++ b/src/backfill.ts
@@ -36,7 +36,16 @@ export function parseDateArg(value: string | undefined, now: Date = new Date()):
   const m = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
   if (!m) throw new Error("date must be YYYY-MM-DD");
   const [, yyyy, mm, dd] = m;
-  return new Date(Number(yyyy), Number(mm) - 1, Number(dd));
+  const year = Number(yyyy);
+  const month = Number(mm);
+  const day = Number(dd);
+  const date = new Date(0);
+  date.setFullYear(year, month - 1, day);
+  date.setHours(0, 0, 0, 0);
+  if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) {
+    throw new Error("date must be a valid YYYY-MM-DD calendar date");
+  }
+  return date;
 }
 
 function dateKey(date: Date): string {
@@ -88,6 +97,10 @@ function walkJsonl(root: string): string[] {
   return out;
 }
 
+export function hasPathSegment(filePath: string, segment: string): boolean {
+  return filePath.split(/[\\/]+/).includes(segment);
+}
+
 function extractTextParts(value: unknown, textType: string): string | null {
   if (typeof value === "string") return value;
   if (!Array.isArray(value)) return null;
@@ -135,7 +148,7 @@ function collectCodexEntries(date: Date, codexHome = join(homedir(), ".codex")):
 }
 
 function collectClaudeEntries(date: Date, claudeHome = join(homedir(), ".claude")): { scanned: number; entries: LogEntry[] } {
-  const files = walkJsonl(join(claudeHome, "projects")).filter((file) => !file.includes("/subagents/"));
+  const files = walkJsonl(join(claudeHome, "projects")).filter((file) => !hasPathSegment(file, "subagents"));
   const entries: LogEntry[] = [];
 
   for (const file of files) {
@@ -176,7 +189,18 @@ function noteContainsEntry(config: AgentLogConfig, entry: LogEntry, date: Date):
   const line = buildAgentLogEntry(entry.time, entry.prompt);
   if (config.plain) return content.includes(line);
   const divider = buildSessionDivider(entry.sessionId, entry.source);
-  return content.includes(divider) && content.includes(line);
+  const lines = content.split("\n");
+
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i] !== divider) continue;
+
+    for (let j = i + 1; j < lines.length; j++) {
+      if (lines[j] === line) return true;
+      if (lines[j].startsWith("#### ") || lines[j].startsWith("## ") || /^- - - - (?:\[\[|\()/.test(lines[j])) break;
+    }
+  }
+
+  return false;
 }
 
 export function runBackfill(config: AgentLogConfig, options: BackfillOptions = {}): BackfillResult {

--- a/src/backfill.ts
+++ b/src/backfill.ts
@@ -1,0 +1,206 @@
+import { existsSync, readFileSync, readdirSync, statSync } from "fs";
+import { basename, join } from "path";
+import { homedir } from "os";
+import { appendEntry, dailyNotePath } from "./note-writer.js";
+import { buildAgentLogEntry, buildSessionDivider, cwdToProject } from "./schema/daily-note.js";
+import { prettyPrompt } from "./schema/pretty-prompt.js";
+import type { AgentLogConfig, LogEntry, SourceType } from "./types.js";
+
+export type BackfillSource = SourceType | "all";
+
+export interface BackfillOptions {
+  date?: Date;
+  source?: BackfillSource;
+  dryRun?: boolean;
+  codexHome?: string;
+  claudeHome?: string;
+}
+
+export interface BackfillResult {
+  date: string;
+  scanned: number;
+  found: number;
+  inserted: number;
+  skipped: number;
+  filePath: string | null;
+}
+
+type RawJson = Record<string, unknown>;
+
+function pad2(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+export function parseDateArg(value: string | undefined, now: Date = new Date()): Date {
+  if (!value) return new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const m = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!m) throw new Error("date must be YYYY-MM-DD");
+  const [, yyyy, mm, dd] = m;
+  return new Date(Number(yyyy), Number(mm) - 1, Number(dd));
+}
+
+function dateKey(date: Date): string {
+  return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`;
+}
+
+function timeKey(date: Date): string {
+  return `${pad2(date.getHours())}:${pad2(date.getMinutes())}`;
+}
+
+function sameLocalDate(timestamp: string | undefined, date: Date): boolean {
+  if (!timestamp) return false;
+  const parsed = new Date(timestamp);
+  if (Number.isNaN(parsed.getTime())) return false;
+  return dateKey(parsed) === dateKey(date);
+}
+
+function readJsonLines(filePath: string): RawJson[] {
+  if (!existsSync(filePath)) return [];
+  return readFileSync(filePath, "utf-8")
+    .split("\n")
+    .filter(Boolean)
+    .flatMap((line) => {
+      try {
+        const parsed = JSON.parse(line);
+        return typeof parsed === "object" && parsed !== null ? [parsed as RawJson] : [];
+      } catch {
+        return [];
+      }
+    });
+}
+
+function walkJsonl(root: string): string[] {
+  if (!existsSync(root)) return [];
+  const out: string[] = [];
+  const stack = [root];
+  while (stack.length > 0) {
+    const dir = stack.pop()!;
+    for (const name of readdirSync(dir)) {
+      const path = join(dir, name);
+      const st = statSync(path);
+      if (st.isDirectory()) {
+        stack.push(path);
+      } else if (name.endsWith(".jsonl")) {
+        out.push(path);
+      }
+    }
+  }
+  return out;
+}
+
+function extractTextParts(value: unknown, textType: string): string | null {
+  if (typeof value === "string") return value;
+  if (!Array.isArray(value)) return null;
+  const parts = value
+    .filter((part): part is RawJson => typeof part === "object" && part !== null)
+    .filter((part) => part["type"] === textType && typeof part["text"] === "string")
+    .map((part) => part["text"] as string);
+  return parts.length > 0 ? parts.join("\n") : null;
+}
+
+function pushEntry(entries: LogEntry[], raw: string | null, timestamp: string | undefined, base: Omit<LogEntry, "time" | "prompt">, date: Date): void {
+  if (!raw || !sameLocalDate(timestamp, date)) return;
+  const prompt = prettyPrompt(raw);
+  if (!prompt) return;
+  entries.push({
+    ...base,
+    time: timeKey(new Date(timestamp!)),
+    prompt,
+  });
+}
+
+function collectCodexEntries(date: Date, codexHome = join(homedir(), ".codex")): { scanned: number; entries: LogEntry[] } {
+  const root = join(codexHome, "sessions", String(date.getFullYear()), pad2(date.getMonth() + 1), pad2(date.getDate()));
+  const files = walkJsonl(root);
+  const entries: LogEntry[] = [];
+
+  for (const file of files) {
+    const lines = readJsonLines(file);
+    const meta = lines.find((line) => line["type"] === "session_meta")?.["payload"] as RawJson | undefined;
+    const sessionId = typeof meta?.["id"] === "string" ? meta["id"] : basename(file, ".jsonl");
+    const cwd = typeof meta?.["cwd"] === "string" ? meta["cwd"] : process.cwd();
+    if (meta?.["thread_source"] === "subagent") continue;
+
+    const base = { sessionId, cwd, project: cwdToProject(cwd), source: "codex" as const };
+    for (const line of lines) {
+      if (line["type"] !== "event_msg") continue;
+      const payload = line["payload"] as RawJson | undefined;
+      if (payload?.["type"] !== "user_message") continue;
+      const message = typeof payload["message"] === "string" ? payload["message"] : null;
+      pushEntry(entries, message, line["timestamp"] as string | undefined, base, date);
+    }
+  }
+
+  return { scanned: files.length, entries };
+}
+
+function collectClaudeEntries(date: Date, claudeHome = join(homedir(), ".claude")): { scanned: number; entries: LogEntry[] } {
+  const files = walkJsonl(join(claudeHome, "projects")).filter((file) => !file.includes("/subagents/"));
+  const entries: LogEntry[] = [];
+
+  for (const file of files) {
+    for (const line of readJsonLines(file)) {
+      if (line["type"] !== "user") continue;
+      if (line["isSidechain"] === true) continue;
+      const sessionId = typeof line["sessionId"] === "string" ? line["sessionId"] : basename(file, ".jsonl");
+      const cwd = typeof line["cwd"] === "string" ? line["cwd"] : process.cwd();
+      const message = line["message"] as RawJson | undefined;
+      if (message?.["role"] !== "user") continue;
+      const raw = extractTextParts(message["content"], "text");
+      const base = { sessionId, cwd, project: cwdToProject(cwd), source: "claude" as const };
+      pushEntry(entries, raw, line["timestamp"] as string | undefined, base, date);
+    }
+  }
+
+  return { scanned: files.length, entries };
+}
+
+export function collectBackfillEntries(options: BackfillOptions = {}): { scanned: number; entries: LogEntry[] } {
+  const date = options.date ?? parseDateArg(undefined);
+  const source = options.source ?? "all";
+  const chunks = [];
+  if (source === "all" || source === "codex") chunks.push(collectCodexEntries(date, options.codexHome));
+  if (source === "all" || source === "claude") chunks.push(collectClaudeEntries(date, options.claudeHome));
+  const entries = chunks.flatMap((chunk) => chunk.entries);
+  entries.sort((a, b) => a.time.localeCompare(b.time) || a.source.localeCompare(b.source) || a.sessionId.localeCompare(b.sessionId));
+  return {
+    scanned: chunks.reduce((sum, chunk) => sum + chunk.scanned, 0),
+    entries,
+  };
+}
+
+function noteContainsEntry(config: AgentLogConfig, entry: LogEntry, date: Date): boolean {
+  const path = dailyNotePath(config, date);
+  if (!path || !existsSync(path)) return false;
+  const content = readFileSync(path, "utf-8");
+  const line = buildAgentLogEntry(entry.time, entry.prompt);
+  if (config.plain) return content.includes(line);
+  const divider = buildSessionDivider(entry.sessionId, entry.source);
+  return content.includes(divider) && content.includes(line);
+}
+
+export function runBackfill(config: AgentLogConfig, options: BackfillOptions = {}): BackfillResult {
+  const date = options.date ?? parseDateArg(undefined);
+  const { scanned, entries } = collectBackfillEntries({ ...options, date });
+  const filePath = dailyNotePath(config, date);
+  let inserted = 0;
+  let skipped = 0;
+
+  for (const entry of entries) {
+    if (noteContainsEntry(config, entry, date)) {
+      skipped++;
+      continue;
+    }
+    if (!options.dryRun) appendEntry(config, entry, date);
+    inserted++;
+  }
+
+  return {
+    date: dateKey(date),
+    scanned,
+    found: entries.length,
+    inserted,
+    skipped,
+    filePath,
+  };
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -636,6 +636,10 @@ async function cmdBackfill(dateArg: string | undefined, opts: { source: Backfill
     console.error("Error: --source must be one of: all, claude, codex");
     process.exit(1);
   }
+  if (!["text", "json"].includes(opts.format)) {
+    console.error("Error: --format must be one of: text, json");
+    process.exit(1);
+  }
 
   const config = loadConfig();
   if (!config) {
@@ -651,7 +655,14 @@ async function cmdBackfill(dateArg: string | undefined, opts: { source: Backfill
     process.exit(1);
   }
 
-  const result = runBackfill(config, { date, source: opts.source, dryRun: opts.dryRun });
+  let result;
+  try {
+    result = runBackfill(config, { date, source: opts.source, dryRun: opts.dryRun });
+  } catch (err) {
+    console.error(err instanceof Error ? `Error: ${err.message}` : String(err));
+    process.exit(1);
+  }
+
   if (opts.format === "json") {
     console.log(JSON.stringify({ status: "success", data: result }));
     return;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -43,6 +43,7 @@ import {
   unregisterCodexNotify,
 } from "./codex-settings.js";
 import { formatVersionHeadline, formatVersionOutput, getRuntimeInfo, readVersion, resolvePackageRoot } from "./version-info.js";
+import { parseDateArg, runBackfill, type BackfillSource } from "./backfill.js";
 import { Command } from "commander";
 
 type InitTarget = "claude" | "codex" | "all";
@@ -630,6 +631,39 @@ async function cmdVersion(): Promise<void> {
   console.log(formatVersionOutput(getRuntimeInfo()));
 }
 
+async function cmdBackfill(dateArg: string | undefined, opts: { source: BackfillSource; dryRun: boolean; format: string }): Promise<void> {
+  if (!["all", "claude", "codex"].includes(opts.source)) {
+    console.error("Error: --source must be one of: all, claude, codex");
+    process.exit(1);
+  }
+
+  const config = loadConfig();
+  if (!config) {
+    console.error("[agentlog] not initialized. Run: agentlog init ~/path/to/vault");
+    process.exit(1);
+  }
+
+  let date: Date;
+  try {
+    date = parseDateArg(dateArg);
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+
+  const result = runBackfill(config, { date, source: opts.source, dryRun: opts.dryRun });
+  if (opts.format === "json") {
+    console.log(JSON.stringify({ status: "success", data: result }));
+    return;
+  }
+
+  const verb = opts.dryRun ? "Would append" : "Appended";
+  console.log(`${verb} ${result.inserted} entries from ${result.found} discovered prompts (${result.skipped} already present).`);
+  console.log(`  date: ${result.date}`);
+  console.log(`  scanned sessions: ${result.scanned}`);
+  if (result.filePath) console.log(`  note: ${result.filePath}`);
+}
+
 async function cmdUninstall(opts: { y: boolean; codex: boolean; all: boolean; dryRun: boolean }): Promise<void> {
   if (opts.codex && opts.all) {
     console.error("Error: choose at most one uninstall target: --codex or --all");
@@ -795,6 +829,16 @@ const SCHEMA_DATA = {
       options: [],
     },
     {
+      name: "backfill",
+      description: "Scan Claude/Codex session JSONL files and append missing prompts to a Daily Note",
+      arguments: [{ name: "date", description: "Date to backfill (YYYY-MM-DD, default: today)", required: false }],
+      options: [
+        { flags: "--source <source>", description: "Source to scan: all, claude, or codex" },
+        { flags: "--dry-run", description: "Report entries without writing to the note" },
+        { flags: "--format <format>", description: "Output format: text or json" },
+      ],
+    },
+    {
       name: "hook",
       description: "Run hook (called by Claude Code or Codex UserPromptSubmit)",
       arguments: [],
@@ -924,6 +968,16 @@ program
   .argument("[prompt...]", "Prompt text to send to codex exec")
   .action(async (prompt: string[]) => {
     await cmdCodexDebug(prompt);
+  });
+
+program
+  .command("backfill [date]")
+  .description("Scan Claude/Codex session JSONL files and append missing prompts to a Daily Note")
+  .option("--source <source>", "Source to scan: all, claude, or codex", "all")
+  .option("--dry-run", "Report entries without writing to the note", false)
+  .option("--format <format>", "Output format: text or json", "text")
+  .action(async (date: string | undefined, opts: { source: BackfillSource; dryRun: boolean; format: string }) => {
+    await cmdBackfill(date, opts);
   });
 
 program

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -519,6 +519,8 @@ async function cmdDoctor(): Promise<void> {
 
     const detail = codexHookState.kind === "unsupported"
       ? `${CODEX_HOOKS_PATH} — unsupported hook config (${codexHookState.reason})`
+      : codexHookState.kind === "needs_migration"
+        ? `${CODEX_HOOKS_PATH} — ${codexHookState.reason}`
       : codexHookState.kind === "registered"
         ? `${CODEX_HOOKS_PATH} — hook registered`
         : hasCodexHookMetadata
@@ -535,6 +537,8 @@ async function cmdDoctor(): Promise<void> {
       detail,
       codexHookState.kind === "unsupported"
         ? "fix hooks.json or move it aside, then run: agentlog init --codex"
+        : codexHookState.kind === "needs_migration"
+          ? "run: agentlog init --codex to migrate the Codex hook"
         : legacyNotifyState.kind === "unsupported"
           ? "simplify legacy notify config or move config.toml aside, then run: agentlog init --codex"
           : hasCodexHookMetadata || hasRestoreMetadata || legacyNotifyState.kind === "registered"
@@ -671,7 +675,7 @@ async function cmdUninstall(opts: { y: boolean; codex: boolean; all: boolean; dr
   } else {
     // Check if Codex hook is still registered
     const codexHookState = readCodexHookState();
-    if (codexHookState.kind === "registered") {
+    if (codexHookState.kind === "registered" || codexHookState.kind === "needs_migration") {
       console.warn(
         "⚠️  Codex hook is still registered. Run `agentlog uninstall --all` to also remove it."
       );

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,10 +3,10 @@
  * AgentLog CLI
  *
  * Commands:
- *   agentlog init [vault] [--plain] [--claude | --codex | --all]
- *                                   — configure Claude hook, Codex hook, or both
- *   agentlog uninstall [-y] [--codex | --all]
- *                                   — remove Claude hook, Codex hook, or both
+ *   agentlog init [vault] [--plain] [--claude | --codex | --hermes | --all]
+ *                                   — configure Claude, Codex, Hermes, or Claude+Codex
+ *   agentlog uninstall [-y] [--codex | --hermes | --all]
+ *                                   — remove Claude, Codex, Hermes, or all metadata
  *   agentlog detect                   — list detected Obsidian vaults
  *   agentlog hook                     — invoked by Claude Code UserPromptSubmit hook
  *   agentlog codex-notify             — legacy Codex notify handler
@@ -20,7 +20,7 @@ import { saveConfig, loadConfig, expandHome, configPath, configDir } from "./con
 import type { AgentLogConfig } from "./types.js";
 import { detectVaults, detectCli } from "./detect.js";
 import { isVersionAtLeast, isCliDisabledOutput, MIN_CLI_VERSION, resolveCliBin, parseCliVersion } from "./obsidian-cli.js";
-import { registerHook, unregisterHook, inspectClaudeHookState, CLAUDE_SETTINGS_PATH } from "./claude-settings.js";
+import { unregisterHook, inspectClaudeHookState, CLAUDE_SETTINGS_PATH } from "./claude-settings.js";
 import {
   ask,
   detectBinary,
@@ -44,85 +44,124 @@ import {
 } from "./codex-settings.js";
 import { formatVersionHeadline, formatVersionOutput, getRuntimeInfo, readVersion, resolvePackageRoot } from "./version-info.js";
 import { parseDateArg, runBackfill, type BackfillSource } from "./backfill.js";
+import {
+  hookProviders,
+  providerById,
+  providersForInitTarget,
+  providersForUninstallTarget,
+  type InitTarget,
+  type UninstallTarget,
+} from "./hook-providers/index.js";
+import { uninstallLegacyCodexNotify } from "./hook-providers/codex.js";
+import { resolveHermesConfigTargets } from "./hermes-config.js";
 import { Command } from "commander";
 
-type InitTarget = "claude" | "codex" | "all";
-type UninstallTarget = "claude" | "codex" | "all";
-
-async function runInit(vaultArg: string, plain: boolean): Promise<void> {
-  const vault = validateVaultOrExit(vaultArg, plain);
-
-  saveMergedConfig(vault, plain, { claudeHookInstalled: true });
-  printSavedConfig(vault, plain);
-  printObsidianCliStatus(plain);
-
-  // Register hook in ~/.claude/settings.json
-  registerHook();
-  console.log(`Hook registered: ${CLAUDE_SETTINGS_PATH}`);
-  console.log(`
-AgentLog is ready. Claude Code prompts will be logged to your Daily Note.`);
+interface HermesCliOptions {
+  hermesProfile?: string[];
+  hermesAllProfiles?: boolean;
 }
 
-async function runCodexInit(vaultArg: string, plain: boolean): Promise<void> {
-  const codexBin = detectBinary("codex");
-  if (!codexBin) {
-    console.error("Error: Codex CLI not found in PATH");
+function providerContext(config: AgentLogConfig | null, opts: HermesCliOptions = {}) {
+  return {
+    homeDir: process.env.HOME,
+    hermesHome: process.env.HERMES_HOME ?? config?.hermesHome,
+    hermesProfiles: opts.hermesProfile && opts.hermesProfile.length > 0 ? opts.hermesProfile : config?.hermesProfiles,
+    hermesAllProfiles: opts.hermesAllProfiles,
+    hermesCommand: agentlogHermesHookCommand(),
+  };
+}
+
+function shellQuote(value: string): string {
+  if (/^[A-Za-z0-9_/:=.,@%+-]+$/.test(value)) return value;
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+function agentlogHermesHookCommand(): string {
+  const agentlogBin = detectBinary("agentlog");
+  return `${shellQuote(agentlogBin || "agentlog")} hook --source hermes`;
+}
+
+function savePatchedConfig(config: AgentLogConfig | null, patch: Partial<AgentLogConfig> | undefined): void {
+  if (!config || !patch) return;
+  const next: AgentLogConfig = { ...config };
+  for (const [key, value] of Object.entries(patch) as Array<[keyof AgentLogConfig, AgentLogConfig[keyof AgentLogConfig]]>) {
+    if (value === undefined) delete next[key];
+    else (next as unknown as Record<string, unknown>)[key] = value;
+  }
+  saveConfig(next);
+}
+
+function validateHermesCliOptions(target: InitTarget | UninstallTarget, opts: HermesCliOptions): void {
+  const hasHermesProfile = !!opts.hermesProfile && opts.hermesProfile.length > 0;
+  if (hasHermesProfile && opts.hermesAllProfiles) {
+    console.error("Error: choose either --hermes-profile or --hermes-all-profiles");
     process.exit(1);
   }
+  if ((hasHermesProfile || opts.hermesAllProfiles) && target !== "hermes") {
+    console.error("Error: Hermes profile options require --hermes");
+    process.exit(1);
+  }
+}
 
+function hermesConfigTargetLines(opts: HermesCliOptions = {}): string[] {
+  return resolveHermesConfigTargets({
+    homeDir: process.env.HOME,
+    hermesHome: process.env.HERMES_HOME,
+    profiles: opts.hermesProfile,
+    allProfiles: opts.hermesAllProfiles,
+  }).map((target) => `${target.profile}:${target.path}`);
+}
+
+async function runProviderInit(vaultArg: string, plain: boolean, target: InitTarget, opts: HermesCliOptions = {}): Promise<void> {
   const vault = validateVaultOrExit(vaultArg, plain);
-  let result: CodexHookMutationResult;
+  const providerIds = providersForInitTarget(target);
+  const ctx = { vault, plain, ...providerContext(loadConfig(), opts) };
+  const messages: string[] = [];
+  const configPatch: Partial<AgentLogConfig> = {};
+
   try {
-    result = registerCodexHook();
+    for (const providerId of providerIds) {
+      providerById(providerId).preflightInstall?.(ctx);
+    }
   } catch (err) {
     console.error(err instanceof Error ? err.message : String(err));
     process.exit(1);
   }
 
-  saveMergedConfig(vault, plain, { codexHookInstalled: true });
-  printSavedConfig(vault, plain);
-  printObsidianCliStatus(plain);
-  console.log(`  Codex CLI: ${codexBin}`);
-  console.log(`Codex hook registered: ${CODEX_HOOKS_PATH}`);
-  if (!result.changed) console.log(`  Existing AgentLog Codex hook left unchanged`);
-  console.log(`  Review/trust the hook in Codex with /hooks if prompted.`);
-  console.log(`
-AgentLog is ready. Codex turns will be logged to your Daily Note.`);
-}
-
-async function runAllInit(vaultArg: string, plain: boolean): Promise<void> {
-  const codexBin = detectBinary("codex");
-  if (!codexBin) {
-    console.error("Error: Codex CLI not found in PATH");
-    process.exit(1);
+  for (const providerId of providerIds) {
+    const provider = providerById(providerId);
+    try {
+      const result = provider.install(ctx);
+      Object.assign(configPatch, result.configPatch);
+      messages.push(...result.messages);
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
   }
 
-  const vault = validateVaultOrExit(vaultArg, plain);
-  let result: CodexHookMutationResult;
-  try {
-    result = registerCodexHook();
-  } catch (err) {
-    console.error(err instanceof Error ? err.message : String(err));
-    process.exit(1);
-  }
-
-  saveMergedConfig(vault, plain, { codexHookInstalled: true, claudeHookInstalled: true });
+  saveMergedConfig(vault, plain, configPatch);
   printSavedConfig(vault, plain);
   printObsidianCliStatus(plain);
+  for (const message of messages) console.log(message);
+  if (providerIds.includes("codex")) {
+    console.log(`  Review/trust the hook in Codex with /hooks if prompted.`);
+  }
 
-  registerHook();
-  console.log(`Hook registered: ${CLAUDE_SETTINGS_PATH}`);
-  console.log(`  Codex CLI: ${codexBin}`);
-  console.log(`Codex hook registered: ${CODEX_HOOKS_PATH}`);
-  if (!result.changed) console.log(`  Existing AgentLog Codex hook left unchanged`);
-  console.log(`  Review/trust the hook in Codex with /hooks if prompted.`);
-  console.log(`
-AgentLog is ready. Claude Code prompts and Codex turns will be logged to your Daily Note.`);
+  if (target === "claude") {
+    console.log(`\nAgentLog is ready. Claude Code prompts will be logged to your Daily Note.`);
+  } else if (target === "codex") {
+    console.log(`\nAgentLog is ready. Codex turns will be logged to your Daily Note.`);
+  } else if (target === "hermes") {
+    console.log(`\nAgentLog is ready. Hermes turns will be logged after Hermes accepts the shell hook.`);
+  } else {
+    console.log(`\nAgentLog is ready. Claude Code prompts and Codex turns will be logged to your Daily Note.`);
+  }
 }
 
 async function interactiveInit(
   plain: boolean,
-  runner: (vault: string, plain: boolean) => Promise<void> = runInit
+  runner: (vault: string, plain: boolean) => Promise<void>
 ): Promise<void> {
   if (plain) {
     const folder = await ask("Enter folder path for plain mode: ");
@@ -196,13 +235,8 @@ async function interactiveInit(
 }
 
 function uninstallClaude(configDirPath: string): void {
-  // Remove hook from ~/.claude/settings.json
-  const hookRemoved = unregisterHook();
-  if (hookRemoved) {
-    console.log(`Hook removed: ${CLAUDE_SETTINGS_PATH}`);
-  } else {
-    console.log(`Hook not found (already removed or never registered)`);
-  }
+  const result = hookProviders.claude.uninstall();
+  for (const message of result.messages) console.log(message);
 
   // Remove config directory
   if (existsSync(configDirPath)) {
@@ -217,38 +251,54 @@ function uninstallClaude(configDirPath: string): void {
 
 function uninstallCodex(clearRestoreMetadata: boolean): void {
   const config = loadConfig();
-  let result: CodexHookMutationResult;
+  let result;
   try {
-    result = unregisterCodexHook();
+    result = hookProviders.codex.uninstall();
   } catch (err) {
     console.error(err instanceof Error ? err.message : String(err));
     process.exit(1);
   }
-  if (result.changed) {
-    console.log(`Codex hook removed: ${CODEX_HOOKS_PATH}`);
-  } else {
-    console.log("Codex hook not found (already removed or never registered)");
-  }
+  for (const message of result.messages) console.log(message);
 
-  const legacyNotify = unregisterCodexNotify(config?.codexNotifyRestore ?? null);
-  if (legacyNotify.changed) {
-    const action = legacyNotify.restoreNotify && legacyNotify.restoreNotify.length > 0 ? "restored" : "removed";
-    console.log(`Legacy Codex notify ${action}: ${CODEX_CONFIG_PATH}`);
-  }
+  for (const message of uninstallLegacyCodexNotify(config)) console.log(message);
 
   if (clearRestoreMetadata && config) {
-    const next: AgentLogConfig = { ...config };
-    delete next.codexHookInstalled;
-    delete next.codexNotifyRestore;
-    saveConfig(next);
+    savePatchedConfig(config, { ...result.configPatch, codexNotifyRestore: undefined });
   }
 
   console.log("\nCodex integration uninstalled.");
 }
 
+function uninstallHermes(opts: HermesCliOptions = {}): void {
+  const config = loadConfig();
+  let result;
+  try {
+    result = hookProviders.hermes.uninstall(providerContext(config, opts));
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+  for (const message of result.messages) console.log(message);
+  savePatchedConfig(config, result.configPatch);
+  console.log("\nHermes integration metadata removed.");
+}
+
+function preflightProviderUninstall(target: UninstallTarget, opts: HermesCliOptions = {}): void {
+  const config = loadConfig();
+  const ctx = providerContext(config, opts);
+  for (const providerId of providersForUninstallTarget(target)) {
+    try {
+      providerById(providerId).preflightUninstall?.(ctx);
+    } catch (err) {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    }
+  }
+}
+
 // --- Command implementations ---
 
-async function cmdInitDryRun(vaultArg: string, plain: boolean, target: string): Promise<void> {
+async function cmdInitDryRun(vaultArg: string, plain: boolean, target: string, opts: HermesCliOptions = {}): Promise<void> {
   if (!vaultArg && target !== "codex") {
     console.error("Error: --dry-run requires a vault path argument");
     process.exit(1);
@@ -274,31 +324,36 @@ async function cmdInitDryRun(vaultArg: string, plain: boolean, target: string): 
   if (target === "codex" || target === "all") {
     console.log(`  Would register codex hook integration in: ${CODEX_HOOKS_PATH}`);
   }
+  if (target === "hermes") {
+    console.log(`  Would save Hermes metadata to: ${cfgPath}`);
+    console.log("  Would write Hermes hook config:");
+    for (const line of hermesConfigTargetLines(opts)) console.log(`    ${line}`);
+  }
 }
 
-async function cmdInit(vaultArg: string | undefined, opts: { plain: boolean; claude: boolean; codex: boolean; all: boolean; dryRun: boolean }): Promise<void> {
+async function cmdInit(vaultArg: string | undefined, opts: { plain: boolean; claude: boolean; codex: boolean; hermes: boolean; all: boolean; dryRun: boolean; hermesProfile?: string[]; hermesAllProfiles?: boolean }): Promise<void> {
   const { plain, dryRun } = opts;
 
-  if ((opts.all && (opts.claude || opts.codex)) || (opts.claude && opts.codex)) {
-    console.error("Error: choose exactly one target: --claude, --codex, or --all");
+  const selectedTargets = [opts.claude, opts.codex, opts.hermes, opts.all].filter(Boolean).length;
+  if (selectedTargets > 1) {
+    console.error("Error: choose exactly one target: --claude, --codex, --hermes, or --all");
     process.exit(1);
   }
 
-  const target: InitTarget = opts.all ? "all" : opts.codex ? "codex" : "claude";
+  const target: InitTarget = opts.all ? "all" : opts.codex ? "codex" : opts.hermes ? "hermes" : "claude";
+  validateHermesCliOptions(target, opts);
 
   if (dryRun) {
-    await cmdInitDryRun(vaultArg ?? "", plain, target === "claude" ? "hook" : target);
+    await cmdInitDryRun(vaultArg ?? "", plain, target === "claude" ? "hook" : target, opts);
     return;
   }
-
-  const runner = target === "all" ? runAllInit : target === "codex" ? runCodexInit : runInit;
 
   if (!vaultArg) {
-    await interactiveInit(plain, runner);
+    await interactiveInit(plain, (vault, isPlain) => runProviderInit(vault, isPlain, target, opts));
     return;
   }
 
-  await runner(vaultArg, plain);
+  await runProviderInit(vaultArg, plain, target, opts);
 }
 
 async function cmdDetect(opts: { format: string; fields?: string }): Promise<void> {
@@ -481,31 +536,20 @@ async function cmdDoctor(): Promise<void> {
 
   const hasCodexHookMetadata = config?.codexHookInstalled === true;
   const hasClaudeHookMetadata = config?.claudeHookInstalled === true;
-  const hasRestoreMetadata = !!config && Object.prototype.hasOwnProperty.call(config, "codexNotifyRestore");
-  const codexHookState = readCodexHookState();
-  const legacyNotifyState = readCodexNotifyState();
-  const codexRelevant =
-    hasCodexHookMetadata ||
-    hasRestoreMetadata ||
-    codexHookState.kind !== "missing" ||
-    legacyNotifyState.kind !== "missing";
+  const hasHermesHookMetadata = config?.hermesHookInstalled === true;
+  const hermesCtx = providerContext(config);
+  const codexRelevant = hookProviders.codex.isRelevant(config);
+  const hermesRelevant = hookProviders.hermes.isRelevant(config, hermesCtx);
 
   // 6. Claude hook registered and compatible with Claude Code matcher validation.
-  const hookState = inspectClaudeHookState();
+  const hookState = hookProviders.claude.inspect();
   const hookOk = hookState.kind === "registered";
-  const hookDetail = hookState.kind === "registered"
-    ? CLAUDE_SETTINGS_PATH
-    : hookState.kind === "unsupported"
-      ? `${CLAUDE_SETTINGS_PATH} — ${hookState.reason}`
-      : "not registered";
   check(
     "hook",
     hookOk,
-    hookDetail,
-    hookState.kind === "unsupported"
-      ? "run: agentlog init to migrate AgentLog hook, or fix Claude settings"
-      : "run: agentlog init to re-register",
-    codexRelevant && hookState.kind === "missing" && !hasClaudeHookMetadata
+    hookState.detail,
+    hookState.kind === "registered" ? undefined : hookState.repairHint,
+    (codexRelevant || hermesRelevant) && hookState.kind === "missing" && !hasClaudeHookMetadata
   );
 
   // 7. Codex hook checks (only when configured or explicitly requested)
@@ -518,33 +562,25 @@ async function cmdDoctor(): Promise<void> {
       "install Codex CLI, then re-run: agentlog init --codex ~/path/to/vault"
     );
 
-    const detail = codexHookState.kind === "unsupported"
-      ? `${CODEX_HOOKS_PATH} — unsupported hook config (${codexHookState.reason})`
-      : codexHookState.kind === "needs_migration"
-        ? `${CODEX_HOOKS_PATH} — ${codexHookState.reason}`
-      : codexHookState.kind === "registered"
-        ? `${CODEX_HOOKS_PATH} — hook registered`
-        : hasCodexHookMetadata
-          ? `${CODEX_HOOKS_PATH} — not registered (inconsistent state)`
-          : legacyNotifyState.kind === "registered"
-            ? `${CODEX_CONFIG_PATH} — legacy notify registered; migrate to hooks`
-            : legacyNotifyState.kind === "unsupported"
-              ? `${CODEX_CONFIG_PATH} — unsupported legacy notify config (${legacyNotifyState.reason})`
-              : `${CODEX_HOOKS_PATH} — not registered`;
-
+    const codexState = hookProviders.codex.inspect();
     check(
       "codex",
-      codexHookState.kind === "registered",
-      detail,
-      codexHookState.kind === "unsupported"
-        ? "fix hooks.json or move it aside, then run: agentlog init --codex"
-        : codexHookState.kind === "needs_migration"
-          ? "run: agentlog init --codex to migrate the Codex hook"
-        : legacyNotifyState.kind === "unsupported"
-          ? "simplify legacy notify config or move config.toml aside, then run: agentlog init --codex"
-          : hasCodexHookMetadata || hasRestoreMetadata || legacyNotifyState.kind === "registered"
-            ? "run: agentlog init --codex to repair or migrate to hooks"
-          : "run: agentlog init --codex ~/path/to/vault"
+      codexState.kind === "registered",
+      hasCodexHookMetadata && codexState.kind === "missing"
+        ? `${codexState.detail} (inconsistent state)`
+        : codexState.detail,
+      codexState.kind === "registered" ? undefined : codexState.repairHint
+    );
+  }
+
+  if (hermesRelevant) {
+    const hermesState = hookProviders.hermes.inspect(hermesCtx);
+    check(
+      "hermes",
+      hermesState.kind === "registered",
+      hermesState.detail,
+      hermesState.kind === "registered" ? undefined : hermesState.repairHint,
+      !hasHermesHookMetadata
     );
   }
 
@@ -582,7 +618,7 @@ async function cmdOpen(): Promise<void> {
   }
 }
 
-async function cmdHook(_source: "claude" | "codex" = "claude"): Promise<void> {
+async function cmdHook(_source: "claude" | "codex" | "hermes" = "claude"): Promise<void> {
   // Dynamically import hook to avoid loading it unless needed
   await import("./hook.js");
 }
@@ -675,13 +711,14 @@ async function cmdBackfill(dateArg: string | undefined, opts: { source: Backfill
   if (result.filePath) console.log(`  note: ${result.filePath}`);
 }
 
-async function cmdUninstall(opts: { y: boolean; codex: boolean; all: boolean; dryRun: boolean }): Promise<void> {
-  if (opts.codex && opts.all) {
-    console.error("Error: choose at most one uninstall target: --codex or --all");
+async function cmdUninstall(opts: { y: boolean; codex: boolean; hermes: boolean; all: boolean; dryRun: boolean; hermesProfile?: string[]; hermesAllProfiles?: boolean }): Promise<void> {
+  if ([opts.codex, opts.hermes, opts.all].filter(Boolean).length > 1) {
+    console.error("Error: choose at most one uninstall target: --codex, --hermes, or --all");
     process.exit(1);
   }
 
-  const target: UninstallTarget = opts.all ? "all" : opts.codex ? "codex" : "claude";
+  const target: UninstallTarget = opts.all ? "all" : opts.codex ? "codex" : opts.hermes ? "hermes" : "claude";
+  validateHermesCliOptions(target, opts);
   const cfgDir = configDir();
 
   if (opts.dryRun) {
@@ -694,15 +731,22 @@ async function cmdUninstall(opts: { y: boolean; codex: boolean; all: boolean; dr
       console.log(`  Would remove codex hook from: ${CODEX_HOOKS_PATH}`);
       console.log(`  Would restore/remove legacy codex notify in: ${CODEX_CONFIG_PATH}`);
     }
+    if (target === "hermes" || target === "all") {
+      console.log("  Would remove Hermes hook config from:");
+      for (const line of hermesConfigTargetLines(target === "hermes" ? opts : {})) console.log(`    ${line}`);
+      console.log(`  Would remove Hermes metadata from: ${configPath()}`);
+    }
     return;
   }
 
   if (!opts.y && process.stdin.isTTY) {
     const prompt = target === "all"
-      ? "Remove AgentLog Claude hook, Codex hook, and config? [y/N]: "
+      ? "Remove AgentLog Claude hook, Codex hook, Hermes metadata, and config? [y/N]: "
       : target === "codex"
         ? "Remove AgentLog Codex hook and legacy notify integration? [y/N]: "
-        : "Remove AgentLog hook and config? [y/N]: ";
+        : target === "hermes"
+          ? "Remove AgentLog Hermes metadata? [y/N]: "
+          : "Remove AgentLog hook and config? [y/N]: ";
     const answer = await ask(prompt);
     if (answer.toLowerCase() !== "y") {
       console.log("Aborted.");
@@ -710,13 +754,21 @@ async function cmdUninstall(opts: { y: boolean; codex: boolean; all: boolean; dr
     }
   }
 
+  preflightProviderUninstall(target, target === "hermes" ? opts : {});
+
   if (target === "codex") {
     uninstallCodex(true);
     return;
   }
 
+  if (target === "hermes") {
+    uninstallHermes(opts);
+    return;
+  }
+
   if (target === "all") {
     uninstallCodex(false);
+    uninstallHermes();
   } else {
     // Check if Codex hook is still registered
     const codexHookState = readCodexHookState();
@@ -771,15 +823,17 @@ const SCHEMA_DATA = {
   commands: [
     {
       name: "init",
-      description: "Configure Claude hook, Codex hook, or both",
+      description: "Configure Claude hook, Codex hook, or Hermes hook",
       arguments: [{ name: "vault", description: "Path to Obsidian vault or plain folder", required: false }],
       options: [
         { flags: "--plain", description: "Write to plain folder without Obsidian timeblock parsing" },
         { flags: "--claude", description: "Register Claude Code hook only (default)" },
         { flags: "--codex", description: "Register Codex hook only" },
+        { flags: "--hermes", description: "Register Hermes shell hook and record metadata" },
+        { flags: "--hermes-profile <profile>", description: "Register a named Hermes profile config (repeatable)" },
+        { flags: "--hermes-all-profiles", description: "Register default plus every existing Hermes profile config" },
         { flags: "--all", description: "Register both Claude hook and Codex hook" },
         { flags: "--dry-run", description: "Show what would happen without making changes" },
-        { flags: "--format <format>", description: "Output format: text or json" },
       ],
     },
     {
@@ -809,14 +863,16 @@ const SCHEMA_DATA = {
     },
     {
       name: "uninstall",
-      description: "Remove Claude hook, Codex hook, or both",
+      description: "Remove Claude hook, Codex hook, Hermes hook, or all integrations",
       arguments: [],
       options: [
         { flags: "-y", description: "Skip confirmation prompt" },
         { flags: "--codex", description: "Remove Codex hook and legacy notify integration" },
+        { flags: "--hermes", description: "Remove Hermes hook config and metadata" },
+        { flags: "--hermes-profile <profile>", description: "Remove a named Hermes profile config hook (repeatable)" },
+        { flags: "--hermes-all-profiles", description: "Remove default plus every existing Hermes profile config hook" },
         { flags: "--all", description: "Remove Claude hook, Codex hook, legacy notify, and config" },
         { flags: "--dry-run", description: "Show what would happen without making changes" },
-        { flags: "--format <format>", description: "Output format: text or json" },
       ],
     },
     {
@@ -853,7 +909,9 @@ const SCHEMA_DATA = {
       name: "hook",
       description: "Run hook (called by Claude Code or Codex UserPromptSubmit)",
       arguments: [],
-      options: [],
+      options: [
+        { flags: "--source <source>", description: "Source to record: claude, codex, or hermes" },
+      ],
     },
     {
       name: "codex-notify",
@@ -908,14 +966,16 @@ Options:
 
 program
   .command("init [vault]")
-  .description("Configure Claude hook, Codex hook, or both")
+  .description("Configure Claude hook, Codex hook, or Hermes hook")
   .option("--plain", "Write to plain folder without Obsidian timeblock parsing", false)
   .option("--claude", "Register Claude Code hook only (default)", false)
   .option("--codex", "Register Codex hook only", false)
+  .option("--hermes", "Register Hermes shell hook and record metadata", false)
+  .option("--hermes-profile <profile>", "Register a named Hermes profile config (repeatable)", (value: string, previous: string[]) => [...previous, value], [])
+  .option("--hermes-all-profiles", "Register default plus every existing Hermes profile config", false)
   .option("--all", "Register both Claude hook and Codex hook", false)
   .option("--dry-run", "Show what would happen without making changes", false)
-  .option("--format <format>", "Output format: text or json", "text")
-  .action(async (vault: string | undefined, opts: { plain: boolean; claude: boolean; codex: boolean; all: boolean; dryRun: boolean; format: string }) => {
+  .action(async (vault: string | undefined, opts: { plain: boolean; claude: boolean; codex: boolean; hermes: boolean; all: boolean; dryRun: boolean; hermesProfile?: string[]; hermesAllProfiles?: boolean }) => {
     await cmdInit(vault, opts);
   });
 
@@ -953,13 +1013,15 @@ program
 
 program
   .command("uninstall")
-  .description("Remove Claude hook, Codex hook, or both")
+  .description("Remove Claude hook, Codex hook, Hermes hook, or all integrations")
   .option("-y", "Skip confirmation prompt", false)
   .option("--codex", "Remove Codex hook and legacy notify integration", false)
+  .option("--hermes", "Remove Hermes hook config and metadata", false)
+  .option("--hermes-profile <profile>", "Remove a named Hermes profile config hook (repeatable)", (value: string, previous: string[]) => [...previous, value], [])
+  .option("--hermes-all-profiles", "Remove default plus every existing Hermes profile config hook", false)
   .option("--all", "Remove Claude hook, Codex hook, legacy notify, and config", false)
   .option("--dry-run", "Show what would happen without making changes", false)
-  .option("--format <format>", "Output format: text or json", "text")
-  .action(async (opts: { y: boolean; codex: boolean; all: boolean; dryRun: boolean; format: string }) => {
+  .action(async (opts: { y: boolean; codex: boolean; hermes: boolean; all: boolean; dryRun: boolean; hermesProfile?: string[]; hermesAllProfiles?: boolean }) => {
     await cmdUninstall(opts);
   });
 
@@ -994,8 +1056,8 @@ program
 program
   .command("hook")
   .description("Run hook (called by Claude Code or Codex UserPromptSubmit)")
-  .option("--source <source>", "Source to record: claude or codex", "claude")
-  .action(async (opts: { source: "claude" | "codex" }) => {
+  .option("--source <source>", "Source to record: claude, codex, or hermes", "claude")
+  .action(async (opts: { source: "claude" | "codex" | "hermes" }) => {
     await cmdHook(opts.source);
   });
 
@@ -1020,10 +1082,9 @@ program.on("command:*", (operands: string[]) => {
   process.exit(1);
 });
 
-await program.parseAsync(process.argv);
-
-// If no subcommand was invoked, print help and exit 0
 if (!process.argv.slice(2).length) {
   program.outputHelp();
   process.exit(0);
 }
+
+await program.parseAsync(process.argv);

--- a/src/codex-hooks.ts
+++ b/src/codex-hooks.ts
@@ -232,7 +232,19 @@ export function inspectCodexHookState(json: string): CodexHookState {
 }
 
 export function hasAgentlogCodexHook(json: string): boolean {
-  return inspectCodexHookState(json).kind === "registered";
+  let root: Record<string, unknown>;
+  try {
+    root = parseHooksJson(json);
+  } catch {
+    return false;
+  }
+
+  if (typeof root["hooks"] !== "object" || root["hooks"] === null || Array.isArray(root["hooks"])) {
+    return false;
+  }
+
+  const userPromptSubmit = (root["hooks"] as Record<string, unknown>)["UserPromptSubmit"];
+  return Array.isArray(userPromptSubmit) && userPromptSubmit.some(isAgentlogCodexHookEntry);
 }
 
 function readCodexHooksJson(): string {

--- a/src/codex-hooks.ts
+++ b/src/codex-hooks.ts
@@ -5,6 +5,7 @@ import { join } from "path";
 export const CODEX_HOOKS_PATH = join(homedir(), ".codex", "hooks.json");
 export const CODEX_HOOKS_BACKUP_PATH = join(homedir(), ".codex", "hooks.json.bak");
 export const AGENTLOG_CODEX_HOOK_COMMAND = "agentlog hook --source codex";
+export const LEGACY_AGENTLOG_CODEX_HOOK_COMMAND = "agentlog hook";
 
 export const CODEX_HOOK_ENTRY = {
   hooks: [
@@ -23,6 +24,7 @@ export interface CodexHookMutationResult {
 export type CodexHookState =
   | { kind: "missing" }
   | { kind: "registered" }
+  | { kind: "needs_migration"; reason: string }
   | { kind: "unsupported"; reason: string };
 
 function parseHooksJson(json: string): Record<string, unknown> {
@@ -60,6 +62,24 @@ function isAgentlogCodexHookHandler(hook: unknown): boolean {
   );
 }
 
+function isLegacyAgentlogCodexHookHandler(hook: unknown): boolean {
+  return (
+    typeof hook === "object" &&
+    hook !== null &&
+    (hook as Record<string, unknown>)["type"] === "command" &&
+    (hook as Record<string, unknown>)["command"] === LEGACY_AGENTLOG_CODEX_HOOK_COMMAND
+  );
+}
+
+function hasLegacyAgentlogCodexHookEntry(entry: unknown): boolean {
+  return (
+    typeof entry === "object" &&
+    entry !== null &&
+    Array.isArray((entry as Record<string, unknown>)["hooks"]) &&
+    ((entry as Record<string, unknown>)["hooks"] as unknown[]).some(isLegacyAgentlogCodexHookHandler)
+  );
+}
+
 function ensureHookArray(root: Record<string, unknown>): unknown[] {
   if (root["hooks"] === undefined) {
     root["hooks"] = {};
@@ -79,36 +99,35 @@ function ensureHookArray(root: Record<string, unknown>): unknown[] {
   return hooks["UserPromptSubmit"] as unknown[];
 }
 
-function formatHooksJson(root: Record<string, unknown>): string {
-  return `${JSON.stringify(root, null, 2)}\n`;
-}
-
-export function installCodexHook(json: string): CodexHookMutationResult {
-  const root = parseHooksJson(json);
-  const userPromptSubmit = ensureHookArray(root);
-
-  if (userPromptSubmit.some(isAgentlogCodexHookEntry)) {
-    return { json, changed: false };
+function pruneUserPromptSubmitState(root: Record<string, unknown>): void {
+  if (typeof root["state"] !== "object" || root["state"] === null || Array.isArray(root["state"])) {
+    return;
   }
 
-  userPromptSubmit.push(CODEX_HOOK_ENTRY);
-  return { json: formatHooksJson(root), changed: true };
+  const state = root["state"] as Record<string, unknown>;
+  for (const key of Object.keys(state)) {
+    if (key.includes(":user_prompt_submit:")) {
+      delete state[key];
+    }
+  }
+  if (Object.keys(state).length === 0) {
+    delete root["state"];
+  }
 }
 
-export function uninstallCodexHook(json: string): CodexHookMutationResult {
-  const root = parseHooksJson(json);
-  if (root["hooks"] === undefined) return { json, changed: false };
+function removeAgentlogHandlers(root: Record<string, unknown>, options: { current: boolean; legacy: boolean }): boolean {
+  if (root["hooks"] === undefined) return false;
   if (typeof root["hooks"] !== "object" || root["hooks"] === null || Array.isArray(root["hooks"])) {
     throw new Error("Unsupported Codex hooks configuration: hooks must be an object");
   }
 
   const hooks = root["hooks"] as Record<string, unknown>;
-  if (hooks["UserPromptSubmit"] === undefined) return { json, changed: false };
+  if (hooks["UserPromptSubmit"] === undefined) return false;
   if (!Array.isArray(hooks["UserPromptSubmit"])) {
     throw new Error("Unsupported Codex hooks configuration: hooks.UserPromptSubmit must be an array");
   }
 
-  let removedAgentlogHandler = false;
+  let removed = false;
   const before = hooks["UserPromptSubmit"] as unknown[];
   const after = before.flatMap((entry) => {
     if (
@@ -121,13 +140,18 @@ export function uninstallCodexHook(json: string): CodexHookMutationResult {
 
     const hookGroup = entry as Record<string, unknown>;
     const handlers = hookGroup["hooks"] as unknown[];
-    const nextHandlers = handlers.filter((handler) => !isAgentlogCodexHookHandler(handler));
+    const nextHandlers = handlers.filter((handler) => {
+      const shouldRemove =
+        (options.current && isAgentlogCodexHookHandler(handler)) ||
+        (options.legacy && isLegacyAgentlogCodexHookHandler(handler));
+      if (shouldRemove) removed = true;
+      return !shouldRemove;
+    });
     if (nextHandlers.length === handlers.length) return [entry];
-    removedAgentlogHandler = true;
     if (nextHandlers.length === 0) return [];
     return [{ ...hookGroup, hooks: nextHandlers }];
   });
-  if (!removedAgentlogHandler) return { json, changed: false };
+  if (!removed) return false;
 
   if (after.length === 0) {
     delete hooks["UserPromptSubmit"];
@@ -138,6 +162,32 @@ export function uninstallCodexHook(json: string): CodexHookMutationResult {
   if (Object.keys(hooks).length === 0) {
     delete root["hooks"];
   }
+  pruneUserPromptSubmitState(root);
+
+  return true;
+}
+
+function formatHooksJson(root: Record<string, unknown>): string {
+  return `${JSON.stringify(root, null, 2)}\n`;
+}
+
+export function installCodexHook(json: string): CodexHookMutationResult {
+  const root = parseHooksJson(json);
+  const removedLegacy = removeAgentlogHandlers(root, { current: false, legacy: true });
+  const userPromptSubmit = ensureHookArray(root);
+
+  if (userPromptSubmit.some(isAgentlogCodexHookEntry)) {
+    return removedLegacy ? { json: formatHooksJson(root), changed: true } : { json, changed: false };
+  }
+
+  userPromptSubmit.push(CODEX_HOOK_ENTRY);
+  return { json: formatHooksJson(root), changed: true };
+}
+
+export function uninstallCodexHook(json: string): CodexHookMutationResult {
+  const root = parseHooksJson(json);
+  const removed = removeAgentlogHandlers(root, { current: true, legacy: true });
+  if (!removed) return { json, changed: false };
 
   if (Object.keys(root).length === 0) {
     return { json: "", changed: true };
@@ -168,7 +218,17 @@ export function inspectCodexHookState(json: string): CodexHookState {
     };
   }
 
-  return userPromptSubmit.some(isAgentlogCodexHookEntry) ? { kind: "registered" } : { kind: "missing" };
+  const hasCurrent = userPromptSubmit.some(isAgentlogCodexHookEntry);
+  const hasLegacy = userPromptSubmit.some(hasLegacyAgentlogCodexHookEntry);
+  if (hasLegacy) {
+    return {
+      kind: "needs_migration",
+      reason: hasCurrent
+        ? "legacy AgentLog Codex hook remains beside the current hook"
+        : "legacy AgentLog Codex hook must be migrated to --source codex",
+    };
+  }
+  return hasCurrent ? { kind: "registered" } : { kind: "missing" };
 }
 
 export function hasAgentlogCodexHook(json: string): boolean {

--- a/src/codex-notify.ts
+++ b/src/codex-notify.ts
@@ -7,8 +7,10 @@ import { prettyPrompt } from "./schema/pretty-prompt.js";
 import {
   ENGLISHASK_GUARD_ENV,
   appendEnglishAskFeedback,
+  buildEnglishAskContext,
   englishAskSuggestion,
   evaluateEnglishAsk,
+  shouldEvaluateEnglishAsk,
 } from "./english-ask.js";
 
 function readStdin(): Promise<string> {
@@ -71,12 +73,19 @@ export async function runCodexNotify(rawArg?: string): Promise<void> {
       now
     );
 
-    const feedback = evaluateEnglishAsk(config, parsed.prompt, parsed.cwd);
-    if (feedback) {
+    if (shouldEvaluateEnglishAsk(config, parsed.prompt)) {
       try {
-        appendEnglishAskFeedback(result.filePath, feedback, entry, config);
-        const suggestion = englishAskSuggestion(config, feedback);
-        if (suggestion) process.stderr.write(suggestion);
+        const noteContext = buildEnglishAskContext(result.filePath, entry);
+        const assistantContext = parsed.lastAssistantMessage
+          ? `assistant: ${parsed.lastAssistantMessage}`
+          : null;
+        const context = [noteContext, assistantContext].filter(Boolean).join("\n") || null;
+        const feedback = evaluateEnglishAsk(config, parsed.prompt, parsed.cwd, context);
+        if (feedback) {
+          appendEnglishAskFeedback(result.filePath, feedback, entry, config);
+          const suggestion = englishAskSuggestion(config, feedback);
+          if (suggestion) process.stderr.write(suggestion);
+        }
       } catch {
         // EnglishAsk is best-effort; the normal AgentLog entry is already written.
       }

--- a/src/english-ask.ts
+++ b/src/english-ask.ts
@@ -1,13 +1,23 @@
-import { existsSync, readFileSync, statSync, writeFileSync } from "fs";
+import { closeSync, existsSync, openSync, readFileSync, readSync, statSync, writeFileSync } from "fs";
 import { spawnSync } from "child_process";
-import type { AgentLogConfig, EnglishAskFeedback } from "./types.js";
+import { StringDecoder } from "string_decoder";
+import type { AgentLogConfig, EnglishAskFeedback, SourceType } from "./types.js";
 
 export const ENGLISHASK_GUARD_ENV = "AGENTLOG_ENGLISHASK_EVAL";
 
-const DEFAULT_TIMEOUT_MS = 8_000;
+const DEFAULT_EVALUATOR_COMMAND = ["codex", "exec", "--ignore-user-config", "--ephemeral", "-"];
+const DEFAULT_TIMEOUT_MS = 20_000;
 const DEFAULT_THRESHOLD = 3;
 const DEFAULT_MAX_PROMPT_CHARS = 2_000;
+const DEFAULT_MAX_CONTEXT_CHARS = 4_000;
 const DEFAULT_MAX_OUTPUT_CHARS = 4_000;
+const DEFAULT_CONTEXT_TURNS = 12;
+
+type RawJson = Record<string, unknown>;
+type ContextTurn = {
+  role: "user" | "assistant";
+  text: string;
+};
 
 function configured(config: AgentLogConfig): boolean {
   return config.englishAsk?.enabled === true;
@@ -32,8 +42,125 @@ function redact(value: string): string {
     .replace(/(Bearer\s+)[A-Za-z0-9._-]{12,}/gi, "$1[redacted-token]");
 }
 
-function buildEvaluatorPrompt(prompt: string): string {
-  return `Evaluate this Codex user prompt for answerability from prior context, not grammar.
+function parseJsonLine(line: string): RawJson | null {
+  if (!line) return null;
+  try {
+    const parsed = JSON.parse(line);
+    return typeof parsed === "object" && parsed !== null ? parsed as RawJson : null;
+  } catch {
+    return null;
+  }
+}
+
+function* readJsonLines(filePath: string): Generator<RawJson> {
+  if (!existsSync(filePath)) return;
+
+  const fd = openSync(filePath, "r");
+  const decoder = new StringDecoder("utf-8");
+  const buffer = Buffer.alloc(64 * 1024);
+  let carry = "";
+
+  try {
+    while (true) {
+      const bytes = readSync(fd, buffer, 0, buffer.length, null);
+      if (bytes === 0) break;
+      carry += decoder.write(buffer.subarray(0, bytes));
+
+      let newlineIndex = carry.indexOf("\n");
+      while (newlineIndex >= 0) {
+        const parsed = parseJsonLine(carry.slice(0, newlineIndex));
+        if (parsed) yield parsed;
+        carry = carry.slice(newlineIndex + 1);
+        newlineIndex = carry.indexOf("\n");
+      }
+    }
+
+    carry += decoder.end();
+    const parsed = parseJsonLine(carry);
+    if (parsed) yield parsed;
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function textFromParts(value: unknown): string | null {
+  if (typeof value === "string") return value;
+  if (!Array.isArray(value)) return null;
+  const parts = value
+    .filter((part): part is RawJson => typeof part === "object" && part !== null)
+    .filter((part) =>
+      ["text", "input_text", "output_text"].includes(String(part["type"])) &&
+      typeof part["text"] === "string"
+    )
+    .map((part) => part["text"] as string);
+  return parts.length > 0 ? parts.join("\n") : null;
+}
+
+function compactTurnText(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function pushTurn(turns: ContextTurn[], role: ContextTurn["role"], raw: unknown): void {
+  const text = typeof raw === "string" ? raw : textFromParts(raw);
+  const compact = text ? compactTurnText(text) : "";
+  if (!compact) return;
+  const last = turns[turns.length - 1];
+  if (last?.role === role && last.text === compact) return;
+  turns.push({ role, text: compact });
+}
+
+function codexTranscriptTurns(line: RawJson): ContextTurn[] {
+  const payload = line["payload"];
+  if (typeof payload !== "object" || payload === null) return [];
+  const p = payload as RawJson;
+
+  if (line["type"] === "event_msg" && p["type"] === "user_message") {
+    const message = typeof p["message"] === "string" ? p["message"] : null;
+    return message ? [{ role: "user", text: compactTurnText(message) }] : [];
+  }
+  if (line["type"] === "event_msg" && p["type"] === "agent_message") {
+    const message = typeof p["message"] === "string" ? p["message"] : null;
+    return message ? [{ role: "assistant", text: compactTurnText(message) }] : [];
+  }
+  if (line["type"] === "response_item" && p["type"] === "message" && p["role"] === "assistant") {
+    const text = textFromParts(p["content"]);
+    return text ? [{ role: "assistant", text: compactTurnText(text) }] : [];
+  }
+  return [];
+}
+
+function claudeTranscriptTurns(line: RawJson): ContextTurn[] {
+  if (line["isSidechain"] === true) return [];
+  if (line["type"] !== "user" && line["type"] !== "assistant") return [];
+  const message = line["message"];
+  if (typeof message !== "object" || message === null) return [];
+  const m = message as RawJson;
+  if (m["role"] !== "user" && m["role"] !== "assistant") return [];
+  const role = m["role"] as ContextTurn["role"];
+  const text = textFromParts(m["content"]);
+  return text ? [{ role, text: compactTurnText(text) }] : [];
+}
+
+function buildTranscriptContext(transcriptPath: string | undefined, maxTurns = DEFAULT_CONTEXT_TURNS): string | null {
+  if (!transcriptPath || !existsSync(transcriptPath)) return null;
+  const turns: ContextTurn[] = [];
+  for (const line of readJsonLines(transcriptPath)) {
+    for (const turn of [...codexTranscriptTurns(line), ...claudeTranscriptTurns(line)]) {
+      pushTurn(turns, turn.role, turn.text);
+      if (turns.length > maxTurns) {
+        turns.splice(0, turns.length - maxTurns);
+      }
+    }
+  }
+  const context = turns
+    .map((turn) => `${turn.role}: ${turn.text}`)
+    .join("\n")
+    .trim();
+  return context || null;
+}
+
+function buildEvaluatorPrompt(prompt: string, context: string | null): string {
+  return `Evaluate this AgentLog user prompt for answerability from prior context, not grammar.
 
 Score rubric:
 5: directly answerable
@@ -47,6 +174,9 @@ Score: N/5
 Natural version: ...
 Missing context: ...
 Rewrite with: ...
+
+Prior user/model context:
+${context || "(none)"}
 
 User prompt:
 ${prompt}`;
@@ -71,19 +201,26 @@ export function shouldEvaluateEnglishAsk(config: AgentLogConfig, prompt: string)
   return looksLikeEnglish(prompt);
 }
 
-export function evaluateEnglishAsk(config: AgentLogConfig, prompt: string, cwd: string): EnglishAskFeedback | null {
+export function evaluateEnglishAsk(
+  config: AgentLogConfig,
+  prompt: string,
+  cwd: string,
+  context: string | null = null
+): EnglishAskFeedback | null {
   if (!shouldEvaluateEnglishAsk(config, prompt)) return null;
 
   const englishAsk = config.englishAsk ?? {};
   const timeoutMs = englishAsk.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const maxPromptChars = englishAsk.maxPromptChars ?? DEFAULT_MAX_PROMPT_CHARS;
+  const maxContextChars = englishAsk.maxContextChars ?? DEFAULT_MAX_CONTEXT_CHARS;
   const maxOutputChars = englishAsk.maxOutputChars ?? DEFAULT_MAX_OUTPUT_CHARS;
-  const command = englishAsk.evaluatorCommand ?? ["codex", "exec", "-"];
+  const command = englishAsk.evaluatorCommand ?? DEFAULT_EVALUATOR_COMMAND;
   const [bin, ...args] = command;
   if (!bin) return null;
 
   const sanitizedPrompt = truncate(redact(prompt), maxPromptChars);
-  const input = buildEvaluatorPrompt(sanitizedPrompt);
+  const sanitizedContext = context ? truncate(redact(context), maxContextChars) : null;
+  const input = buildEvaluatorPrompt(sanitizedPrompt, sanitizedContext);
 
   try {
     const result = spawnSync(bin, args, {
@@ -113,6 +250,35 @@ export function evaluateEnglishAsk(config: AgentLogConfig, prompt: string, cwd: 
   } catch {
     return null;
   }
+}
+
+function sessionPromptLines(lines: string[], entry: { sessionId: string; source?: SourceType }): string[] {
+  const source = entry.source ?? "codex";
+  const divider = `- - - - [[${source}_${entry.sessionId}]]`;
+  const start = lines.lastIndexOf(divider);
+  if (start === -1) return [];
+
+  const prompts: string[] = [];
+  for (let i = start + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.startsWith("- - - - [[") || line.startsWith("#### ") || /^## [^#]/.test(line)) break;
+    if (/^- \d{2}:\d{2} /.test(line)) prompts.push(line.slice(2));
+  }
+  return prompts;
+}
+
+export function buildEnglishAskContext(
+  filePath: string,
+  entry: { sessionId: string; source?: SourceType; transcriptPath?: string },
+  maxLines = 8
+): string | null {
+  const transcriptContext = buildTranscriptContext(entry.transcriptPath);
+  if (transcriptContext) return transcriptContext;
+
+  if (!existsSync(filePath)) return null;
+  const lines = readFileSync(filePath, "utf-8").split("\n");
+  const context = sessionPromptLines(lines, entry).slice(-maxLines).join("\n").trim();
+  return context || null;
 }
 
 export function englishAskSuggestion(config: AgentLogConfig, feedback: EnglishAskFeedback): string | null {
@@ -159,7 +325,7 @@ function insertFeedbackBlock(content: string, block: string): string {
 export function appendEnglishAskFeedback(
   filePath: string,
   feedback: EnglishAskFeedback,
-  entry: { time: string; project: string; cwd: string; sessionId: string },
+  entry: { time: string; project: string; cwd: string; sessionId: string; source?: SourceType },
   config: AgentLogConfig
 ): void {
   const mode = config.englishAsk?.mode ?? "log-only";
@@ -172,7 +338,7 @@ export function appendEnglishAskFeedback(
   const block = [
     `### ${entry.time} · ${entry.project}`,
     `<!-- cwd=${entry.cwd} -->`,
-    `- session: [[codex_${entry.sessionId}]]`,
+    `- session: [[${entry.source ?? "codex"}_${entry.sessionId}]]`,
     `- score: ${scoreText}`,
     `- prompt: ${listItemValue(feedback.prompt)}`,
     `${rewriteHint}`,

--- a/src/hermes-config.ts
+++ b/src/hermes-config.ts
@@ -1,0 +1,283 @@
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "fs";
+import { homedir } from "os";
+import { dirname, join } from "path";
+import { YAMLMap, YAMLSeq, isMap, isScalar, isSeq, parseDocument, type Document, type Node } from "yaml";
+
+export const AGENTLOG_HERMES_HOOK_COMMAND = "agentlog hook --source hermes";
+
+export interface HermesConfigTarget {
+  profile: string;
+  path: string;
+}
+
+export interface HermesTargetResult extends HermesConfigTarget {
+  changed: boolean;
+}
+
+export interface HermesConfigTargetOptions {
+  homeDir?: string;
+  hermesHome?: string;
+  profiles?: string[];
+  allProfiles?: boolean;
+  command?: string;
+}
+
+export interface HermesConfigMutationResult {
+  changed: boolean;
+  targets: HermesTargetResult[];
+}
+
+export type HermesHookState =
+  | { kind: "missing"; targets: HermesConfigTarget[] }
+  | { kind: "registered"; targets: HermesConfigTarget[] }
+  | { kind: "partial"; registered: HermesConfigTarget[]; missing: HermesConfigTarget[] }
+  | { kind: "unsupported"; reason: string; targets: HermesConfigTarget[] };
+
+export const HERMES_CONFIG_PATH = join(homedir(), ".hermes", "config.yaml");
+type HermesDocument = Document<Node, false>;
+type HermesMap = YAMLMap<unknown, Node>;
+type HermesSeq = YAMLSeq<Node>;
+
+function homeFromOptions(options: HermesConfigTargetOptions): string {
+  return options.homeDir ?? homedir();
+}
+
+function defaultHermesRoot(options: HermesConfigTargetOptions): string {
+  return join(homeFromOptions(options), ".hermes");
+}
+
+function currentHermesHome(options: HermesConfigTargetOptions): string {
+  return options.hermesHome ?? process.env.HERMES_HOME ?? defaultHermesRoot(options);
+}
+
+function normalizeProfiles(profiles: string[] | undefined): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const profile of profiles ?? []) {
+    const trimmed = profile.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    result.push(trimmed);
+  }
+  return result;
+}
+
+function hookCommand(options: HermesConfigTargetOptions): string {
+  return options.command?.trim() || AGENTLOG_HERMES_HOOK_COMMAND;
+}
+
+export function resolveHermesConfigTargets(options: HermesConfigTargetOptions = {}): HermesConfigTarget[] {
+  const root = currentHermesHome(options);
+  const profiles = normalizeProfiles(options.profiles);
+
+  if (options.allProfiles) {
+    const targets: HermesConfigTarget[] = [{ profile: "default", path: join(root, "config.yaml") }];
+    const profilesRoot = join(root, "profiles");
+    if (existsSync(profilesRoot)) {
+      for (const name of readdirSync(profilesRoot).sort()) {
+        const profilePath = join(profilesRoot, name);
+        const configPath = join(profilePath, "config.yaml");
+        let isDirectory = false;
+        try {
+          isDirectory = statSync(profilePath).isDirectory();
+        } catch {
+          continue;
+        }
+        if (isDirectory && existsSync(configPath)) {
+          targets.push({ profile: name, path: configPath });
+        }
+      }
+    }
+    return targets;
+  }
+
+  if (profiles.length > 0) {
+    return profiles.map((profile) => {
+      if (profile === "default") return { profile, path: join(root, "config.yaml") };
+      return { profile, path: join(root, "profiles", profile, "config.yaml") };
+    });
+  }
+
+  return [{ profile: "default", path: join(currentHermesHome(options), "config.yaml") }];
+}
+
+export function hermesManualSetupSnippet(): string {
+  return [
+    "hooks:",
+    "  pre_llm_call:",
+    `    - command: "${AGENTLOG_HERMES_HOOK_COMMAND}"`,
+  ].join("\n");
+}
+
+function loadConfigDocument(path: string): HermesDocument {
+  if (!existsSync(path)) {
+    const doc = parseDocument<Node, false>("");
+    doc.contents = new YAMLMap() as Node;
+    return doc;
+  }
+
+  const content = readFileSync(path, "utf-8");
+  const doc = parseDocument<Node, false>(content || "");
+  if (doc.errors.length > 0) {
+    throw new Error(`Unsupported Hermes config: ${doc.errors[0]?.message ?? "invalid YAML"}`);
+  }
+  if (doc.contents === null) {
+    doc.contents = new YAMLMap() as Node;
+  }
+  if (!isMap(doc.contents)) {
+    throw new Error("Unsupported Hermes config: config.yaml must be a YAML object");
+  }
+  return doc;
+}
+
+function writeConfigDocument(path: string, doc: HermesDocument): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, String(doc), "utf-8");
+}
+
+function ensureRootMap(doc: HermesDocument): HermesMap {
+  if (doc.contents === null) doc.contents = new YAMLMap() as Node;
+  if (!isMap(doc.contents)) {
+    throw new Error("Unsupported Hermes config: config.yaml must be a YAML object");
+  }
+  return doc.contents as HermesMap;
+}
+
+function ensurePreLlmHookList(doc: HermesDocument): HermesSeq {
+  const root = ensureRootMap(doc);
+  let hooks = root.get("hooks", true) as Node | undefined | null;
+  if (hooks === undefined || hooks === null) {
+    hooks = new YAMLMap() as Node;
+    root.set("hooks", hooks);
+  }
+  if (!isMap(hooks)) {
+    throw new Error("Unsupported Hermes config: hooks must be an object");
+  }
+  const hooksMap = hooks as HermesMap;
+  let preLlmCall = hooksMap.get("pre_llm_call", true) as Node | undefined | null;
+  if (preLlmCall === undefined || preLlmCall === null) {
+    preLlmCall = new YAMLSeq() as Node;
+    hooksMap.set("pre_llm_call", preLlmCall);
+  }
+  if (!isSeq(preLlmCall)) {
+    throw new Error("Unsupported Hermes config: hooks.pre_llm_call must be an array");
+  }
+  return preLlmCall as HermesSeq;
+}
+
+function entryCommand(entry: unknown): string | null {
+  if (isScalar(entry)) return typeof entry.value === "string" ? entry.value : null;
+  if (!isMap(entry)) return null;
+  const command = entry.get("command", true);
+  if (typeof command === "string") return command;
+  return isScalar(command) && typeof command.value === "string" ? command.value : null;
+}
+
+function isAgentlogHookCommand(command: string, desiredCommand: string): boolean {
+  const trimmed = command.trim();
+  const unquotedAgentlogSuffix = /(?:^|\s)(?:"[^"]*\/agentlog"|'[^']*\/agentlog'|[^'" ]*\/agentlog) hook --source hermes$/;
+  return (
+    trimmed === desiredCommand ||
+    trimmed === AGENTLOG_HERMES_HOOK_COMMAND ||
+    trimmed.endsWith(`/agentlog hook --source hermes`) ||
+    unquotedAgentlogSuffix.test(trimmed)
+  );
+}
+
+function hasDesiredAgentlogHook(list: HermesSeq, desiredCommand: string): boolean {
+  return list.items.some((entry) => entryCommand(entry) === desiredCommand);
+}
+
+export function registerHermesHook(options: HermesConfigTargetOptions = {}): HermesConfigMutationResult {
+  const targets = resolveHermesConfigTargets(options);
+  const command = hookCommand(options);
+  const results: HermesTargetResult[] = [];
+
+  for (const target of targets) {
+    const doc = loadConfigDocument(target.path);
+    const preLlmCall = ensurePreLlmHookList(doc);
+    const withoutStaleAgentlog = preLlmCall.items.filter((entry) => {
+      const existingCommand = entryCommand(entry);
+      return existingCommand === null || !isAgentlogHookCommand(existingCommand, command) || existingCommand === command;
+    });
+    const removedStale = withoutStaleAgentlog.length !== preLlmCall.items.length;
+    if (removedStale) {
+      preLlmCall.items.splice(0, preLlmCall.items.length, ...withoutStaleAgentlog);
+    }
+    const needsAdd = !hasDesiredAgentlogHook(preLlmCall, command);
+    const changed = removedStale || needsAdd;
+    if (changed) {
+      if (needsAdd) preLlmCall.items.push(doc.createNode({ command }));
+      writeConfigDocument(target.path, doc);
+    }
+    results.push({ ...target, changed });
+  }
+
+  return {
+    changed: results.some((target) => target.changed),
+    targets: results,
+  };
+}
+
+export function unregisterHermesHook(options: HermesConfigTargetOptions = {}): HermesConfigMutationResult {
+  const targets = resolveHermesConfigTargets(options);
+  const command = hookCommand(options);
+  const results: HermesTargetResult[] = [];
+
+  for (const target of targets) {
+    if (!existsSync(target.path)) {
+      results.push({ ...target, changed: false });
+      continue;
+    }
+    const doc = loadConfigDocument(target.path);
+    const preLlmCall = ensurePreLlmHookList(doc);
+    const next = preLlmCall.items.filter((entry) => {
+      const existingCommand = entryCommand(entry);
+      return existingCommand === null || !isAgentlogHookCommand(existingCommand, command);
+    });
+    const changed = next.length !== preLlmCall.items.length;
+    if (changed) {
+      preLlmCall.items.splice(0, preLlmCall.items.length, ...next);
+      writeConfigDocument(target.path, doc);
+    }
+    results.push({ ...target, changed });
+  }
+
+  return {
+    changed: results.some((target) => target.changed),
+    targets: results,
+  };
+}
+
+export function readHermesHookState(options: HermesConfigTargetOptions = {}): HermesHookState {
+  const targets = resolveHermesConfigTargets(options);
+  const command = hookCommand(options);
+  const registered: HermesConfigTarget[] = [];
+  const missing: HermesConfigTarget[] = [];
+
+  for (const target of targets) {
+    if (!existsSync(target.path)) {
+      missing.push(target);
+      continue;
+    }
+    try {
+      const doc = loadConfigDocument(target.path);
+      const preLlmCall = ensurePreLlmHookList(doc);
+      if (preLlmCall.items.some((entry) => {
+        const existingCommand = entryCommand(entry);
+        return existingCommand !== null && isAgentlogHookCommand(existingCommand, command);
+      })) registered.push(target);
+      else missing.push(target);
+    } catch (err) {
+      return {
+        kind: "unsupported",
+        reason: err instanceof Error ? err.message : String(err),
+        targets,
+      };
+    }
+  }
+
+  if (registered.length === targets.length) return { kind: "registered", targets };
+  if (registered.length > 0) return { kind: "partial", registered, missing };
+  return { kind: "missing", targets };
+}

--- a/src/hook-providers/claude.ts
+++ b/src/hook-providers/claude.ts
@@ -1,0 +1,53 @@
+import { CLAUDE_SETTINGS_PATH, inspectClaudeHookState, registerHook, unregisterHook } from "../claude-settings.js";
+import type { AgentLogConfig } from "../types.js";
+import type { HookProvider } from "./types.js";
+
+export const claudeProvider: HookProvider = {
+  id: "claude",
+  label: "Claude Code",
+  configFlag: "claudeHookInstalled",
+  command: "agentlog hook",
+
+  install() {
+    registerHook();
+    return {
+      changed: true,
+      messages: [`Hook registered: ${CLAUDE_SETTINGS_PATH}`],
+      configPatch: { claudeHookInstalled: true },
+    };
+  },
+
+  uninstall() {
+    const changed = unregisterHook();
+    return {
+      changed,
+      messages: [
+        changed
+          ? `Hook removed: ${CLAUDE_SETTINGS_PATH}`
+          : "Hook not found (already removed or never registered)",
+      ],
+      configPatch: { claudeHookInstalled: undefined },
+    };
+  },
+
+  inspect() {
+    const state = inspectClaudeHookState();
+    if (state.kind === "registered") return { kind: "registered", detail: CLAUDE_SETTINGS_PATH };
+    if (state.kind === "unsupported") {
+      return {
+        kind: "unsupported",
+        detail: `${CLAUDE_SETTINGS_PATH} — ${state.reason}`,
+        repairHint: "run: agentlog init to migrate AgentLog hook, or fix Claude settings",
+      };
+    }
+    return {
+      kind: "missing",
+      detail: "not registered",
+      repairHint: "run: agentlog init to re-register",
+    };
+  },
+
+  isRelevant(config: AgentLogConfig | null) {
+    return config?.claudeHookInstalled === true;
+  },
+};

--- a/src/hook-providers/codex.ts
+++ b/src/hook-providers/codex.ts
@@ -1,0 +1,119 @@
+import { detectBinary } from "../cli-shared.js";
+import {
+  CODEX_HOOKS_PATH,
+  readCodexHookState,
+  registerCodexHook,
+  unregisterCodexHook,
+  type CodexHookMutationResult,
+} from "../codex-hooks.js";
+import { CODEX_CONFIG_PATH, readCodexNotifyState, unregisterCodexNotify } from "../codex-settings.js";
+import type { AgentLogConfig } from "../types.js";
+import type { HookProvider } from "./types.js";
+
+export const codexProvider: HookProvider = {
+  id: "codex",
+  label: "Codex CLI",
+  configFlag: "codexHookInstalled",
+  command: "agentlog hook --source codex",
+
+  preflightInstall() {
+    const codexBin = detectBinary("codex");
+    if (!codexBin) throw new Error("Error: Codex CLI not found in PATH");
+    const state = readCodexHookState();
+    if (state.kind === "unsupported") throw new Error(state.reason);
+  },
+
+  install() {
+    const codexBin = detectBinary("codex");
+    if (!codexBin) throw new Error("Error: Codex CLI not found in PATH");
+
+    const result: CodexHookMutationResult = registerCodexHook();
+    const messages = [
+      `  Codex CLI: ${codexBin}`,
+      `Codex hook registered: ${CODEX_HOOKS_PATH}`,
+    ];
+    if (!result.changed) messages.push("  Existing AgentLog Codex hook left unchanged");
+    return {
+      changed: result.changed,
+      messages,
+      configPatch: { codexHookInstalled: true },
+    };
+  },
+
+  preflightUninstall() {
+    const state = readCodexHookState();
+    if (state.kind === "unsupported") throw new Error(state.reason);
+  },
+
+  uninstall() {
+    const result = unregisterCodexHook();
+    const messages = [
+      result.changed
+        ? `Codex hook removed: ${CODEX_HOOKS_PATH}`
+        : "Codex hook not found (already removed or never registered)",
+    ];
+    return {
+      changed: result.changed,
+      messages,
+      configPatch: { codexHookInstalled: undefined },
+    };
+  },
+
+  inspect() {
+    const state = readCodexHookState();
+    const legacyNotifyState = readCodexNotifyState();
+    if (state.kind === "registered") {
+      return { kind: "registered", detail: `${CODEX_HOOKS_PATH} — hook registered` };
+    }
+    if (state.kind === "unsupported") {
+      return {
+        kind: "unsupported",
+        detail: `${CODEX_HOOKS_PATH} — unsupported hook config (${state.reason})`,
+        repairHint: "fix hooks.json or move it aside, then run: agentlog init --codex",
+      };
+    }
+    if (state.kind === "needs_migration") {
+      return {
+        kind: "needs_migration",
+        detail: `${CODEX_HOOKS_PATH} — ${state.reason}`,
+        repairHint: "run: agentlog init --codex to migrate the Codex hook",
+      };
+    }
+    if (legacyNotifyState.kind === "registered") {
+      return {
+        kind: "missing",
+        detail: `${CODEX_CONFIG_PATH} — legacy notify registered; migrate to hooks`,
+        repairHint: "run: agentlog init --codex to repair or migrate to hooks",
+      };
+    }
+    if (legacyNotifyState.kind === "unsupported") {
+      return {
+        kind: "unsupported",
+        detail: `${CODEX_CONFIG_PATH} — unsupported legacy notify config (${legacyNotifyState.reason})`,
+        repairHint: "simplify legacy notify config or move config.toml aside, then run: agentlog init --codex",
+      };
+    }
+    return {
+      kind: "missing",
+      detail: `${CODEX_HOOKS_PATH} — not registered`,
+      repairHint: "run: agentlog init --codex ~/path/to/vault",
+    };
+  },
+
+  isRelevant(config: AgentLogConfig | null) {
+    const legacyNotifyState = readCodexNotifyState();
+    return (
+      config?.codexHookInstalled === true ||
+      (!!config && Object.prototype.hasOwnProperty.call(config, "codexNotifyRestore")) ||
+      readCodexHookState().kind !== "missing" ||
+      legacyNotifyState.kind !== "missing"
+    );
+  },
+};
+
+export function uninstallLegacyCodexNotify(config: AgentLogConfig | null): string[] {
+  const legacyNotify = unregisterCodexNotify(config?.codexNotifyRestore ?? null);
+  if (!legacyNotify.changed) return [];
+  const action = legacyNotify.restoreNotify && legacyNotify.restoreNotify.length > 0 ? "restored" : "removed";
+  return [`Legacy Codex notify ${action}: ${CODEX_CONFIG_PATH}`];
+}

--- a/src/hook-providers/hermes.ts
+++ b/src/hook-providers/hermes.ts
@@ -1,0 +1,104 @@
+import {
+  AGENTLOG_HERMES_HOOK_COMMAND,
+  type HermesConfigTargetOptions,
+  readHermesHookState,
+  registerHermesHook,
+  unregisterHermesHook,
+} from "../hermes-config.js";
+import type { AgentLogConfig } from "../types.js";
+import type { HookInstallContext, HookProvider } from "./types.js";
+
+function hermesOptions(ctx: Partial<HookInstallContext> | undefined): HermesConfigTargetOptions {
+  return {
+    homeDir: ctx?.homeDir,
+    hermesHome: ctx?.hermesHome,
+    profiles: ctx?.hermesProfiles,
+    allProfiles: ctx?.hermesAllProfiles,
+    command: ctx?.hermesCommand,
+  };
+}
+
+function profilesFromTargets(targets: Array<{ profile: string }>): string[] {
+  return targets.map((target) => target.profile);
+}
+
+function formatTargets(targets: Array<{ profile: string; path: string }>): string {
+  return targets.map((target) => `${target.profile}:${target.path}`).join(", ");
+}
+
+export const hermesProvider: HookProvider = {
+  id: "hermes",
+  label: "Hermes Agent",
+  configFlag: "hermesHookInstalled",
+  command: AGENTLOG_HERMES_HOOK_COMMAND,
+
+  preflightInstall(ctx) {
+    const state = readHermesHookState(hermesOptions(ctx));
+    if (state.kind === "unsupported") throw new Error(state.reason);
+  },
+
+  install(ctx) {
+    const options = hermesOptions(ctx);
+    const result = registerHermesHook(options);
+    return {
+      changed: result.changed,
+      messages: [
+        `Hermes hook registered: ${formatTargets(result.targets)}`,
+        `  ${options.command ?? AGENTLOG_HERMES_HOOK_COMMAND}`,
+      ],
+      configPatch: {
+        hermesHookInstalled: true,
+        ...(ctx.hermesHome ? { hermesHome: ctx.hermesHome } : {}),
+        hermesProfiles: profilesFromTargets(result.targets),
+      },
+    };
+  },
+
+  preflightUninstall(ctx) {
+    const state = readHermesHookState(hermesOptions(ctx));
+    if (state.kind === "unsupported") throw new Error(state.reason);
+  },
+
+  uninstall(ctx) {
+    const result = unregisterHermesHook(hermesOptions(ctx));
+    return {
+      changed: result.changed,
+      messages: [
+        result.changed
+          ? `Hermes hook removed: ${formatTargets(result.targets)}`
+          : `Hermes hook not found: ${formatTargets(result.targets)}`,
+      ],
+      configPatch: { hermesHookInstalled: undefined, hermesHome: undefined, hermesProfiles: undefined },
+    };
+  },
+
+  inspect(ctx) {
+    const state = readHermesHookState(hermesOptions(ctx));
+    if (state.kind === "registered") {
+      return { kind: "registered", detail: `${formatTargets(state.targets)} — hook command present` };
+    }
+    if (state.kind === "unsupported") {
+      return {
+        kind: "unsupported",
+        detail: `${formatTargets(state.targets)} — ${state.reason}`,
+        repairHint: "check Hermes config permissions",
+      };
+    }
+    if (state.kind === "partial") {
+      return {
+        kind: "missing",
+        detail: `registered: ${formatTargets(state.registered)}; missing: ${formatTargets(state.missing)}`,
+        repairHint: "run: agentlog init --hermes to repair Hermes hooks",
+      };
+    }
+    return {
+      kind: "missing",
+      detail: `${formatTargets(state.targets)} — hook command not detected`,
+      repairHint: "run: agentlog init --hermes ~/path/to/vault",
+    };
+  },
+
+  isRelevant(config: AgentLogConfig | null, ctx) {
+    return config?.hermesHookInstalled === true || readHermesHookState(hermesOptions(ctx)).kind !== "missing";
+  },
+};

--- a/src/hook-providers/index.ts
+++ b/src/hook-providers/index.ts
@@ -1,0 +1,26 @@
+import { claudeProvider } from "./claude.js";
+import { codexProvider } from "./codex.js";
+import { hermesProvider } from "./hermes.js";
+import type { HookProvider, HookProviderId, InitTarget, UninstallTarget } from "./types.js";
+
+export type { HookProvider, HookProviderId, InitTarget, UninstallTarget } from "./types.js";
+
+export const hookProviders = {
+  claude: claudeProvider,
+  codex: codexProvider,
+  hermes: hermesProvider,
+} satisfies Record<HookProviderId, HookProvider>;
+
+export function providerById(id: HookProviderId): HookProvider {
+  return hookProviders[id];
+}
+
+export function providersForInitTarget(target: InitTarget): HookProviderId[] {
+  if (target === "all") return ["claude", "codex"];
+  return [target];
+}
+
+export function providersForUninstallTarget(target: UninstallTarget): HookProviderId[] {
+  if (target === "all") return ["claude", "codex", "hermes"];
+  return [target];
+}

--- a/src/hook-providers/types.ts
+++ b/src/hook-providers/types.ts
@@ -1,0 +1,46 @@
+import type { AgentLogConfig } from "../types.js";
+
+export type HookProviderId = "claude" | "codex" | "hermes";
+export type InitTarget = HookProviderId | "all";
+export type UninstallTarget = HookProviderId | "all";
+
+export type HookProviderState =
+  | { kind: "registered"; detail: string }
+  | { kind: "missing"; detail: string; repairHint: string; warnOnly?: boolean }
+  | { kind: "needs_migration"; detail: string; repairHint: string }
+  | { kind: "unsupported"; detail: string; repairHint: string };
+
+export interface HookInstallContext {
+  vault: string;
+  plain: boolean;
+  homeDir?: string;
+  hermesHome?: string;
+  hermesProfiles?: string[];
+  hermesAllProfiles?: boolean;
+  hermesCommand?: string;
+}
+
+export interface HookInstallResult {
+  changed: boolean;
+  messages: string[];
+  configPatch?: Partial<AgentLogConfig>;
+}
+
+export interface HookUninstallResult {
+  changed: boolean;
+  messages: string[];
+  configPatch?: Partial<AgentLogConfig>;
+}
+
+export interface HookProvider {
+  id: HookProviderId;
+  label: string;
+  configFlag: "claudeHookInstalled" | "codexHookInstalled" | "hermesHookInstalled";
+  command: string;
+  preflightInstall?(ctx: HookInstallContext): void;
+  install(ctx: HookInstallContext): HookInstallResult;
+  preflightUninstall?(ctx?: Partial<HookInstallContext>): void;
+  uninstall(ctx?: Partial<HookInstallContext>): HookUninstallResult;
+  inspect(ctx?: Partial<HookInstallContext>): HookProviderState;
+  isRelevant(config: AgentLogConfig | null, ctx?: Partial<HookInstallContext>): boolean;
+}

--- a/src/hook.ts
+++ b/src/hook.ts
@@ -12,12 +12,22 @@ import { parseHookInput } from "./schema/hook-input.js";
 import { cwdToProject } from "./schema/daily-note.js";
 import { prettyPrompt } from "./schema/pretty-prompt.js";
 import { appendEntry } from "./note-writer.js";
-import type { SourceType } from "./types.js";
+import {
+  ENGLISHASK_GUARD_ENV,
+  appendEnglishAskFeedback,
+  buildEnglishAskContext,
+  englishAskSuggestion,
+  evaluateEnglishAsk,
+  shouldEvaluateEnglishAsk,
+} from "./english-ask.js";
+import { isSourceType, type SourceType } from "./types.js";
 
 function resolveSource(): SourceType {
   const sourceIndex = process.argv.indexOf("--source");
-  const source = sourceIndex >= 0 ? process.argv[sourceIndex + 1] : "claude";
-  return source === "codex" ? "codex" : "claude";
+  if (sourceIndex < 0) return "claude";
+  const source = process.argv[sourceIndex + 1];
+  if (isSourceType(source)) return source;
+  throw new Error(`Unsupported source: ${source ?? ""}`);
 }
 
 /** Read all stdin as a string. Works with both Bun and Node.js. */
@@ -31,7 +41,15 @@ function readStdin(): Promise<string> {
 }
 
 async function main(): Promise<void> {
-  const source = resolveSource();
+  if (process.env[ENGLISHASK_GUARD_ENV] === "1") return;
+
+  let source: SourceType;
+  try {
+    source = resolveSource();
+  } catch (err) {
+    process.stderr.write(`[agentlog] source error: ${err}\n`);
+    return;
+  }
 
   // 1. Load config — if absent, hint and exit (not initialized)
   const config = loadConfig();
@@ -54,6 +72,7 @@ async function main(): Promise<void> {
     process.stderr.write(`[agentlog] parse error: ${err}\n`);
     return;
   }
+  if (parsed.shouldLog === false) return;
 
   // 4. Build time string
   const now = new Date();
@@ -76,7 +95,23 @@ async function main(): Promise<void> {
   };
 
   try {
-    appendEntry(config, entry, now);
+    const result = appendEntry(config, entry, now);
+    if (source !== "hermes" && shouldEvaluateEnglishAsk(config, parsed.prompt)) {
+      try {
+        const context = buildEnglishAskContext(result.filePath, {
+          ...entry,
+          transcriptPath: parsed.transcriptPath,
+        });
+        const feedback = evaluateEnglishAsk(config, parsed.prompt, parsed.cwd, context);
+        if (feedback) {
+          appendEnglishAskFeedback(result.filePath, feedback, entry, config);
+          const suggestion = englishAskSuggestion(config, feedback);
+          if (suggestion) process.stderr.write(suggestion);
+        }
+      } catch {
+        // EnglishAsk is best-effort; the normal AgentLog entry is already written.
+      }
+    }
   } catch (err) {
     process.stderr.write(`[agentlog] write error: ${err}\n`);
   }

--- a/src/note-writer.ts
+++ b/src/note-writer.ts
@@ -201,10 +201,10 @@ function insertIntoAgentLogSection(content: string, entry: LogEntry): string {
   const metaRe = /^<!-- cwd=(.+?) -->$/;
   const legacyMetaRe = /^<!-- cwd=(.+?) ses=([\w-]+) -->$/;
   const legacyHeaderRe = /^#### .+ <!-- cwd=(.+?) ses=([\w-]+) -->$/;
-  // Match current [[claude_...]]/[[codex_...]] and legacy [[ses_...]]/(ses_...) dividers.
+  // Match current source-prefixed dividers and legacy [[ses_...]]/(ses_...) dividers.
   // Captures the source prefix so session matching stays source-aware: a codex entry
   // must never be filed under a claude_ divider (or vice versa) even when the ids collide.
-  const dividerRe = /^- - - - (?:\[\[(claude|codex|ses)_([\w-]+)\]\]|\((ses)_([\w-]+)\))$/;
+  const dividerRe = /^- - - - (?:\[\[(claude|codex|hermes|ses)_([\w-]+)\]\]|\((ses)_([\w-]+)\))$/;
 
   let projectIdx = -1;
   let projectMetaIdx = -1; // -1 means legacy inline format (no separate metadata line)

--- a/src/schema/codex-notify-input.ts
+++ b/src/schema/codex-notify-input.ts
@@ -18,6 +18,7 @@ export interface ParsedCodexNotifyInput {
   sessionId: string;
   cwd: string;
   prompt: string;
+  lastAssistantMessage?: string;
 }
 
 export function parseCodexNotifyInput(raw: string): ParsedCodexNotifyInput | null {
@@ -59,5 +60,8 @@ export function parseCodexNotifyInput(raw: string): ParsedCodexNotifyInput | nul
     sessionId: obj["thread-id"] as string,
     cwd: obj["cwd"] as string,
     prompt,
+    lastAssistantMessage: typeof obj["last-assistant-message"] === "string" && obj["last-assistant-message"]
+      ? obj["last-assistant-message"]
+      : undefined,
   };
 }

--- a/src/schema/hook-input.ts
+++ b/src/schema/hook-input.ts
@@ -1,8 +1,7 @@
 /**
  * Hook Input Schema — Source of Truth
  *
- * Claude Code and Codex send this JSON payload via stdin when a
- * UserPromptSubmit hook fires.
+ * Claude Code, Codex, and Hermes send JSON payloads via stdin when hooks fire.
  * All fields are validated at runtime by parseHookInput().
  */
 
@@ -18,13 +17,14 @@ export interface HookInputMessage {
 }
 
 /**
- * Full UserPromptSubmit hook payload.
+ * Full hook payload.
  *
  * Required fields: hook_event_name, session_id, cwd
  * Codex requires `prompt`. Claude compatibility keeps older fallback shapes.
+ * Hermes requires `pre_llm_call` and `extra.user_message`.
  */
 export interface HookInput {
-  hook_event_name: "UserPromptSubmit";
+  hook_event_name: "UserPromptSubmit" | "pre_llm_call";
   session_id: string;
   cwd: string;
   /** Path to the session transcript JSONL file */
@@ -41,6 +41,14 @@ export interface HookInput {
   message?: HookInputMessage;
   /** Claude/backward-compatibility fallback if prompt and message are absent */
   parts?: HookInputPart[];
+  /** Hermes event-specific kwargs for pre_llm_call. */
+  extra?: {
+    user_message?: string;
+    conversation_history?: unknown[];
+    is_first_turn?: boolean;
+    model?: string;
+    platform?: string;
+  };
 }
 
 /** Parsed, normalized result after validating hook input */
@@ -48,10 +56,12 @@ export interface ParsedHookInput {
   sessionId: string;
   cwd: string;
   prompt: string;
+  transcriptPath?: string;
+  shouldLog?: boolean;
 }
 
 export interface ParseHookInputOptions {
-  source?: "claude" | "codex";
+  source?: "claude" | "codex" | "hermes";
 }
 
 /**
@@ -81,7 +91,11 @@ export function parseHookInput(raw: string, options: ParseHookInputOptions = {})
 
   const obj = input as Record<string, unknown>;
 
-  if (obj["hook_event_name"] !== "UserPromptSubmit") {
+  if (options.source === "hermes") {
+    if (obj["hook_event_name"] !== "pre_llm_call") {
+      throw new Error("Missing or unsupported hook_event_name for Hermes: pre_llm_call");
+    }
+  } else if (obj["hook_event_name"] !== "UserPromptSubmit") {
     throw new Error("Missing or unsupported hook_event_name: UserPromptSubmit");
   }
   if (typeof obj["session_id"] !== "string" || !obj["session_id"]) {
@@ -94,7 +108,30 @@ export function parseHookInput(raw: string, options: ParseHookInputOptions = {})
   // Prompt extraction with fallback chain
   let prompt: string | undefined;
 
-  if (typeof obj["prompt"] === "string" && obj["prompt"]) {
+  if (options.source === "hermes") {
+    const extra = obj["extra"];
+    if (
+      typeof extra === "object" &&
+      extra !== null &&
+      typeof (extra as Record<string, unknown>)["user_message"] === "string" &&
+      (extra as Record<string, unknown>)["user_message"]
+    ) {
+      prompt = (extra as Record<string, unknown>)["user_message"] as string;
+      if ((extra as Record<string, unknown>)["is_first_turn"] === false) {
+        return {
+          sessionId: obj["session_id"] as string,
+          cwd: obj["cwd"] as string,
+          prompt,
+          transcriptPath: typeof obj["transcript_path"] === "string" && obj["transcript_path"]
+            ? obj["transcript_path"]
+            : undefined,
+          shouldLog: false,
+        };
+      }
+    } else {
+      throw new Error("Missing required field for Hermes pre_llm_call: extra.user_message");
+    }
+  } else if (typeof obj["prompt"] === "string" && obj["prompt"]) {
     prompt = obj["prompt"];
   } else if (options.source === "codex") {
     throw new Error("Missing required field for Codex UserPromptSubmit: prompt");
@@ -121,5 +158,8 @@ export function parseHookInput(raw: string, options: ParseHookInputOptions = {})
     sessionId: obj["session_id"] as string,
     cwd: obj["cwd"] as string,
     prompt,
+    transcriptPath: typeof obj["transcript_path"] === "string" && obj["transcript_path"]
+      ? obj["transcript_path"]
+      : undefined,
   };
 }

--- a/src/schema/pretty-prompt.ts
+++ b/src/schema/pretty-prompt.ts
@@ -19,6 +19,7 @@ const SKIP_PATTERNS: RegExp[] = [
   /^This session is being continued from a previous conversation/,
   /^# \w.+ — /,
   /^Stop hook feedback:/,
+  /^<turn_aborted>/,
   /^\[AUTOPILOT/,
   /^\[RALPH LOOP/,
   /^\[MAGIC KEYWORD/,

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,9 @@ export interface AgentLogConfig {
   plain?: boolean;
   claudeHookInstalled?: boolean;
   codexHookInstalled?: boolean;
+  hermesHookInstalled?: boolean;
+  hermesHome?: string;
+  hermesProfiles?: string[];
   /** Legacy metadata for pre-hook Codex notify installs. */
   codexNotifyRestore?: string[] | null;
   englishAsk?: EnglishAskConfig;
@@ -17,6 +20,7 @@ export interface EnglishAskConfig {
   threshold?: number;
   timeoutMs?: number;
   maxPromptChars?: number;
+  maxContextChars?: number;
   maxOutputChars?: number;
   evaluatorCommand?: string[];
 }
@@ -28,7 +32,12 @@ export interface EnglishAskFeedback {
 }
 
 /** Source of the log entry — which AI tool produced it */
-export type SourceType = "claude" | "codex";
+export const SOURCE_TYPES = ["claude", "codex", "hermes"] as const;
+export type SourceType = (typeof SOURCE_TYPES)[number];
+
+export function isSourceType(value: string | undefined): value is SourceType {
+  return SOURCE_TYPES.includes(value as SourceType);
+}
 
 /** A single log entry to be written into a Daily Note */
 export interface LogEntry {


### PR DESCRIPTION
## Summary
- release AgentLog v0.3.0
- add Hermes hook provider lifecycle support
- harden EnglishAsk hook context and fail-soft behavior
- include Codex backfill and legacy hook migration improvements

## Verification
- feature and version PR CI passed
- bun test (311 pass)
- bun run typecheck
- bun run build
- npm pack --dry-run

Merging this PR triggers the Release workflow for GitHub Release and npm publish.