### PR TITLE
fix: Obsidian 로케일별 요일 파일명 후보로 Daily Note 경로 해결 (closes #56)

### DIFF
--- a/src/__tests__/note-writer.test.ts
+++ b/src/__tests__/note-writer.test.ts
@@ -80,6 +80,49 @@ describe("dailyNotePath", () => {
     rmSync(mockBin, { force: true });
   });
 
+  it("prefers an existing English-weekday note over the Korean candidate without invoking CLI", () => {
+    const vault = makeTmpDir();
+    const mockBin = join(tmpdir(), `mock-obs-${Date.now()}`);
+    const sentinel = join(vault, "cli-called");
+    mkdirSync(join(vault, ".obsidian"), { recursive: true });
+    writeFileSync(
+      join(vault, ".obsidian", "daily-notes.json"),
+      JSON.stringify({ folder: "Notes", format: "YYYY-MM-DD-ddd" }),
+      "utf-8",
+    );
+    mkdirSync(join(vault, "Notes"), { recursive: true });
+    writeFileSync(join(vault, "Notes", "2026-03-01-Sun.md"), "# note", "utf-8");
+    writeFileSync(mockBin, `#!/bin/bash\ntouch ${JSON.stringify(sentinel)}\necho "Cli/should-not-run.md"`, "utf-8");
+    chmodSync(mockBin, 0o755);
+    process.env.OBSIDIAN_BIN = mockBin;
+
+    const path = dailyNotePath({ vault }, TEST_DATE);
+    expect(path).toBe(join(vault, "Notes/2026-03-01-Sun.md"));
+    expect(existsSync(sentinel)).toBe(false);
+
+    rmSync(mockBin, { force: true });
+    rmSync(vault, { recursive: true, force: true });
+  });
+
+  it("prefers an existing Korean-weekday note when both locale candidates exist", () => {
+    process.env.OBSIDIAN_BIN = "/nonexistent/obsidian";
+    const vault = makeTmpDir();
+    mkdirSync(join(vault, ".obsidian"), { recursive: true });
+    writeFileSync(
+      join(vault, ".obsidian", "daily-notes.json"),
+      JSON.stringify({ folder: "Notes", format: "YYYY-MM-DD-ddd" }),
+      "utf-8",
+    );
+    mkdirSync(join(vault, "Notes"), { recursive: true });
+    writeFileSync(join(vault, "Notes", "2026-03-01-일.md"), "# ko", "utf-8");
+    writeFileSync(join(vault, "Notes", "2026-03-01-Sun.md"), "# en", "utf-8");
+
+    const path = dailyNotePath({ vault }, TEST_DATE);
+    expect(path).toBe(join(vault, "Notes/2026-03-01-일.md"));
+
+    rmSync(vault, { recursive: true, force: true });
+  });
+
   it("uses Daily Notes folder config without invoking CLI", () => {
     const vault = makeTmpDir();
     const mockBin = join(tmpdir(), `mock-obs-${Date.now()}`);
@@ -330,6 +373,36 @@ describe("appendEntry — session-grouped AgentLog section", () => {
     expect(content).toContain("#### 10:53 · js/agentlog");
     expect(content).toContain("<!-- cwd=/Users/pray/work/js/agentlog -->");
     expect(content).toContain("- - - - [[claude_abc12345-def6-7890-abcd-ef1234567890]]");
+    expect(content).toContain("- 10:53 테스트 작업");
+  });
+
+  it("appends into the note Obsidian bootstraps under a different locale's weekday name", () => {
+    // Obsidian's locale renders "ddd" as "Sun" while agentlog's ko candidate expects "일".
+    const mockBin = join(tmpDir, "mock-obsidian-en");
+    const enFilePath = join(tmpDir, "Daily", "2026-03-01-Sun.md");
+    writeFileSync(
+      mockBin,
+      [
+        "#!/bin/bash",
+        "if [ \"$1\" = \"daily\" ]; then",
+        `  printf '%s' "# 2026-03-01" > ${JSON.stringify(enFilePath)}`,
+        "  exit 0",
+        "fi",
+        "exit 1",
+      ].join("\n"),
+      "utf-8"
+    );
+    chmodSync(mockBin, 0o755);
+    process.env.OBSIDIAN_BIN = mockBin;
+
+    const result = appendEntry(config, makeEntry(), TEST_DATE);
+
+    expect(result.created).toBe(true);
+    expect(result.filePath).toBe(enFilePath);
+    expect(existsSync(dailyFilePath())).toBe(false);
+
+    const content = readFileSync(enFilePath, "utf-8");
+    expect(content).toContain("## AgentLog");
     expect(content).toContain("- 10:53 테스트 작업");
   });
 

--- a/src/note-writer.ts
+++ b/src/note-writer.ts
@@ -3,7 +3,6 @@ import { join, dirname, resolve, relative, isAbsolute, sep } from "path";
 import type { AgentLogConfig, LogEntry, WriteResult } from "./types.js";
 import {
   KO_DAYS,
-  dailyNoteFileName,
   buildAgentLogEntry,
   buildSessionDivider,
   buildLatestLine,
@@ -32,11 +31,27 @@ const SUPPORTED_FORMAT_TOKENS = new Set([
   "d",
 ]);
 
-function formatDailyNoteFileName(date: Date, format: string): string | null {
+// Obsidian renders weekday tokens through moment with the app's display
+// language, so the same daily-notes.json format can yield different file
+// names depending on locale (e.g. "2026-08-18-화.md" vs "2026-08-18-Tue.md").
+// agentlog cannot observe that locale, so it computes candidates per locale.
+type WeekdayLocale = "ko" | "en";
+const WEEKDAY_LOCALES: readonly WeekdayLocale[] = ["ko", "en"];
+const EN_DAYS_MIN = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"] as const;
+const EN_DAYS_SHORT = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"] as const;
+const EN_DAYS_LONG = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"] as const;
+
+/** Default file name format when daily-notes.json has no format (matches dailyNoteFileName). */
+const DEFAULT_DAILY_FORMAT = "YYYY-MM-DD-ddd";
+
+function formatDailyNoteFileName(date: Date, format: string, locale: WeekdayLocale): string | null {
   const baseFormat = format.endsWith(".md") ? format.slice(0, -3) : format;
   const alphaTokens = baseFormat.match(FORMAT_ALPHA_RE) ?? [];
   if (alphaTokens.some((token) => !SUPPORTED_FORMAT_TOKENS.has(token))) return null;
-  const dayShort = KO_DAYS[date.getDay()];
+  const day = date.getDay();
+  const dayMin = locale === "ko" ? KO_DAYS[day] : EN_DAYS_MIN[day];
+  const dayShort = locale === "ko" ? KO_DAYS[day] : EN_DAYS_SHORT[day];
+  const dayLong = locale === "ko" ? `${KO_DAYS[day]}요일` : EN_DAYS_LONG[day];
   const replacements: Record<string, string> = {
     YYYY: String(date.getFullYear()),
     YY: String(date.getFullYear()).slice(-2),
@@ -45,8 +60,8 @@ function formatDailyNoteFileName(date: Date, format: string): string | null {
     DD: pad2(date.getDate()),
     D: String(date.getDate()),
     ddd: dayShort,
-    dddd: `${dayShort}요일`,
-    dd: dayShort,
+    dddd: dayLong,
+    dd: dayMin,
     d: String(date.getDay()),
   };
   const replaced = baseFormat.replace(FORMAT_TOKEN_RE, (token) => replacements[token] ?? token);
@@ -62,23 +77,29 @@ function safeVaultJoin(vault: string, ...segments: string[]): string | null {
 }
 
 /**
- * Read Daily Notes path from .obsidian/daily-notes.json.
- * Avoids spawning the Obsidian CLI binary, which causes renderer reloads.
+ * Compute Daily Note path candidates from .obsidian/daily-notes.json,
+ * one per weekday locale (ko first, then en; deduped when the format has
+ * no weekday token). Avoids spawning the Obsidian CLI binary, which causes
+ * renderer reloads.
  */
-function vaultDailyPath(vault: string, date: Date): string | null {
+function vaultDailyPathCandidates(vault: string, date: Date): string[] {
   const cfgPath = join(vault, ".obsidian", "daily-notes.json");
-  if (!existsSync(cfgPath)) return null;
+  if (!existsSync(cfgPath)) return [];
   try {
     const raw = readFileSync(cfgPath, "utf-8");
     const cfg = JSON.parse(raw) as DailyNotesConfig;
     const folder = typeof cfg.folder === "string" ? cfg.folder.trim() : "Daily";
-    const fileName = cfg.format?.trim()
-      ? formatDailyNoteFileName(date, cfg.format.trim())
-      : dailyNoteFileName(date);
-    if (!fileName) return null;
-    return safeVaultJoin(vault, folder, fileName);
+    const format = cfg.format?.trim() || DEFAULT_DAILY_FORMAT;
+    const candidates: string[] = [];
+    for (const locale of WEEKDAY_LOCALES) {
+      const fileName = formatDailyNoteFileName(date, format, locale);
+      if (!fileName) continue;
+      const path = safeVaultJoin(vault, folder, fileName);
+      if (path && !candidates.includes(path)) candidates.push(path);
+    }
+    return candidates;
   } catch {
-    return null;
+    return [];
   }
 }
 
@@ -96,9 +117,13 @@ export function dailyNotePath(config: AgentLogConfig, date: Date): string | null
     return join(config.vault, `${yyyy}-${mm}-${dd}.md`);
   }
 
-  // Try .obsidian/daily-notes.json first (no CLI spawn, no renderer reload)
-  const vaultPath = vaultDailyPath(config.vault, date);
-  if (vaultPath) return vaultPath;
+  // Try .obsidian/daily-notes.json first (no CLI spawn, no renderer reload).
+  // Prefer the candidate that already exists — Obsidian may have created the
+  // note under either locale's weekday name.
+  const candidates = vaultDailyPathCandidates(config.vault, date);
+  const existing = candidates.find((p) => existsSync(p));
+  if (existing) return existing;
+  if (candidates.length > 0) return candidates[0];
 
   // Try Obsidian CLI (respects user's Daily Notes folder setting)
   const relativePath = cliDailyPath();
@@ -106,6 +131,32 @@ export function dailyNotePath(config: AgentLogConfig, date: Date): string | null
   if (cliPath) return cliPath;
 
   return null;
+}
+
+/** True when `date` falls on the current calendar day (local time). */
+function isToday(date: Date): boolean {
+  const now = new Date();
+  return (
+    date.getFullYear() === now.getFullYear() &&
+    date.getMonth() === now.getMonth() &&
+    date.getDate() === now.getDate()
+  );
+}
+
+/**
+ * Re-resolve the Daily Note path after an Obsidian CLI bootstrap.
+ * The bootstrapped note is named per Obsidian's locale, which can differ from
+ * the computed candidate; rescan candidates first, then fall back to the CLI's
+ * authoritative path — but only for today, since `daily:path` always answers
+ * for the current day.
+ */
+function resolveBootstrappedPath(config: AgentLogConfig, date: Date): string | null {
+  const resolved = dailyNotePath(config, date);
+  if (resolved && existsSync(resolved)) return resolved;
+  if (!isToday(date)) return null;
+  const relativePath = cliDailyPath();
+  const cliPath = relativePath ? safeVaultJoin(config.vault, relativePath) : null;
+  return cliPath && existsSync(cliPath) ? cliPath : null;
 }
 
 /**
@@ -122,7 +173,7 @@ export function appendEntry(
   entry: LogEntry,
   date: Date = new Date()
 ): WriteResult {
-  const filePath = dailyNotePath(config, date);
+  let filePath = dailyNotePath(config, date);
   if (!filePath) {
     throw new Error("Daily Note path could not be resolved. Enable the Obsidian CLI or configure Daily Notes settings.");
   }
@@ -135,6 +186,9 @@ export function appendEntry(
   if (created) {
     if (!cliEnsureDailyNoteExists()) {
       throw new Error("Daily Note is missing and Obsidian CLI could not create it.");
+    }
+    if (!existsSync(filePath)) {
+      filePath = resolveBootstrappedPath(config, date) ?? filePath;
     }
     if (!existsSync(filePath)) {
       throw new Error("Daily Note is missing after Obsidian CLI bootstrap.");


### PR DESCRIPTION
## Summary
- Obsidian은 daily-notes.json 요일 토큰(dd/ddd/dddd)을 moment 로케일로 렌더링하지만 agentlog는 KO_DAYS 하드코딩 — 로케일이 영어로 바뀌자 계산 경로(`-화.md`)와 실제 파일(`-Tue.md`)이 어긋나 2026-08-16부터 모든 기록이 유실됨
- `vaultDailyPath` → `vaultDailyPathCandidates`: ko/en 두 로케일 후보를 계산하고 **존재하는 파일 우선** 선택 (steady state에서 CLI spawn 없음 유지)
- bootstrap 후 계산 경로가 없으면 후보 재스캔, 최후 수단으로 CLI `daily:path` 재해결 (`daily:path`는 항상 오늘을 답하므로 오늘 날짜 한정 — backfill 과거 날짜가 오늘 노트로 오기록되는 것 방지)
- ko/en 외 로케일(예: 일본어)은 후보로는 못 잡지만 CLI 재해결이 안전망

## Test
- `bun run typecheck` ✅
- `bun test` 314 pass ✅ (신규 3: 존재하는 en 후보 우선/양쪽 존재 시 ko 우선/en 로케일 bootstrap 후 append)
- 실 vault 검증: hook 실행 → `2026-08-18-Tue.md`에 정상 append, `agentlog backfill`로 08-16~18 유실분 90건 복구 완료

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)